### PR TITLE
Udpated project name for eclipse

### DIFF
--- a/.project
+++ b/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>rosetta-model</name>
+	<name>rosetta-cdm</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<artifactId>rosetta-cdm</artifactId>
 	<packaging>jar</packaging>
 	<version>0.0.0.master</version>
-	<name>rosetta-model</name>
+	<name>rosetta-cdm</name>
 	<url>http://maven.apache.org</url>
 
 	<properties>


### PR DESCRIPTION
Changed name of eclipse project from rosetta-model to rosetta-cdm. This allows us to have bth rosetta-model and rosetta-cdm in the same eclipse runtime.