### PR TITLE
Underlier for Equity Option Baskets

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,26 @@
-# *Infrastructure - Dependency Updates*
+# _Payout underlier for Equity Option Baskets_
+
+_Background_
+
+An issue was identified with the underlier mapping from FpML to CDM for Equity Option Basket products. The mapping from CDM was not generating an underlier and its corresponding baskets for these products and therefore some samples were not accurately qualified.
+
+This release addresses this mapping issue, correctly generating the underlier and its corresponding baskets.
 
 _What is being released?_
 
-This release updates the `rosetta-dsl` dependency:
+_Translate_
 
-- Versions:
-    - `7.5.4` Fixed DSL issue related to `typeAlias` - see https://github.com/REGnosys/rosetta-dsl/issues/554 
-
-This release contains no changes to the model or test expectations.
+Added minor changes for mapping coverage of equity options with baskets.
 
 _Review directions_
 
-CDM Java implementors should update their maven `pom.xml` to the latest CDM maven artefact (groupId com.isda, artifactId cdm) and recompile.
+In the CDM Portal, select the Textual Browser and inspect the changes identified above.
+
+In the CDM Portal, select Ingestion and review the following samples:
+
+fpml-5-10/incomplete-products/equity-options
+
+- eqd ex08 basket long form
+- eqd ex20 nested basket
+- eqd ex21 flat weight basket
+- eqd ex26 mixed asset basket

--- a/rosetta-source/src/main/rosetta/mapping-fpml-confirmation-tradestate-synonym.rosetta
+++ b/rosetta-source/src/main/rosetta/mapping-fpml-confirmation-tradestate-synonym.rosetta
@@ -2413,8 +2413,7 @@ synonym source FpML_5_Confirmation_To_TradeState extends FpML
 			[value "features"]
 			[hint "averagingMethod"]
 		+ underlier
-			[value "singleUnderlyer" path "underlyer"]
-			[value "basket" path "underlyer"]
+			[value "singleUnderlyer" path "underlyer", "underlyer"]
 			[hint "bond", "equity", "mortgage", "convertibleBond", "index"]
 			[hint "swap"]
 			[hint "creditDefaultSwap"]
@@ -2811,7 +2810,7 @@ synonym source FpML_5_Confirmation_To_TradeState extends FpML
 			[value "varianceOptionTransactionSupplement"]
 			[value "dividendSwapTransactionSupplement" path "dividendSwapOptionTransactionSupplement"]
 			[value "varianceSwapTransactionSupplement" path "varianceOptionTransactionSupplement"]
-			[hint "fxVarianceSwap"]
+        	[hint "fxVarianceSwap"]
 			[hint "fxVolatilitySwap"]
 			// Other
 			[value "commoditySwap"]

--- a/rosetta-source/src/main/rosetta/mapping-fpml-confirmation-tradestate-synonym.rosetta
+++ b/rosetta-source/src/main/rosetta/mapping-fpml-confirmation-tradestate-synonym.rosetta
@@ -2810,7 +2810,7 @@ synonym source FpML_5_Confirmation_To_TradeState extends FpML
 			[value "varianceOptionTransactionSupplement"]
 			[value "dividendSwapTransactionSupplement" path "dividendSwapOptionTransactionSupplement"]
 			[value "varianceSwapTransactionSupplement" path "varianceOptionTransactionSupplement"]
-        	[hint "fxVarianceSwap"]
+        	        [hint "fxVarianceSwap"]
 			[hint "fxVolatilitySwap"]
 			// Other
 			[value "commoditySwap"]


### PR DESCRIPTION
This contribution fixes a mapping issue which prevented CDM from generating the underlier and its corresponding baskets, for equity option basket products.