### PR TITLE
editing for clarity and consistency

### DIFF
--- a/documentation/source/documentation.rst
+++ b/documentation/source/documentation.rst
@@ -244,11 +244,11 @@ As a result, the bond, equity, and other securities are defined as extensions of
 Product Qualification
 ^^^^^^^^^^^^^^^^^^^^^
 
-**Product qualification is inferred from the economic terms of the product** rather than explicitly naming the product type.  The CDM uses a set of Product Qualification functions to achieve this purpose. These functions can be identified as those annotated with ``[qualification Product]``.
+**Product qualification is inferred from the economic terms of the product** instead of explicitly naming the product type.  The CDM uses a set of Product Qualification functions to achieve this purpose. These functions can be identified as those annotated with ``[qualification Product]``.
 
-A Product Qualification function applies a taxonomy-specific business logic to identify if the product attribute values, which represent the product's economic terms, match the specified criteria for the product named in that taxonomy. For example, if a certain set of attributes are populated and others are absent, then that specific product type is inferred. The Product Qualification function name in the CDM begins with the word ``Qualify`` followed by an underscore ``_`` and then the taxonomy name (also separated by underscores).
+A Product Qualification function applies a taxonomy-specific business logic to identify if the product attribute values, as represented by the product's economic terms, match the specified criteria for the product named in that taxonomy. For example, if a certain set of attributes are populated and others are absent, then that specific product type is inferred. The Product Qualification function name in the CDM begins with the word ``Qualify`` followed by an underscore ``_`` and then the product type from the applicable taxonomy  (also separated by underscores).
 
-An example is provided below for the qualification of a Zero-Coupon Fixed-Float Inflation Swap.
+The CDM implements the ISDA Product Taxonomy v2.0 to qualify contractual products, foreign exchange, and repurchase agreements. Given the prevalence of usage of the ISDA Product Taxonomy v1.0, the equivalent name from that taxonomy is also systematically indicated in the CDM, using a ``synonym`` annotation displayed under the function output. An example is provided below for the qualification of a Zero-Coupon Fixed-Float Inflation Swap:
 
 .. code-block:: Haskell
 
@@ -266,13 +266,9 @@ An example is provided below for the qualification of a Zero-Coupon Fixed-Float 
      and economicTerms -> payout -> interestRatePayout -> paymentDates -> paymentFrequency -> periodMultiplier = 1
      and economicTerms -> payout -> interestRatePayout -> paymentDates -> paymentFrequency -> period = PeriodExtendedEnum -> T
 
-If all the statements above are true, then the function evaluates to True. In this case, the product in the primitive event is determined to be qualified as the product referenced by the function name.
+If all the statements above are true, then the function evaluates to True, and the product is determined to be qualified as the product referenced by the function name.
 
-The CDM implements the ISDA Product Taxonomy v2.0 to qualify OTC derivative products. Given the prevalence of usage of the ISDA Product Taxonomy v1.0, the equivalence with that taxonomy has also been systematically indicated in the CDM, using a ``synonym`` displayed under the function output. The status of the Product Qualification functions in the CDM is as follows:
-
-* The full scope of for Interest Rate Products has been represented, down to the full level of detail in the taxonomy. This is shown in the example above, where the ``ZeroCoupon`` qualifying suffix is part of the function name.
-* Credit Default products are qualified, but not down to the full level of detail. The ISDA Product Taxonomy v2.0 references the transaction type instead of the product features, whose possible values are not publicly available and hence not positioned as a CDM enumeration.
-* Only a small number of products for Foreign Exchange have been qualified.
+CDM supports Product Qualification functions for Credit Derivatives, Interest Rate Derivatives, Equity Derivatives, Foreign Exchange, and Repurchase Agreements. The full scope of for Interest Rate Products has been represented, down to the full level of detail in the taxonomy. This is shown in the example above, where the ``ZeroCoupon`` qualifying suffix is part of the function name. Credit Default products are qualified, but not down to the full level of detail. The ISDA Product Taxonomy v2.0 references the transaction type instead of the product features, whose possible values are not publicly available and hence not positioned as a CDM enumeration.
 
 The output of the qualification function is used to populate the ``productQualifier`` attribute of the ``ProductIdentification`` object, which is created when a ``ContractualProduct`` object is created. The product identification includes both the product qualification generated by the CDM and any additional product identification information which may come from the originating document, such as FpML. In this case, taxonomy schemes may be associated to such product identification information, which are also propagated in the ``ProductIdentification`` object.
 
@@ -315,6 +311,7 @@ The ``productIdentification`` data structure and an example of the (serialised) 
    } ]
  }
 
+.. note:: In a typical CDM model implementation, the full set of Product Qualification functions would be invoked against each instance of the product in order to determine the inferred productQualifier.
 .. note:: ``productType`` is a *meta-type* that indicates that its value is meant to be populated via a function. This mechanism is explained in the `Qualified Type Section`_ of the Rosetta DSL documentation. For a further understanding of the underlying qualification logic in the Product Qualification, see the explanation of the *object qualification* feature of the Rosetta DSL, as described in the `Function Definition Section`_.
 
 Event Model
@@ -841,7 +838,7 @@ Why a Process Model
 
 **The CDM lays the foundation for the standardisation, automation and inter-operability of industry processes**. Industry processes represent events and actions that occur through the transaction's lifecycle, from negotiating a legal agreement to allocating a block-trade or calculating settlement amounts.
 
-While ISDA already defines how industry processes should work in the ISDA Documentation, differences in the implementation minutia may still cause operational friction between market participants. Evidence shows that even calculations defined in mathematical notation (for example, day count fraction formulae which are used when calculating interest rate payments) can be a source of dispute between parties in a transaction.
+While ISDA defines the protocols for industry processes in its library of ISDA Documentation, differences in the implementation minutia may cause operational friction between market participants. Evidence shows that even when calculations are defined in mathematical notation (for example, day count fraction formulae which are used when calculating interest rate payments) can be a source of dispute between parties in a transaction.
 
 What Is the Process Model
 """""""""""""""""""""""""
@@ -853,14 +850,14 @@ Machine readability and executability is crucial to eliminate implementation dis
 How Does It Work
 """"""""""""""""
 
-The process model is systematically translated into executable code using purpose-built technology as described in the `Code Generation Section`_. A number of modern, widely adopted and freely available programming languages are currently supported:
+The process model is systematically translated into executable code for the Java representation of the CDM using purpose-built technology as described in the `Code Generation Section`_. The CDM data model and process model specifications can also be translated into a number of other modern, widely adopted and freely available programming languages are currently supported, as noted below:
 
 * Java
 * Scala
 * DAML
 * Typescript
 
-and the list will continue to grow with the requirements of the CDM user community.
+CDM has the capability to add support for other languages as required by the market.
 
 Executable code artefacts are distributed with the CDM and freely available to download from the ISDA CDM `Portal`_.
 
@@ -875,7 +872,7 @@ The scope of the process model has two dimensions:
 Coverage
 """"""""
 
-**The CDM process model currently covers the post-trade lifecycle of over-the-counter derivative transactions**. Generally, a process is in-scope when it is already covered in ISDA Documentation or other technical documents. To illustrate, the following processes, although a non-exhaustive list, are all in scope:
+**The CDM process model currently covers the post-trade lifecycle of securities, contractual products, and foreign exchange**. Generally, a process is in-scope when it is already covered in ISDA Documentation or other technical documents. For example, the following processes are all in scope:
 
 * Trade execution and confirmation
 * Clearing
@@ -885,29 +882,27 @@ Coverage
 * Margin calculation
 * Regulatory reporting (although covered in a different documentation section)
 
-For an up-to-date model coverage of the trade lifecycle process, please refer to the `function coverage matrix`_ (*coming soon*).
-
 Granularity
 """""""""""
 
-**It is important for implementors of the CDM to understand what the model does and does not specify** regarding the above list of post-trade lifecycle processes.
+**It is important for implementors of the CDM to understand the scope of the model** with regard to specifications and executable code for the above list of post-trade lifecycle processes.
 
-The CDM process model leverages the *function* component of the Rosetta DSL. As detailed in the `Function Component Section`_ of the documentation, a function takes a set of input values and applies some logical instructions to return an output, both of which may be CDM objects or basic types. While a function specifies at minimum its inputs and output, its logic may be *fully defined* or only *partially defined* depending on how much of the output's attribute values it builds. Unspecified parts of a process represent functionality that firms are expected to implement, either internally or through third-parties such as utilities.
+The CDM process model leverages the *function* component of the Rosetta DSL. As detailed in the `Function Component Section`_ of the documentation, a function receives a set of input values and applies logical instructions to return an output.  The input and output may both be CDM objects or other data structures. While a function specifies its inputs and output, its logic may be *fully defined* or only *partially defined* depending on how much of the output's attribute values it builds. Unspecified parts of a process represent functionality that firms are expected to implement, either internally or through third-parties such as utilities.
 
-It is not always possible or desirable to fully specify the business logic of a process from a model. Parts of processes or sub-processes may be omitted from the CDM for the following reasons:
+It is not always possible or practical to fully specify the business logic of a process from a model. Parts of processes or sub-processes may be omitted from the CDM for the following reasons:
 
 * The sub-process is not needed to create a functional CDM output object.
 * The sub-process has already been defined and its implementation is widely adopted by the industry.
 * The sub-process is specific to a firm's internal process and therefore cannot be specified in an industry standard.
 
-The CDM process model focuses on what is necessary to create functional objects that satisfy the below criterion:
+Given these reasons, the CDM process model focuses on the most critical data and processes required to create functional objects that satisfy the below criterion:
 
-* Any of the object's qualifiable constituents (such as ``BusinessEvent`` and ``Product``) can be qualified.
+* All of the object's qualifiable constituents (such as ``BusinessEvent`` and ``Product``) used as inputs are qualified as true according to a specified function.
 * Lineage and cross-referencing between objects is accurate for data integrity purposes.
 
-Implementors must populate the remaining attribute values required for the output to be valid, by extending the executable code generated by the process model in their implementation.
+For any remaining data or processes, implementors can populate the remaining attribute values required for the output to be valid by extending the executable code generated by the process model or by creating their own functions.
 
-For the trade lifecycle processes in scope, the CDM process model covers the following sub-process components, which are each detailed in the next sections:
+For the trade lifecycle processes that are in scope, the CDM process model covers the following sub-process components, which are each detailed in the next sections:
 
 #. Validation process
 #. Calculation process
@@ -917,11 +912,11 @@ For the trade lifecycle processes in scope, the CDM process model covers the fol
 Validation Process
 ^^^^^^^^^^^^^^^^^^
 
-While validation rules are generally specified for existing data standards like FpML alongside the standard documentation, the logic needs to be evaluated and translated into code by software engineering teams. It often results in the validation logic not being consistently enforced.
+In many legacy models, validation rules are generally specified in text-based documentat, which requires software engineers to evalaute and translate the logic into code. The frequently occuring result of this human interpretation process is inconsistent enforcement of the intended logic.
 
-By contrast, validation components are an integral part of the CDM process model and distributed as executable code. Those CDM validation components leverage the validation components of the Rosetta DSL, as described in the `Validation Component Section`_.
+By contrast, in the CDM, validation components are an integral part of the process model specifications and are distributed as executable code in the Java representation of the CDM. The CDM validation components leverage the validation components of the Rosetta DSL, as described in the `Validation Component Section`_.
 
-As an example, the ``FpML_ird_57`` data rule implements the **FpML ird validation rule #57**, which states that if the calculation period frequency is expressed in units of month or year, then the roll convention cannot be a week day. A machine readable and executable definition of that specification is provided in the CDM, as a ``condition`` attached to the ``CalculationPeriodFrequency`` type:
+As an example, the the **FpML ird validation rule #57**, states that if the calculation period frequency is expressed in units of month or year, then the roll convention cannot be a weekday. A machine readable and executable definition of that specification is provided in the CDM, as a ``condition`` attached to the ``CalculationPeriodFrequency`` type:
 
 .. code-block:: Haskell
 
@@ -941,9 +936,11 @@ As an example, the ``FpML_ird_57`` data rule implements the **FpML ird validatio
 Calculation Process
 ^^^^^^^^^^^^^^^^^^^
 
-The CDM provides certain ISDA Definitions as machine executable formulas to standardise the industry calculation processes that use those definitions. The ISDA 2006 definitions of **Fixed Amount** and **Floating Amount** have been used as an initial scope to confirm applicability, alongside some of the required day count fractions. Performance calculations are also being introduced in the CDM to support the Total Return Swap model used in particular for Equity.
+The CDM provides certain ISDA Definitions as machine executable formulas to standardise the industry calculation processes that depend on those definitions.  Examples include the ISDA 2006 definitions of **Fixed Amount** and **Floating Amount** , the ISDA 2006 definitions of Day Count Fraction rules, and performance calculations for Equity Swaps.  CDM also provides related utility functions.
 
-Those calculation processes leverage the *calculation function* component of the Rosetta DSL, as detailed in the `Function Definition Section`_, and accordingly are associated to a ``calculation`` annotation.
+These calculation processes leverage the *calculation function* component of the Rosetta DSL, as detailed in the `Function Definition Section`_, and accordingly are associated to a ``calculation`` annotation.
+
+Explanations of these processes are provided in the following sections.
 
 Fixed Amount and Floating Amount Definitions
 """"""""""""""""""""""""""""""""""""""""""""
@@ -971,8 +968,11 @@ The CDM expressions of ``FixedAmount`` and ``FloatingAmount`` are similar in str
 Day Count Fraction
 """"""""""""""""""
 
-The current CDM version incorporates day count fractions calculations representing the set of day count fractions specified as part of the ISDA 2006 Definitions, e.g. the *ACT/365.FIXED* and the *30E/360* day count fractions. While the ACT/365.FIXED definition is simple and relies upon a computation of the number of days in a period, the 30E/360 definition specifies the actual computation in details to account for a 360 days year and a 30 maximum days month.
+The CDM process model incorporates calculations that represent the set of day count fraction rules specified as part of the ISDA 2006 Definitions, e.g. the *ACT/365.FIXED* and the *30E/360* day count fraction rules. Although these rules are widely accepted in the international markets, many of them have complex nuances which can lead to the problem of inconsistent implementaitons and the potential of mismatched settlements.
 
+For example, there are three distinct rule sets in which the length of each month is generally assumed to be 30 days for accrual purposes (and each year is assumed to be 360 days). However there are nuances in the rule sets that distinquish the resulting calculations under different circumstances, such as when the last day of the period is the last day of February. These distinct rule sets are defined by ISDA as 30/360 (also known as 30/360 US), 30E/360 (formerly known as 30/360 ICMA or 30/360 Eurobond), and the 30E/360.ISDA.
+
+The CDM process model eliminates the need for implementators to unravel the logic and write unique code for these rules. Instead, it provides executable code, such as the example below [30/360.ISDA would be a better example]
 .. code-block:: Haskell
 
  func DayCountFraction(dayCountFractionEnum: DayCountFractionEnum -> _30E_360):
@@ -992,14 +992,14 @@ The current CDM version incorporates day count fractions calculations representi
 Utility Function
 """"""""""""""""
 
-CDM model elements often need to be transformed by a function to construct the arguments for a formula in a calculation. A typical example required to compute a cashflow amount in accordance with a schedule (as illustrated in the day count fraction calculation shown above) is to identify the characteristics of the current calculation period.
+CDM elements often need to be transformed by a function to construct the arguments for a formula in a calculation. A typical example is the requirement to identify a period start date, end date, and other date-related attributes required to compute a cashflow amount in accordance with a schedule (as illustrated in the day count fraction calculation shown above).
 
-The CDM has two main types for this:
+The CDM has two main types to address this requirement:
 
 * ``CalculationPeriodDates`` specifies the inputs required to construct a calculation period schedule
 * ``CalculationPeriodData`` specifies actual attribute values of a calculation period such as start date, end date, etc.
 
-From this data model, a function is required to compute the latter based on the former (and also the current date):
+The CalculationPeriod functon receives the ``CalculationPeriodDates`` and the current date as the inputs and produces the ``CalculationPeriodData` as the output, as shown below:
 
 .. code-block:: Haskell
 
@@ -1011,8 +1011,7 @@ From this data model, a function is required to compute the latter based on the 
 
 Equity Performance
 """"""""""""""""""
-
-To support the implementation of Equity Swaps in CDM, calculations have been introduced to support the equity performance concepts used to reset and pay cashflows on such contracts. Those calculations follow the definitions as normalised in the new **2018 ISDA CDM Equity Confirmation for Security Equity Swap** (although this is a new template that is not yet in use across the industry).
+The CDM process model includes calculations to support the equity performance concepts applied to reset and pay cashflows on Equity Swaps. Those calculations follow the definitions as normalised in the new **2018 ISDA CDM Equity Confirmation for Security Equity Swap** (although this is a new template that is not yet in use across the industry).
 
 Some of those calculations are presented below:
 
@@ -1058,8 +1057,6 @@ Reference Data Model
 The CDM only integrates the reference data components that are specifically needed to model the in-scope products, events, legal agreements and function components.
 
 This translates into the representation of the **party**, with two alternate representations, modelled as attributes: the **legal entity** and the **natural person**.  The reason for making use of the class inheritance model, with Party as a the base type that would be extended by LegalEntity and NaturalPerson, is that the Rosetta model doesn't support downcasting, which was causing issues in some scenarios. This will be further assess at some future point.
-
-The CDM reference data representation will be further expanded once use cases for the model is firmed out.
 
 .. code-block:: Java
 


### PR DESCRIPTION
I made a number of edits, and added a few questions preceded by -- 

Some of the reasoning behind the edits and questions is summarized below:

The section should explain in a clear and straight-forward language the purpose of the function and how it works.  I have inserted as much as I know, but would like to add more given a better understanding. The content should  avoid circular explanations, e.g. "product qualification is inferred from... qualification logic"

The fonts should be consistent throughout the document, e..g no random use of the bold font.

I suggest limiting the documentation to the CDM current state.  Unless absolutely necessary to explain a current state, the documentation should exclude statements describing what it does not do, which generally does not help to explain or promote the product.  Additionally, I suggest that we don't reference future plans - - that information belongs somewhere else and moreover, future statements give the impression that CDM is not finished.

If we are going to refer the reader to another section, then we should do it at the end of the current section rather then interrupting the thought process of the reader.  We should also make sure that any hyperlinks bring the user directly to the advertised section.

That example of productIdentification does not look like a "serialized" version of a message.  My understanding of a serialized version is one that does not have any attribute names because it's associated with a specific scheme for which the attributes can be inferred.  This example looks like a "de-serialized" version, which is a qualification that is not necessary to explain this function.