### PR TITLE
Update DSL version to 7.3.1 and bundle version 5.9.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,17 +1,15 @@
-# Product Model - FpML synonym mappings for price and quantity
-
-_Background_
-
-This release updates and extends the FpML mapping coverage for the product model.
+# *Infrastructure - Dependency Updates*
 
 _What is being released?_
 
-* Mappings added to populate CDM type `PriceSchedule` containers with FpML element `fixedPriceStep`
-* Mappings added to populate CDM attribute `QuantitySchedule -> datedValue` with FpML element `period`
-* Mappings added to populate CDM attribute `DatedValue -> date` with FpML element `startDate`
-* Mappings added to populate CDM attribute `DatedValue -> value` with FpML path `notionalStep -> quantity`
-* Mappings added to populate CDM attribute `ResolvablePriceQuantity -> quantitySchedule` with FpML path `protectionTerms -> calculationAmount`
+This release updates the `rosetta-dsl` dependency:
+
+- Version `7.3.1` - Fix Java code-gen bug related to extracting `date` from `zonedDateTime` record type
+- Version `7.3.0` - Add support for external rule reference
+- Version `7.2.1` - Code-gen generated Java that does not contain keyword clashes
+
+This release contains no changes to the model or test expectations.
 
 _Review directions_
 
-* In the CDM Portal, select the Textual Browser and inspect each of the changes identified above.
+CDM Java implementors should update their maven `pom.xml` to the latest CDM maven artefact (groupId com.isda, artifactId cdm) and recompile.

--- a/cdm-distribution/csharp8-pom.xml
+++ b/cdm-distribution/csharp8-pom.xml
@@ -49,6 +49,11 @@
             <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cdm-distribution/csharp9-pom.xml
+++ b/cdm-distribution/csharp9-pom.xml
@@ -49,6 +49,11 @@
             <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cdm-distribution/daml-pom.xml
+++ b/cdm-distribution/daml-pom.xml
@@ -49,6 +49,11 @@
             <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cdm-distribution/golang-pom.xml
+++ b/cdm-distribution/golang-pom.xml
@@ -32,6 +32,11 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/cdm-distribution/golang-pom.xml
+++ b/cdm-distribution/golang-pom.xml
@@ -32,11 +32,6 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <scope>test</scope>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -52,6 +47,11 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cdm-distribution/kotlin-pom.xml
+++ b/cdm-distribution/kotlin-pom.xml
@@ -49,6 +49,11 @@
             <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cdm-distribution/pom.xml
+++ b/cdm-distribution/pom.xml
@@ -244,6 +244,11 @@
             <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <distributionManagement>

--- a/cdm-distribution/pom.xml
+++ b/cdm-distribution/pom.xml
@@ -242,10 +242,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/cdm-distribution/scala-pom.xml
+++ b/cdm-distribution/scala-pom.xml
@@ -49,6 +49,11 @@
             <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/cdm-distribution/typescript-pom.xml
+++ b/cdm-distribution/typescript-pom.xml
@@ -49,6 +49,11 @@
             <artifactId>guava</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/isda-demo/pom.xml
+++ b/isda-demo/pom.xml
@@ -32,16 +32,18 @@
             <artifactId>cdm</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <!-- release version is overridden in rosetta-source -->
         <maven.compiler.release>11</maven.compiler.release>
 
-        <rosetta.bundle.version>0.0.0.junit-deps</rosetta.bundle.version>
+        <rosetta.bundle.version>5.9.0</rosetta.bundle.version>
         <rosetta.dsl.version>7.3.1</rosetta.dsl.version>
 
         <xtext.version>2.27.0</xtext.version>
@@ -78,8 +78,7 @@
             <dependency>
                 <groupId>com.regnosys.rosetta.code-generators</groupId>
                 <artifactId>default-cdm-generators</artifactId>
-<!--                <version>${rosetta.bundle.version}</version>-->
-                <version>5.8.0</version>
+                <version>${rosetta.bundle.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.regnosys</groupId>
@@ -293,7 +292,7 @@
                         <dependency>
                             <groupId>com.regnosys.rosetta.code-generators</groupId>
                             <artifactId>default-cdm-generators</artifactId>
-                            <version>5.8.0</version>
+                            <version>${rosetta.bundle.version}</version>
                         </dependency>
                         <dependency>
                             <groupId>com.regnosys.rosetta</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,61 +18,23 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <rosetta.bundle.version>5.5.1</rosetta.bundle.version>
-        <rosetta.dsl.version>7.1.1</rosetta.dsl.version>
-
-        <opengamma.strata.version>1.7.0</opengamma.strata.version>
-
-        <apache.commons.lang3.version>3.12.0</apache.commons.lang3.version>
-        <apache.commons.cli.version>1.4</apache.commons.cli.version>
-        <kotlin.version>1.7.21</kotlin.version>
-        <jsoup.version>1.15.3</jsoup.version>
-        <jaxb.version>2.3.1</jaxb.version>
-
-        <!-- remove once common moved to parent START -->
-        <jackson.version>2.14.0</jackson.version>
-        <guice.version>5.0.1</guice.version>
-        <guava.version>30.1.1-jre</guava.version>
-        <slf4j-api.version>2.0.1</slf4j-api.version>
-        <logback.version>1.4.4</logback.version>
-        <junit.version>5.9.1</junit.version>
-        <mockito.version>5.1.1</mockito.version>
-        <hamcrest.version>2.2</hamcrest.version>
-        <java-hamcrest.version>2.0.0.0</java-hamcrest.version>
-        <commons.io.version>2.11.0</commons.io.version>
-        <validation-api.version>2.0.1.Final</validation-api.version>
-        <!-- remove once common moved to parent END -->
-
         <!-- release version is overridden in rosetta-source -->
         <maven.compiler.release>11</maven.compiler.release>
 
-        <!-- xtext start -->
-        <xtend.version>2.27.0</xtend.version>
-        <xtext.version>2.27.0</xtext.version>
-        <org.eclipse.jdt.core.version>3.30.0</org.eclipse.jdt.core.version>
-        <org.eclipse.core.resources.version>3.17.0</org.eclipse.core.resources.version>
-        <org.eclipse.osgi.version>3.18.0</org.eclipse.osgi.version>
-        <org.eclipse.jdt.compiler.apt.version>1.3.1100</org.eclipse.jdt.compiler.apt.version>
-        <org.eclipse.jdt.compiler.tool.version>1.3.150</org.eclipse.jdt.compiler.tool.version>
-        <org.eclipse.equinox.common.version>3.16.100</org.eclipse.equinox.common.version>
-        <org.eclipse.equinox.registry.version>3.11.100</org.eclipse.equinox.registry.version>
-        <org.eclipse.equinox.preferences.version>3.10.1</org.eclipse.equinox.preferences.version>
-        <org.eclipse.core.runtime.version>3.25.0</org.eclipse.core.runtime.version>
-        <org.eclipse.emf.ecore.xmi.version>2.16.0</org.eclipse.emf.ecore.xmi.version>
-        <org.eclipse.emf.codegen.ecore-version>2.30.0</org.eclipse.emf.codegen.ecore-version>
-        <org.eclipse.core.expressions.version>3.8.100</org.eclipse.core.expressions.version>
-        <org.eclipse.core.filesystem.version>1.9.400</org.eclipse.core.filesystem.version>
-        <org.eclipse.core.variables.version>3.5.100</org.eclipse.core.variables.version>
-        <org.eclipse.debug.core.version>3.19.100</org.eclipse.debug.core.version>
-        <org.eclipse.emf.common.version>2.25.0</org.eclipse.emf.common.version>
-        <org.eclipse.emf.ecore.version>2.27.0</org.eclipse.emf.ecore.version>
-        <org.eclipse.jdt.launching.version>3.19.600</org.eclipse.jdt.launching.version>
-        <org.eclipse.text.version>3.12.100</org.eclipse.text.version>
-        <!-- xtext end -->
+        <rosetta.bundle.version>0.0.0.junit-deps</rosetta.bundle.version>
+        <rosetta.dsl.version>7.3.1</rosetta.dsl.version>
 
-        <jsr305.version>3.0.2</jsr305.version>
-        <asm.version>9.3</asm.version>
-        <annotations.version>13.0</annotations.version>
+        <xtext.version>2.27.0</xtext.version>
+        <opengamma.strata.version>1.7.0</opengamma.strata.version>
+        <apache.commons.cli.version>1.4</apache.commons.cli.version>
+        <jsoup.version>1.15.3</jsoup.version>
+        <jaxb.version>2.3.1</jaxb.version>
+
+        <junit.version>5.9.1</junit.version>
+        <junit-platform-commons.version>1.9.1</junit-platform-commons.version>
+        <mockito.version>5.1.1</mockito.version>
+        <hamcrest.version>2.2</hamcrest.version>
+
         <maven-dependency-plugin.version>3.1.1</maven-dependency-plugin.version>
         <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
@@ -80,7 +42,6 @@
         <maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
         <versions-maven-plugin.version>2.10.0</versions-maven-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-        <maven-core.version>3.2.5</maven-core.version>
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
@@ -93,6 +54,99 @@
 
     <dependencyManagement>
         <dependencies>
+            <!-- rosetta START -->
+            <dependency>
+                <groupId>com.regnosys.rosetta</groupId>
+                <artifactId>com.regnosys.rosetta</artifactId>
+                <version>${rosetta.dsl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.regnosys.rosetta</groupId>
+                <artifactId>com.regnosys.rosetta.lib</artifactId>
+                <version>${rosetta.dsl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.regnosys.rosetta</groupId>
+                <artifactId>com.regnosys.rosetta.blueprint.lib</artifactId>
+                <version>${rosetta.dsl.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.regnosys</groupId>
+                <artifactId>rosetta-common</artifactId>
+                <version>${rosetta.bundle.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.regnosys.rosetta.code-generators</groupId>
+                <artifactId>default-cdm-generators</artifactId>
+<!--                <version>${rosetta.bundle.version}</version>-->
+                <version>5.8.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.regnosys</groupId>
+                <artifactId>rosetta-testing</artifactId>
+                <version>${rosetta.bundle.version}</version>
+            </dependency>
+            <!-- rosetta END -->
+            <!-- xtext START -->
+            <dependency>
+                <groupId>org.eclipse.xtext</groupId>
+                <artifactId>xtext-dev-bom</artifactId>
+                <version>${xtext.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <!-- xtext END -->
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.glassfish.jaxb</groupId>
+                <artifactId>jaxb-runtime</artifactId>
+                <version>${jaxb.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.opengamma.strata</groupId>
+                <artifactId>strata-basics</artifactId>
+                <version>${opengamma.strata.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.checkerframework</groupId>
+                        <artifactId>checker-compat-qual</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>commons-cli</groupId>
+                <artifactId>commons-cli</artifactId>
+                <version>${apache.commons.cli.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jsoup</groupId>
+                <artifactId>jsoup</artifactId>
+                <version>${jsoup.version}</version>
+            </dependency>
+            <!-- test -->
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-bom</artifactId>
+                <version>${mockito.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.hamcrest</groupId>
+                <artifactId>hamcrest</artifactId>
+                <version>${hamcrest.version}</version>
+            </dependency>
             <!-- plugins START -->
             <dependency>
                 <groupId>org.eclipse.xtext</groupId>
@@ -175,259 +229,6 @@
                 <version>${sphinx-maven-plugin.version}</version>
             </dependency>
             <!-- plugins END -->
-            <!-- xtext START -->
-            <dependency>
-                <artifactId>org.eclipse.equinox.common</artifactId>
-                <groupId>org.eclipse.platform</groupId>
-                <version>${org.eclipse.equinox.common.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jdt</groupId>
-                <artifactId>org.eclipse.jdt.core</artifactId>
-                <version>${org.eclipse.jdt.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.platform</groupId>
-                <artifactId>org.eclipse.core.resources</artifactId>
-                <version>${org.eclipse.core.resources.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.platform</groupId>
-                <artifactId>org.eclipse.osgi</artifactId>
-                <version>${org.eclipse.osgi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jdt</groupId>
-                <artifactId>org.eclipse.jdt.compiler.apt</artifactId>
-                <version>${org.eclipse.jdt.compiler.apt.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jdt</groupId>
-                <artifactId>org.eclipse.jdt.compiler.tool</artifactId>
-                <version>${org.eclipse.jdt.compiler.tool.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.platform</groupId>
-                <artifactId>org.eclipse.core.runtime</artifactId>
-                <version>${org.eclipse.core.runtime.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.platform</groupId>
-                <artifactId>org.eclipse.equinox.preferences</artifactId>
-                <version>${org.eclipse.equinox.preferences.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.platform</groupId>
-                <artifactId>org.eclipse.equinox.registry</artifactId>
-                <version>${org.eclipse.equinox.registry.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.emf</groupId>
-                <artifactId>org.eclipse.emf.ecore.xmi</artifactId>
-                <version>${org.eclipse.emf.ecore.xmi.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.xtend</groupId>
-                <artifactId>org.eclipse.xtend.lib</artifactId>
-                <version>${xtend.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.xtext</groupId>
-                <artifactId>org.eclipse.xtext.xbase.lib</artifactId>
-                <version>${xtext.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.xtext</groupId>
-                <artifactId>org.eclipse.xtext</artifactId>
-                <version>${xtext.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.xtext</groupId>
-                <artifactId>org.eclipse.xtext.xbase.testing</artifactId>
-                <version>${xtext.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.xtext</groupId>
-                <artifactId>org.eclipse.xtext.testing</artifactId>
-                <version>${xtext.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.emf</groupId>
-                <artifactId>org.eclipse.emf.codegen.ecore</artifactId>
-                <version>${org.eclipse.emf.codegen.ecore-version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.platform</groupId>
-                <artifactId>org.eclipse.core.expressions</artifactId>
-                <version>${org.eclipse.core.expressions.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.platform</groupId>
-                <artifactId>org.eclipse.core.filesystem</artifactId>
-                <version>${org.eclipse.core.filesystem.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.platform</groupId>
-                <artifactId>org.eclipse.debug.core</artifactId>
-                <version>${org.eclipse.debug.core.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.emf</groupId>
-                <artifactId>org.eclipse.emf.common</artifactId>
-                <version>${org.eclipse.emf.common.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.emf</groupId>
-                <artifactId>org.eclipse.emf.ecore</artifactId>
-                <version>${org.eclipse.emf.ecore.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jdt</groupId>
-                <artifactId>org.eclipse.jdt.launching</artifactId>
-                <version>${org.eclipse.jdt.launching.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.platform</groupId>
-                <artifactId>org.eclipse.text</artifactId>
-                <version>${org.eclipse.text.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.platform</groupId>
-                <artifactId>org.eclipse.core.variables</artifactId>
-                <version>${org.eclipse.core.variables.version}</version>
-            </dependency>
-            <!-- xtext END -->
-            <!-- rosetta START -->
-            <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta</artifactId>
-                <version>${rosetta.dsl.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta.lib</artifactId>
-                <version>${rosetta.dsl.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta.blueprint.lib</artifactId>
-                <version>${rosetta.dsl.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.regnosys</groupId>
-                <artifactId>rosetta-common</artifactId>
-                <version>${rosetta.bundle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.regnosys.rosetta.code-generators</groupId>
-                <artifactId>default-cdm-generators</artifactId>
-                <version>${rosetta.bundle.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.regnosys</groupId>
-                <artifactId>rosetta-testing</artifactId>
-                <version>${rosetta.bundle.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <!-- rosetta END -->
-            <dependency>
-                <groupId>javax.xml.bind</groupId>
-                <artifactId>jaxb-api</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.glassfish.jaxb</groupId>
-                <artifactId>jaxb-runtime</artifactId>
-                <version>${jaxb.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.guava</groupId>
-                <artifactId>guava</artifactId>
-                <version>${guava.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.opengamma.strata</groupId>
-                <artifactId>strata-basics</artifactId>
-                <version>${opengamma.strata.version}</version>
-                <exclusions>
-                    <exclusion>
-                        <groupId>org.checkerframework</groupId>
-                        <artifactId>checker-compat-qual</artifactId>
-                    </exclusion>
-                </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>commons-cli</groupId>
-                <artifactId>commons-cli</artifactId>
-                <version>${apache.commons.cli.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>log4j-over-slf4j</artifactId>
-                <version>${slf4j-api.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jsoup</groupId>
-                <artifactId>jsoup</artifactId>
-                <version>${jsoup.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-stdlib-jdk8</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-test-junit</artifactId>
-                <version>${kotlin.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jetbrains.kotlin</groupId>
-                <artifactId>kotlin-reflect</artifactId>
-                <version>${kotlin.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>${jsr305.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.ow2.asm</groupId>
-                <artifactId>asm</artifactId>
-                <version>${asm.version}</version>
-            </dependency>
-            <!-- test -->
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.mockito</groupId>
-                <artifactId>mockito-bom</artifactId>
-                <version>${mockito.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>hamcrest</artifactId>
-                <version>${hamcrest.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.hamcrest</groupId>
-                <artifactId>java-hamcrest</artifactId>
-                <version>${java-hamcrest.version}</version>
-            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -492,7 +293,7 @@
                         <dependency>
                             <groupId>com.regnosys.rosetta.code-generators</groupId>
                             <artifactId>default-cdm-generators</artifactId>
-                            <version>${rosetta.bundle.version}</version>
+                            <version>5.8.0</version>
                         </dependency>
                         <dependency>
                             <groupId>com.regnosys.rosetta</groupId>
@@ -503,38 +304,6 @@
                             <groupId>com.regnosys.rosetta</groupId>
                             <artifactId>com.regnosys.rosetta.lib</artifactId>
                             <version>${rosetta.dsl.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.apache.maven</groupId>
-                            <artifactId>maven-core</artifactId>
-                            <version>${maven-core.version}</version>
-                            <exclusions>
-                                <exclusion>
-                                    <groupId>com.google.guava</groupId>
-                                    <artifactId>guava</artifactId>
-                                </exclusion>
-                            </exclusions>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.apache.commons</groupId>
-                            <artifactId>commons-lang3</artifactId>
-                            <version>${apache.commons.lang3.version}</version>
-                        </dependency>
-                        <!-- See https://github.com/eclipse/xtext-xtend/issues/493 -->
-                        <dependency>
-                            <groupId>org.eclipse.jdt</groupId>
-                            <artifactId>org.eclipse.jdt.core</artifactId>
-                            <version>${org.eclipse.jdt.core.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.eclipse.jdt</groupId>
-                            <artifactId>org.eclipse.jdt.compiler.apt</artifactId>
-                            <version>${org.eclipse.jdt.compiler.apt.version}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>org.eclipse.jdt</groupId>
-                            <artifactId>org.eclipse.jdt.compiler.tool</artifactId>
-                            <version>${org.eclipse.jdt.compiler.tool.version}</version>
                         </dependency>
                     </dependencies>
                 </plugin>
@@ -612,6 +381,7 @@
             <url>https://regnosys.jfrog.io/regnosys/libs-snapshot</url>
         </repository>
     </repositories>
+
     <pluginRepositories>
         <pluginRepository>
             <id>central</id>

--- a/rosetta-project/pom.xml
+++ b/rosetta-project/pom.xml
@@ -24,6 +24,21 @@
                 <version>${rosetta.bundle.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>${junit-platform-commons.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -33,24 +48,18 @@
             <artifactId>cdm</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.regnosys</groupId>
+            <artifactId>ingest-test-framework</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
-           <groupId>com.regnosys</groupId>
-           <artifactId>ingest-test-framework</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/rosetta-source/pom.xml
+++ b/rosetta-source/pom.xml
@@ -1039,8 +1039,6 @@
                 </executions>
                 <configuration>
                     <release>${maven.compiler.release}</release>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
                     <excludes>
                         <exclude>**/*.rosetta</exclude>
                     </excludes>
@@ -1063,32 +1061,17 @@
             <artifactId>rosetta-common</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.regnosys</groupId>
+            <artifactId>rosetta-testing</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.opengamma.strata</groupId>
             <artifactId>strata-basics</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>log4j-over-slf4j</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-test-junit</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-cli</groupId>
@@ -1096,10 +1079,14 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.regnosys</groupId>
-            <artifactId>rosetta-testing</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
-
-
 </project>

--- a/scheme-import/pom.xml
+++ b/scheme-import/pom.xml
@@ -33,7 +33,6 @@
         <dependency>
             <groupId>com.regnosys</groupId>
             <artifactId>rosetta-testing</artifactId>
-            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>
@@ -46,10 +45,6 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
         </dependency>
     </dependencies>
 
@@ -123,8 +118,6 @@
                 </executions>
                 <configuration>
                     <release>${maven.compiler.release}</release>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
                     <excludes>
                         <exclude>**/*.rosetta</exclude>
                     </excludes>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -24,6 +24,21 @@
                 <version>${rosetta.bundle.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${junit.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-commons</artifactId>
+                <version>${junit-platform-commons.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -35,27 +50,17 @@
         <dependency>
             <groupId>com.regnosys</groupId>
             <artifactId>ingest-test-framework</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.regnosys</groupId>
             <artifactId>rosetta-testing</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.glassfish.jaxb</groupId>
-            <artifactId>jaxb-runtime</artifactId>
-        </dependency>
-        <!--
-            The osgi dependency from rosetta.lib can take precedence on the classpath causing
-            Java security exceptions when matchers form the same package are subsequently loaded from Hamcrest
-        -->
-        <dependency>
-            <groupId>org.hamcrest</groupId>
-            <artifactId>java-hamcrest</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- No model or test expectation changes
- DSL version updated, all versions backwards compatible:
  - `7.3.1` Fix Java code-gen bug related to extracting `date` from `zonedDateTime` record type
  - `7.3.0` Add support for external rule reference
  - `7.2.1` Code-gen generated Java that does not contain keyword clashes
- Maven dependency cleaned up - transitive dependencies removed (especially xtext)