### PR TITLE
Making the transferExpression field optional

### DIFF
--- a/rosetta-source/src/main/rosetta/event-common-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-common-type.rosetta
@@ -209,7 +209,7 @@ type TransferState: <"Defines the fundamental financial information associated w
 type Transfer extends TransferBase: <"Defines the movement of cash, securities or commodities between two parties on a date.">
 	settlementOrigin SettlementOrigin (0..1) <"Represents the origin to the transfer as a reference for lineage purposes, whether it originated from trade level settlement terms or from payment terms on an economic payout.">
 	resetOrigin Reset (0..1) <"Represents the reset and observation values that were used to determine the transfer amount.">
-	transferExpression TransferExpression (1..1) <"Specifies a transfer expression (cash price, performance amount, scheduled payment amount, etc.) to define the nature of the transfer amount and its source.">
+	transferExpression TransferExpression (0..1) <"Specifies a transfer expression (cash price, performance amount, scheduled payment amount, etc.) to define the nature of the transfer amount and its source.">
 
 type TransferExpression: <"Specifies a transfer expression (cash price, performance amount, scheduled payment amount, etc.) to define the nature of the transfer amount and its source.">
 	priceTransfer FeeTypeEnum (0..1) <"Specifies a transfer amount exchanged as a price or fee for entering into a Business Event, e.g. Premium, Termination fee, Novation fee.">


### PR DESCRIPTION
Changing the cardinality of transferExpression from (1..1) to (0..1) - making this field optional when creating a transferInstruction