### PR TITLE
Add settlement party and role to settlement base

### DIFF
--- a/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
@@ -370,8 +370,7 @@ type SettlementBase: <"A base class to be extended by the SettlementTerms class.
 	transferSettlementType TransferSettlementEnum (0..1) <"The qualification as to how the transfer will settle, e.g. a DvP settlement.">
 	settlementCurrency string (0..1) <"The settlement currency is to be specified when the Settlement Amount cannot be known in advance. The list of valid currencies is not presently positioned as an enumeration as part of the CDM because that scope is limited to the values specified by ISDA and FpML. As a result, implementers have to make reference to the relevant standard, such as the ISO 4217 standard for currency codes.">
 		[metadata scheme]
-		[docReference ICMA GMRA namingConvention "Contractual Currency"
-		    provision "As defined in GMRA paragraph 2(k)/ paragraph 7(a) All the payments made in respect of the Purchase Price or the Repurchase Price of any Transaction shall be made in the currency of the Purchase Price (the Contractual Currency) save as provided in paragraph 10(d)(ii). Notwithstanding the foregoing, the payee of any money may, at its option, accept tender thereof in any other currency, provided, however, that, to the extent permitted by applicable law, the obligation of the payer to pay such money will be discharged only to the extent of the amount of the Contractual Currency that such payee may, consistent with normal banking procedures, purchase with such other currency (after deduction of any premium and costs of exchange) for delivery within the customary delivery period for spot transactions in respect of the relevant currency."]
+		[docReference ICMA GMRA namingConvention "Contractual Currency" provision "As defined in GMRA paragraph 2(k)/ paragraph 7(a)"]
 	settlementDate SettlementDate (0..1) <"The date on which the settlement amount will be paid, subject to adjustment in accordance with any applicable business day convention. This component would not be present for a mandatory early termination provision where the cash settlement payment date is the mandatory early termination date.">
 	settlementCentre SettlementCentreEnum (0..1) <"Optional settlement centre as an enumerated list: Euroclear, Clearstream.">
 	[deprecated]
@@ -382,7 +381,8 @@ type SettlementBase: <"A base class to be extended by the SettlementTerms class.
 	settlementProvision SettlementProvision (0..1) <"Optionally defines the parameters that regulate a settlement.">
 	standardSettlementStyle StandardSettlementStyleEnum (0..1) <"Settlement Style.">
 
-//ICMA-P2
+
+
 type SettlementProvision: <"Defines parameters that regulate a settlement, for instance whether this settlement should be netted with other ones or broken-down into smaller amounts.">
  	shapingProvisions ShapingProvision (0..1) <"Defines the parameters that are necessary to 'shape' a settlement, i.e. break it down into smaller amounts.">
 

--- a/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
@@ -375,8 +375,10 @@ type SettlementBase: <"A base class to be extended by the SettlementTerms class.
 	settlementDate SettlementDate (0..1) <"The date on which the settlement amount will be paid, subject to adjustment in accordance with any applicable business day convention. This component would not be present for a mandatory early termination provision where the cash settlement payment date is the mandatory early termination date.">
 	settlementCentre SettlementCentreEnum (0..1) <"Optional settlement centre as an enumerated list: Euroclear, Clearstream.">
 	[deprecated]
-	settlementParty Party(0..*) <"The parties involved in the settlement process including settlement agents, clearing firm and depository organizations">
-	settlementPartyRole PartyRole(0..*) <"The role of parties involved in the settlement process including settlement agents, clearing firm and depository organizations">
+	settlementParty Party(0..*) <"Reference to the parties involved in the settlement process including settlement agents, clearing firm and depository organizations">
+		[metadata reference]
+	settlementPartyRole PartyRole(0..*) <"Reference to the roles of parties involved in the settlement process including settlement agents, clearing firm and depository organizations">
+		[metadata reference]
 	settlementProvision SettlementProvision (0..1) <"Optionally defines the parameters that regulate a settlement.">
 	standardSettlementStyle StandardSettlementStyleEnum (0..1) <"Settlement Style.">
 

--- a/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
@@ -376,7 +376,7 @@ type SettlementBase: <"A base class to be extended by the SettlementTerms class.
 	settlementCentre SettlementCentreEnum (0..1) <"Optional settlement centre as an enumerated list: Euroclear, Clearstream.">
 	[deprecated]
 	settlementParty Party(0..*) <"The parties involved in the settlement process including settlement agents, clearing firm and depository organizations">
-	settlementParty PartyRole(0..*) <"The role of parties involved in the settlement process including settlement agents, clearing firm and depository organizations">
+	settlementPartyRole PartyRole(0..*) <"The role of parties involved in the settlement process including settlement agents, clearing firm and depository organizations">
 	settlementProvision SettlementProvision (0..1) <"Optionally defines the parameters that regulate a settlement.">
 	standardSettlementStyle StandardSettlementStyleEnum (0..1) <"Settlement Style.">
 

--- a/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
@@ -374,6 +374,9 @@ type SettlementBase: <"A base class to be extended by the SettlementTerms class.
 		    provision "As defined in GMRA paragraph 2(k)/ paragraph 7(a) All the payments made in respect of the Purchase Price or the Repurchase Price of any Transaction shall be made in the currency of the Purchase Price (the Contractual Currency) save as provided in paragraph 10(d)(ii). Notwithstanding the foregoing, the payee of any money may, at its option, accept tender thereof in any other currency, provided, however, that, to the extent permitted by applicable law, the obligation of the payer to pay such money will be discharged only to the extent of the amount of the Contractual Currency that such payee may, consistent with normal banking procedures, purchase with such other currency (after deduction of any premium and costs of exchange) for delivery within the customary delivery period for spot transactions in respect of the relevant currency."]
 	settlementDate SettlementDate (0..1) <"The date on which the settlement amount will be paid, subject to adjustment in accordance with any applicable business day convention. This component would not be present for a mandatory early termination provision where the cash settlement payment date is the mandatory early termination date.">
 	settlementCentre SettlementCentreEnum (0..1) <"Optional settlement centre as an enumerated list: Euroclear, Clearstream.">
+	[deprecated]
+	settlementParty Party(0..*) <"The parties involved in the settlement process including settlement agents, clearing firm and depository organizations">
+	settlementParty PartyRole(0..*) <"The role of parties involved in the settlement process including settlement agents, clearing firm and depository organizations">
 	settlementProvision SettlementProvision (0..1) <"Optionally defines the parameters that regulate a settlement.">
 	standardSettlementStyle StandardSettlementStyleEnum (0..1) <"Settlement Style.">
 


### PR DESCRIPTION
This model change will deprecate settlementcenterenum and add settlement party and party role. Reference, [2213](https://github.com/finos/common-domain-model/issues/2213).