### PR TITLE
Ben Aubry: Adding the FinalPrincipalExchangeCalculation

### DIFF
--- a/rosetta-source/src/main/rosetta/product-asset-enum.rosetta
+++ b/rosetta-source/src/main/rosetta/product-asset-enum.rosetta
@@ -132,3 +132,7 @@ enum FPVFinalPriceElectionFallbackEnum: <"Specifies the fallback provisions in r
 
 	FPVClose <"In respect of the Early Final Valuation Date, the provisions for FPV Close shall apply.">
 	FPVHedgeExecution <"In respect of the Early Final Valuation Date, the provisions for FPV Hedge Execution shall apply.">
+
+enum FinalPrincipalExchangeCalculationEnum: <"To be specified only for products that embed a redemption payment.">
+    Floored <"If Floored is set then Principal Exchange takes the form: Notional Amount * Max(1, Index Final/ Index Base).">
+	NonFloored <"If NonFloored is set then the Principal Exchange takes the form: Notional Amount * Index Final / Index Base.">

--- a/rosetta-source/src/main/rosetta/product-asset-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-asset-type.rosetta
@@ -636,10 +636,7 @@ type InflationRateSpecification extends FloatingRateSpecification: <"A data to: 
 	fallbackBondApplicable boolean (1..1) <"The applicability of a fallback bond as defined in the 2006 ISDA Inflation Derivatives Definitions, sections 1.3 and 1.8.">
 	calculationMethod InflationCalculationMethodEnum (0..1) <"Indicates how to use the inflation index to calculate the payment (e.g. Ratio, Return, Spread). Added for Inflation Asset Swap">
 	calculationStyle InflationCalculationStyleEnum (0..1) <"Indicates the style of how the inflation index calculates the payment (e.g. YearOnYear, ZeroCoupon).">  
-    finalPrincipalExchangeCalculation FinalPrincipalExchangeCalculation (0..1) <"To be specified only for inflation products that embed a redemption payment such as an inflation linked asset swap.">
-
-type FinalPrincipalExchangeCalculation: <"To be specified only for inflation products that embed a redemption payment, e.g. inflation linked asset swap.">
-    floored boolean (1..1) <"If TRUE, Principal Exchange takes the form: Inflation Notional Amount * Max(1, Index Final/ Index Base). If FALSE, the Principal Exchange takes the form: Inflation Notional Amount * Index Final / Index Base.">
+    finalPrincipalExchangeCalculation FinalPrincipalExchangeCalculationEnum (0..1) <"To be specified only for products that embed a redemption payment.">
 
 type FloatingRate: <"A class defining a floating interest rate through the specification of the floating rate index, the tenor, the multiplier schedule, the spread, the qualification of whether a specific rate treatment and/or a cap or floor apply.">
 	[metadata key]

--- a/rosetta-source/src/main/rosetta/product-asset-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-asset-type.rosetta
@@ -635,9 +635,11 @@ type InflationRateSpecification extends FloatingRateSpecification: <"A data to: 
 	initialIndexLevel number (0..1) <"Initial known index level for the first calculation period.">
 	fallbackBondApplicable boolean (1..1) <"The applicability of a fallback bond as defined in the 2006 ISDA Inflation Derivatives Definitions, sections 1.3 and 1.8.">
 	calculationMethod InflationCalculationMethodEnum (0..1) <"Indicates how to use the inflation index to calculate the payment (e.g. Ratio, Return, Spread). Added for Inflation Asset Swap">
-	calculationStyle InflationCalculationStyleEnum (0..1) <"Indicates the style of how the inflation index calculates the payment (e.g. YearOnYear, ZeroCoupon).
-">
+	calculationStyle InflationCalculationStyleEnum (0..1) <"Indicates the style of how the inflation index calculates the payment (e.g. YearOnYear, ZeroCoupon).">  
+    finalPrincipalExchangeCalculation FinalPrincipalExchangeCalculation (0..1) <"To be specified only for inflation products that embed a redemption payment such as an inflation linked asset swap.">
 
+type FinalPrincipalExchangeCalculation: <"To be specified only for inflation products that embed a redemption payment, e.g. inflation linked asset swap.">
+    floored boolean (1..1) <"If TRUE, Principal Exchange takes the form: Inflation Notional Amount * Max(1, Index Final/ Index Base). If FALSE, the Principal Exchange takes the form: Inflation Notional Amount * Index Final / Index Base.">
 
 type FloatingRate: <"A class defining a floating interest rate through the specification of the floating rate index, the tenor, the multiplier schedule, the spread, the qualification of whether a specific rate treatment and/or a cap or floor apply.">
 	[metadata key]


### PR DESCRIPTION
Adding the FinalPrincipalExchangeCalculation for inflation swaps. Added the finalPrincipalExchangeCalculation field with a type of FinalPrincipalExchangeCalculation. Also added a field underneath FinalPrincipalExchangeCalculation which is of type Boolean. This is per the FpML data model, CDM was not supporting this.

Change made by @ben-aubry 