### PR TITLE
WiP - changes for new event ingestion

### DIFF
--- a/src/main/rosetta/model_cdm_event.rosetta
+++ b/src/main/rosetta/model_cdm_event.rosetta
@@ -5,6 +5,7 @@ FpML versionNumber "5.10"
 class CompositeEvent extends Event
 {
 	intent IntentEnum (0..1);
+		[synonym FpML value intent]
 }
 
 enum IntentEnum
@@ -20,11 +21,13 @@ class ContractState one of
 {
 	contract Contract (0..1);
 	contractReference TradeIdentifier (0..1);
+		[synonym FpML value contractReference]
 }
 
 class EventBase extends CompositeEvent
 {
 	quantityChange QuantityChange (0..*);
+		[synonym FpML value quantityChange]
 	partyChange PartyChange (0..*);
 	otherTermsChange OtherTermsChange (0..1);
 	fee Payment (0..*);
@@ -37,8 +40,11 @@ choice rule EventBase_choice
 class QuantityChange
 {
 	before ContractState (0..1);
+		[synonym FpML value before]
 	after ContractState (1..1);
+		[synonym FpML value after]
 	quantityChange ContractualQuantity (1..1);
+		[synonym FpML value quantityChange]
 }
 
 class PartyChange

--- a/src/main/rosetta/model_cdm_product.rosetta
+++ b/src/main/rosetta/model_cdm_product.rosetta
@@ -250,6 +250,7 @@ class ContractualQuantity
 		[synonym FpML value initialValue pathExpression "calculationPeriodAmount.calculation" set notionalAmount when notionalSchedule -> notionalStepSchedule -> step is absent]
 		[synonym FpML value calculationAmount pathExpression "periodicPayment.fixedAmountCalculation"]
 		[synonym FpML value calculationAmount pathExpression "periodicPayment.floatingAmountCalculation"]
+		[synonym FpML value notionalAmount]
 	notionalSchedule NotionalSchedule (0..1);
 		[synonym FpML value notionalSchedule pathExpression "calculationPeriodAmount.calculation" set notionalSchedule when notionalSchedule -> notionalStepSchedule -> step exists]
 	fxLinkedNotional FxLinkedNotionalSchedule (0..1);

--- a/src/main/rosetta/model_event.rosetta
+++ b/src/main/rosetta/model_event.rosetta
@@ -53,6 +53,7 @@ abstract class Event stereotype preExecution, execution, postExecution <"The abs
 {
 	messageInformation MessageInformation (0..1);
 	timeStamp EventTimeStamp (1..1);
+		[synonym FpML value timeStamp]
 	/*
 	 * Need to confirm with FpML experts whether the correlationId is meant to to be used as an eventId
 	 * As part of this, need to confirm whether the sequenceId should used to support cancellations/corrections; there is no mention of such in the FpML specification
@@ -60,7 +61,9 @@ abstract class Event stereotype preExecution, execution, postExecution <"The abs
 	 */
 	correlation Correlation (1..1) <"The correlation Id provides a lineage across related transactions. While optional in FpML, it is made required as part of the Rosetta model, as there is a need for an event identifier of some sort">;
 	eventDate date (1..1);
+		[synonym FpML value eventDate]
 	effectiveDate date (0..1);
+		[synonym FpML value effectiveDate]
 	action ActionEnum (1..1) <"Specifies whether the event is a new, a correction or a cancellation.">;
 		[synonym FpML value isCorrection 
 			set action to ActionEnum.new when False, 
@@ -77,6 +80,7 @@ class EventTimeStamp stereotype preExecution, execution, postExecution <"This cl
 		[synonym FIX value SendingTime tag 52] // Need to confirm whether sendingTime can be equated to createTime
 		[synonym FIX value TransactTime componentID 60]
 		[synonym FpML value creationTimestamp pathExpression "header"]
+		[synonym FpML value creationTimestamp]
 	expiryTimestamp dateTime (0..1) <"The date and time (on the source system) when this event will be considered expired.">;
 		[synonym FpML value expiryTimestamp]
 		[synonym FIX value ExpireTime tag 126]


### PR DESCRIPTION
Here are all the synonyms needed to map the new partial termination xml.  Ingestion logic still required to capture Party and id/href data in Rosetta.

See model_cdm_product.rosetta line:253 This synonym refers to a node I added to the xml document to make this mapping work.  We should discuss the need for this further.

An open question is: should we continue start adding new synonyms as something other than FpML (CDM perhaps)?  Then to re-use existing FpML mappings, we can make the synonym source a list i.e. 
```
class Correlation
{
	...
	correlationId string (1..1) scheme "correlationIdScheme";
		[synonym FpML, CDM value correlationId]
	...
```