### PR TITLE
Update bundle version to 5.9.1 (ingestion test json assert fix)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
         <!-- release version is overridden in rosetta-source -->
         <maven.compiler.release>11</maven.compiler.release>
 
-        <rosetta.bundle.version>5.9.0</rosetta.bundle.version>
+        <rosetta.bundle.version>5.9.1</rosetta.bundle.version>
         <rosetta.dsl.version>7.3.1</rosetta.dsl.version>
 
         <xtext.version>2.27.0</xtext.version>


### PR DESCRIPTION
Bundle version 5.9.1 contains a bug fix to the ingestion testing library related to how the expected json is loaded as asserted