### PR TITLE
Fix codefresh bug and update expectations

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,3 +1,3 @@
 # *Infrastructure - Build Pipeline Bug Fix*
 
-This release fixes the automated build and release pipeline to ensure unit test failures are correctly reported.  The issue was introduced as part of the recent 4.0.0 release.
+This release fixes the automated build and release pipeline to ensure unit test failures are correctly reported.  The issue was introduced as part of the recent 4.0.0 release.  For further information see GitHub issue https://github.com/finos/common-domain-model/issues/2252.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,5 @@
-# *Product Model - Forward Payout*
+# *Infrastructure - Build Pipeline Bug Fix*
 
-This release updates the `ForwardPayout` to extend `PayoutBase` to make it consistent with all other payouts.
+This release fixes the automated build and release pipeline to ensure unit test failures are correctly reported.  The issue was introduced as part of the recent 4.0.0 release.
 
-The `settlementTerms` attribute has been removed from `ForwardPayout` as it is already an attribute of `PayoutBase`.
-
-_Review Directions_
-
-In the CDM Portal, select the Textual Browser and inspect each of the changes identified above.
-
-This release does not have any functional impact on mapping expectations:
-
-- In serialised JSON CDM samples, the attribute ordering has changed due to the repositioning of the `settlementTerms` component, however this has no functional impact on the model.
-- For FpML FX samples, the number of validation failures has increased by 1 because `PayoutBase->payerReceiver` is mandatory but is not populated for the existing samples.  The mapping of FX samples will be reviewed in a future release.
+This release contains no changes to the model.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,3 @@
 # *Infrastructure - Build Pipeline Bug Fix*
 
 This release fixes the automated build and release pipeline to ensure unit test failures are correctly reported.  The issue was introduced as part of the recent 4.0.0 release.
-

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,4 +2,3 @@
 
 This release fixes the automated build and release pipeline to ensure unit test failures are correctly reported.  The issue was introduced as part of the recent 4.0.0 release.
 
-This release contains no changes to the model.

--- a/codefresh.yml
+++ b/codefresh.yml
@@ -243,8 +243,7 @@ steps:
           - master
       condition:
         any:
-          BuildSnapshotFailed: steps.BuildSnapshot.result == 'error'
-          buildReleaseFailed: steps.BuildRelease.result == 'error'
+          mvnBuildFailed: steps.Build.result == 'error'
           buildDamlFailed: steps.BuildDaml.result == 'error'
           buildScalaFailed: steps.BuildScala.result == 'error'
           buildCSharp8Failed: steps.BuildCSharp8.result == 'error'
@@ -276,8 +275,7 @@ steps:
     when:
       condition:
         any:
-          normalBuildFailure: steps.BuildSnapshot.result == 'failure'
-          releaseBuildFailure: steps.BuildRelease.result == 'failure'
+          mvnBuildFailure: steps.Build.result == 'failure'
           damlBuildFailure: steps.BuildDaml.result == 'failure'
           scalaBuildFailure: steps.BuildScala.result == 'failure'
           cSharp8BuildFailure: steps.BuildCSharp8.result == 'failure'
@@ -301,7 +299,7 @@ steps:
     when:
       condition:
         all:
-          buildPassed: steps.BuildRelease.result == 'success'
+          buildPassed: steps.Build.result == 'success'
           isRelease: "${{TAG_REPO}}"
     commands:
       - echo This is a release build, tag repos with release name [${{RELEASE_NAME}}]
@@ -319,7 +317,7 @@ steps:
           - master
       condition:
         all:
-          buildPassed: steps.BuildSnapshot.result == 'success'
+          buildPassed: steps.Build.result == 'success'
           variableDefined: "${{TAG_REPO}} == false"
           skipNextBuild: "${{SKIP_NEXT_BUILD}} == false"
     commands:

--- a/rosetta-source/src/main/resources/cdm-sample-files/functions/business-event/contract-formation/contract-formation-fx-forward-func-input.json
+++ b/rosetta-source/src/main/resources/cdm-sample-files/functions/business-event/contract-formation/contract-formation-fx-forward-func-input.json
@@ -67,9 +67,6 @@
                 "economicTerms" : {
                   "payout" : {
                     "forwardPayout" : [ {
-                      "meta" : {
-                        "globalKey" : "90c7297"
-                      },
                       "settlementTerms" : {
                         "meta" : {
                           "globalKey" : "3e8b15"
@@ -80,6 +77,9 @@
                           },
                           "valueDate" : "2001-12-21"
                         }
+                      },
+                      "meta" : {
+                        "globalKey" : "90c7297"
                       },
                       "underlier" : {
                         "foreignExchange" : {

--- a/rosetta-source/src/main/resources/cdm-sample-files/functions/business-event/execution/execution-fx-forward-func-input.json
+++ b/rosetta-source/src/main/resources/cdm-sample-files/functions/business-event/execution/execution-fx-forward-func-input.json
@@ -167,9 +167,6 @@
             "economicTerms" : {
               "payout" : {
                 "forwardPayout" : [ {
-                  "meta" : {
-                    "globalKey" : "90c7297"
-                  },
                   "settlementTerms" : {
                     "meta" : {
                       "globalKey" : "3e8b15"
@@ -180,6 +177,9 @@
                       },
                       "valueDate" : "2001-12-21"
                     }
+                  },
+                  "meta" : {
+                    "globalKey" : "90c7297"
                   },
                   "underlier" : {
                     "foreignExchange" : {


### PR DESCRIPTION
Due to a Codefresh build script bug some test failures from the previous PR (https://github.com/finos/common-domain-model/pull/2245) were not picked up.  This PR fixes the Codefresh build script and updated the expectations for the failed test. 