### PR TITLE
Add executionDateTime to Execution Details

### DIFF
--- a/rosetta-source/src/main/rosetta/event-common-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-common-type.rosetta
@@ -472,7 +472,8 @@ type ExecutionDetails: <"Defines specific attributes that relate to trade execut
 	executionType ExecutionTypeEnum (1..1) <"Identifies the type of execution, e.g. via voice, electronically...">
 	executionVenue LegalEntity (0..1) <"Represents the venue on which a trade was executed.">
 	packageReference IdentifiedList (0..1) <"A reference to the package linking the trade with other trades, in case the trade was executed as part of a package (hence this attribute is optional).">
-		
+	executionDateTime zonedDateTime (0..1) <"The zoned date and time of the execution.">
+
 	condition ExecutionVenue: <"When the execution type is set to 'Electronically', the execution venue must be specified.">
 		if executionType = ExecutionTypeEnum -> Electronic
 		then executionVenue exists

--- a/rosetta-source/src/main/rosetta/namespace-hierarchy.json
+++ b/rosetta-source/src/main/rosetta/namespace-hierarchy.json
@@ -462,40 +462,40 @@
 							},
 							{
 								"name": "asset",
-								"description": "Observable concepts applicable to assets: price, reference price, valuation method etc. Observable asset concepts: schedule, settlement, price and quantity notation etc.", 
+								"description": "Observable asset concepts: schedule, settlement, price and quantity notation etc. Observable concepts applicable to assets: price, reference price, valuation method etc.", 
 									"children": [
 										{
 											"name": "Data",
-											"description": "Observable concepts applicable to assets: price, reference price, valuation method etc. Observable asset concepts: schedule, settlement, price and quantity notation etc.",
+											"description": "Observable asset concepts: schedule, settlement, price and quantity notation etc. Observable concepts applicable to assets: price, reference price, valuation method etc.",
 											"uri": "observable-asset-type.rosetta"	
 										},
 										{
 											"name": "Enum",
-											"description": "Observable concepts applicable to assets: price, reference price, valuation method etc. Observable asset concepts: schedule, settlement, price and quantity notation etc.",
+											"description": "Observable asset concepts: schedule, settlement, price and quantity notation etc. Observable concepts applicable to assets: price, reference price, valuation method etc.",
 											"uri": "observable-asset-enum.rosetta"	
 										},
 										{
 											"name": "Func",
-											"description": "Observable concepts applicable to assets: price, reference price, valuation method etc. Observable asset concepts: schedule, settlement, price and quantity notation etc.",
+											"description": "Observable asset concepts: schedule, settlement, price and quantity notation etc. Observable concepts applicable to assets: price, reference price, valuation method etc.",
 											"uri": "observable-asset-func.rosetta"	
 										},
 										{
 											"name": "calculatedrate",
-											"description": "Support for calculated floating rates such as lookback compound or observation shift compound rate. Support for calculated floating rates such as lookback compound or observation shift compound rates Floating amount calculations for calculated rates.", 
+											"description": "Support for calculated floating rates such as lookback compound or observation shift compound rates Support for calculated floating rates such as lookback compound or observation shift compound rate. Floating amount calculations for calculated rates.", 
 												"children": [
 													{
 														"name": "Data",
-														"description": "Support for calculated floating rates such as lookback compound or observation shift compound rate. Support for calculated floating rates such as lookback compound or observation shift compound rates Floating amount calculations for calculated rates.",
+														"description": "Support for calculated floating rates such as lookback compound or observation shift compound rates Support for calculated floating rates such as lookback compound or observation shift compound rate. Floating amount calculations for calculated rates.",
 														"uri": "observable-asset-calculatedrate-type.rosetta"	
 													},
 													{
 														"name": "Enum",
-														"description": "Support for calculated floating rates such as lookback compound or observation shift compound rate. Support for calculated floating rates such as lookback compound or observation shift compound rates Floating amount calculations for calculated rates.",
+														"description": "Support for calculated floating rates such as lookback compound or observation shift compound rates Support for calculated floating rates such as lookback compound or observation shift compound rate. Floating amount calculations for calculated rates.",
 														"uri": "observable-asset-calculatedrate-enum.rosetta"	
 													},
 													{
 														"name": "Func",
-														"description": "Support for calculated floating rates such as lookback compound or observation shift compound rate. Support for calculated floating rates such as lookback compound or observation shift compound rates Floating amount calculations for calculated rates.",
+														"description": "Support for calculated floating rates such as lookback compound or observation shift compound rates Support for calculated floating rates such as lookback compound or observation shift compound rate. Floating amount calculations for calculated rates.",
 														"uri": "observable-asset-calculatedrate-func.rosetta"	
 													}
 												]
@@ -610,21 +610,21 @@
 										},
 										{
 											"name": "floatingrate",
-											"description": "Product-related, asset class-specific floating-rate index concepts, such as rate definitions . Product-related, asset class-specific floating-rate index concepts, such as rate definitions  Product-related, asset class-specific floating-rate index concepts, such as rate definitions.", 
+											"description": "Product-related, asset class-specific floating-rate index concepts, such as rate definitions  Product-related, asset class-specific floating-rate index concepts, such as rate definitions . Product-related, asset class-specific floating-rate index concepts, such as rate definitions.", 
 												"children": [
 													{
 														"name": "Data",
-														"description": "Product-related, asset class-specific floating-rate index concepts, such as rate definitions . Product-related, asset class-specific floating-rate index concepts, such as rate definitions  Product-related, asset class-specific floating-rate index concepts, such as rate definitions.",
+														"description": "Product-related, asset class-specific floating-rate index concepts, such as rate definitions  Product-related, asset class-specific floating-rate index concepts, such as rate definitions . Product-related, asset class-specific floating-rate index concepts, such as rate definitions.",
 														"uri": "product-asset-floatingrate-type.rosetta"	
 													},
 													{
 														"name": "Enum",
-														"description": "Product-related, asset class-specific floating-rate index concepts, such as rate definitions . Product-related, asset class-specific floating-rate index concepts, such as rate definitions  Product-related, asset class-specific floating-rate index concepts, such as rate definitions.",
+														"description": "Product-related, asset class-specific floating-rate index concepts, such as rate definitions  Product-related, asset class-specific floating-rate index concepts, such as rate definitions . Product-related, asset class-specific floating-rate index concepts, such as rate definitions.",
 														"uri": "product-asset-floatingrate-enum.rosetta"	
 													},
 													{
 														"name": "Func",
-														"description": "Product-related, asset class-specific floating-rate index concepts, such as rate definitions . Product-related, asset class-specific floating-rate index concepts, such as rate definitions  Product-related, asset class-specific floating-rate index concepts, such as rate definitions.",
+														"description": "Product-related, asset class-specific floating-rate index concepts, such as rate definitions  Product-related, asset class-specific floating-rate index concepts, such as rate definitions . Product-related, asset class-specific floating-rate index concepts, such as rate definitions.",
 														"uri": "product-asset-floatingrate-func.rosetta"	
 													}
 												]


### PR DESCRIPTION
ExecutionDetails type currently does not include an execution date and time, and Trade type only includes date type. This is needed for various regulatory reports and booking systems. 