### PR TITLE
Re-org package names in the test module

### DIFF
--- a/tests/src/test/java/com/regnosys/functions/FunctionTest.java
+++ b/tests/src/test/java/com/regnosys/functions/FunctionTest.java
@@ -1,4 +1,4 @@
-package com.regnosys.granite.ingestor.functions;
+package com.regnosys.functions;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;

--- a/tests/src/test/java/com/regnosys/ingest/IngestionEnvUtil.java
+++ b/tests/src/test/java/com/regnosys/ingest/IngestionEnvUtil.java
@@ -1,4 +1,4 @@
-package org.isda.cdm.util;
+package com.regnosys.ingest;
 
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionFactory;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionService;

--- a/tests/src/test/java/com/regnosys/ingest/cme/CMEClearedConfirmTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/cme/CMEClearedConfirmTest.java
@@ -1,4 +1,4 @@
-package com.regnosys.granite.ingestor.cme;
+package com.regnosys.ingest.cme;
 
 import cdm.event.workflow.WorkflowStep;
 import com.google.common.collect.ImmutableList;

--- a/tests/src/test/java/com/regnosys/ingest/cme/CMESubmissionTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/cme/CMESubmissionTest.java
@@ -1,6 +1,6 @@
-package com.regnosys.granite.ingestor.ore;
+package com.regnosys.ingest.cme;
 
-import cdm.event.common.TradeState;
+import cdm.event.workflow.WorkflowStep;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTest;
@@ -14,12 +14,12 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.net.URL;
 import java.util.stream.Stream;
 
-class OreTradeTest extends IngestionTest<TradeState>{
+class CMESubmissionTest extends IngestionTest<WorkflowStep>{
 
-	private static final String ORE_1_0_39_FILES_DIR = "cdm-sample-files/ore-1-0-39/";
+	private static final String CME_SUBMISSION_1_17_FILES_DIR = "cdm-sample-files/cme-submission-irs-1-0/";
 
 	private static ImmutableList<URL> EXPECTATION_FILES = ImmutableList.<URL>builder()
-			.add(Resources.getResource(ORE_1_0_39_FILES_DIR + "expectations.json"))
+			.add(Resources.getResource(CME_SUBMISSION_1_17_FILES_DIR + "expectations.json"))
 			.build();
 	
 	private static IngestionService ingestionService;
@@ -28,12 +28,12 @@ class OreTradeTest extends IngestionTest<TradeState>{
 	static void setup() {
 		CdmRuntimeModule runtimeModule = new CdmRuntimeModule();
 		initialiseIngestionFactory(runtimeModule, IngestionTestUtil.getPostProcessors(runtimeModule));
-		ingestionService = IngestionFactory.getInstance().getOre1039();
+		ingestionService = IngestionFactory.getInstance().getCmeSubmissionIrs1();
 	}
 	
 	@Override
-	protected Class<TradeState> getClazz() {
-		return TradeState.class;
+	protected Class<WorkflowStep> getClazz() {
+		return WorkflowStep.class;
 	}
 
 	@Override

--- a/tests/src/test/java/com/regnosys/ingest/dtcc/DtccIngestion11ServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/dtcc/DtccIngestion11ServiceTest.java
@@ -1,17 +1,14 @@
-package com.regnosys.granite.ingestor.dtcc;
+package com.regnosys.ingest.dtcc;
 
 import cdm.event.workflow.WorkflowStep;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
-import com.regnosys.ingest.test.framework.ingestor.IngestionReport;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTest;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTestUtil;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionFactory;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionService;
 import com.regnosys.ingest.test.framework.ingestor.synonym.MappingReport;
 import com.regnosys.ingest.test.framework.ingestor.synonym.MappingResult;
-import com.regnosys.ingest.test.framework.ingestor.testing.Expectation;
 import org.finos.cdm.CdmRuntimeModule;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
@@ -22,29 +19,24 @@ import java.net.URL;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-class DtccIngestion9ServiceTest extends IngestionTest<WorkflowStep> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DtccIngestion9ServiceTest.class);
+class DtccIngestion11ServiceTest  extends IngestionTest<WorkflowStep> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DtccIngestion11ServiceTest.class);
 
-	private static final String DTCC_9_0_FILES_DIR = "cdm-sample-files/dtcc-9-0/";
+	private static final String DTCC_11_0_FILES_DIR = "cdm-sample-files/dtcc-11-0/";
 
 	private static ImmutableList<URL> EXPECTATION_FILES = ImmutableList.<URL>builder()
-			.add(Resources.getResource(DTCC_9_0_FILES_DIR + "expectations.json"))
+			.add(Resources.getResource(DTCC_11_0_FILES_DIR + "expectations.json"))
 			.build();
 
-	private static IngestionService dtcc9IngestionService;
+	private static IngestionService dtcc11IngestionService;
 
 	@BeforeAll
 	static void setup() {
 		CdmRuntimeModule runtimeModule = new CdmRuntimeModule();
 		initialiseIngestionFactory(runtimeModule, IngestionTestUtil.getPostProcessors(runtimeModule));
-		dtcc9IngestionService = IngestionFactory.getInstance().getDtcc9();
+		dtcc11IngestionService = IngestionFactory.getInstance().getDtcc11();
 	}
-
-	@Override
-	protected void assertExpectations(Expectation expectation, IngestionReport<WorkflowStep> ingested) throws JsonProcessingException {
-
-	}
-
+	
 	@Override
 	protected Class<WorkflowStep> getClazz() {
 		return WorkflowStep.class;
@@ -52,7 +44,7 @@ class DtccIngestion9ServiceTest extends IngestionTest<WorkflowStep> {
 
 	@Override
 	protected IngestionService ingestionService() {
-		return dtcc9IngestionService;
+		return dtcc11IngestionService;
 	}
 
 	@SuppressWarnings("unused")//used by the junit parameterized test

--- a/tests/src/test/java/com/regnosys/ingest/dtcc/DtccIngestion9ServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/dtcc/DtccIngestion9ServiceTest.java
@@ -1,14 +1,17 @@
-package com.regnosys.granite.ingestor.dtcc;
+package com.regnosys.ingest.dtcc;
 
 import cdm.event.workflow.WorkflowStep;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
+import com.regnosys.ingest.test.framework.ingestor.IngestionReport;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTest;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTestUtil;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionFactory;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionService;
 import com.regnosys.ingest.test.framework.ingestor.synonym.MappingReport;
 import com.regnosys.ingest.test.framework.ingestor.synonym.MappingResult;
+import com.regnosys.ingest.test.framework.ingestor.testing.Expectation;
 import org.finos.cdm.CdmRuntimeModule;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
@@ -19,24 +22,29 @@ import java.net.URL;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-class DtccIngestion11ServiceTest  extends IngestionTest<WorkflowStep> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(DtccIngestion11ServiceTest.class);
+class DtccIngestion9ServiceTest extends IngestionTest<WorkflowStep> {
+    private static final Logger LOGGER = LoggerFactory.getLogger(DtccIngestion9ServiceTest.class);
 
-	private static final String DTCC_11_0_FILES_DIR = "cdm-sample-files/dtcc-11-0/";
+	private static final String DTCC_9_0_FILES_DIR = "cdm-sample-files/dtcc-9-0/";
 
 	private static ImmutableList<URL> EXPECTATION_FILES = ImmutableList.<URL>builder()
-			.add(Resources.getResource(DTCC_11_0_FILES_DIR + "expectations.json"))
+			.add(Resources.getResource(DTCC_9_0_FILES_DIR + "expectations.json"))
 			.build();
 
-	private static IngestionService dtcc11IngestionService;
+	private static IngestionService dtcc9IngestionService;
 
 	@BeforeAll
 	static void setup() {
 		CdmRuntimeModule runtimeModule = new CdmRuntimeModule();
 		initialiseIngestionFactory(runtimeModule, IngestionTestUtil.getPostProcessors(runtimeModule));
-		dtcc11IngestionService = IngestionFactory.getInstance().getDtcc11();
+		dtcc9IngestionService = IngestionFactory.getInstance().getDtcc9();
 	}
-	
+
+	@Override
+	protected void assertExpectations(Expectation expectation, IngestionReport<WorkflowStep> ingested) throws JsonProcessingException {
+
+	}
+
 	@Override
 	protected Class<WorkflowStep> getClazz() {
 		return WorkflowStep.class;
@@ -44,7 +52,7 @@ class DtccIngestion11ServiceTest  extends IngestionTest<WorkflowStep> {
 
 	@Override
 	protected IngestionService ingestionService() {
-		return dtcc11IngestionService;
+		return dtcc9IngestionService;
 	}
 
 	@SuppressWarnings("unused")//used by the junit parameterized test

--- a/tests/src/test/java/com/regnosys/ingest/fis/FisIngestionTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fis/FisIngestionTest.java
@@ -1,4 +1,4 @@
-package com.regnosys.granite.ingestor;
+package com.regnosys.ingest.fis;
 
 import cdm.event.workflow.WorkflowStep;
 import com.google.common.collect.ImmutableList;

--- a/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510IncompleteProcessesIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510IncompleteProcessesIngestionServiceTest.java
@@ -1,4 +1,4 @@
-package com.regnosys.granite.ingestor;
+package com.regnosys.ingest.fpml;
 
 import cdm.event.workflow.WorkflowStep;
 import com.google.common.collect.ImmutableList;
@@ -15,13 +15,13 @@ import java.util.stream.Stream;
 
 import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
 
-public class NativeCdmEventsIngestionServiceTest extends IngestionTest<WorkflowStep> {
+public class Fpml510IncompleteProcessesIngestionServiceTest extends IngestionTest<WorkflowStep> {
 
-	private static final String BASE_DIR = "cdm-sample-files/native-cdm-events/";
+	private static final String INCOMPLETE_PROCESSES = "cdm-sample-files/fpml-5-10/incomplete-processes/";
 
 	private static ImmutableList<URL> EXPECTATION_FILES = ImmutableList.<URL>builder()
-		.add(Resources.getResource(BASE_DIR + "expectations.json"))
-		.build();
+			.add(Resources.getResource(INCOMPLETE_PROCESSES + "expectations.json"))
+			.build();
 
 	private static IngestionService ingestionService;
 
@@ -31,7 +31,7 @@ public class NativeCdmEventsIngestionServiceTest extends IngestionTest<WorkflowS
 		initialiseIngestionFactory(runtimeModule, IngestionTestUtil.getPostProcessors(runtimeModule));
 		ingestionService = getFpml5ConfirmationToWorkflowStep();
 	}
-
+	
 	@Override
 	protected Class<WorkflowStep> getClazz() {
 		return WorkflowStep.class;

--- a/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510IncompleteProcessesIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510IncompleteProcessesIngestionServiceTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.net.URL;
 import java.util.stream.Stream;
 
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
+import static com.regnosys.ingest.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
 
 public class Fpml510IncompleteProcessesIngestionServiceTest extends IngestionTest<WorkflowStep> {
 

--- a/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510IncompleteProductIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510IncompleteProductIngestionServiceTest.java
@@ -1,4 +1,4 @@
-package com.regnosys.granite.ingestor.fpml;
+package com.regnosys.ingest.fpml;
 
 import cdm.event.common.TradeState;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTest;
@@ -12,9 +12,9 @@ import java.util.stream.Stream;
 
 import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
 
-public class Fpml510ProductIngestionServiceTest extends IngestionTest<TradeState> {
+public class Fpml510IncompleteProductIngestionServiceTest extends IngestionTest<TradeState> {
 
-	private static final String BASE_DIR = "cdm-sample-files/fpml-5-10/products/";
+	private static final String INCOMPLETE_BASE = "cdm-sample-files/fpml-5-10/incomplete-products/";
 
 	private static IngestionService ingestionService;
 
@@ -24,7 +24,7 @@ public class Fpml510ProductIngestionServiceTest extends IngestionTest<TradeState
 		initialiseIngestionFactory(runtimeModule, IngestionTestUtil.getPostProcessors(runtimeModule));
 		ingestionService = getFpml5ConfirmationToTradeState();
 	}
-	
+
 	@Override
 	protected Class<TradeState> getClazz() {
 		return TradeState.class;
@@ -37,6 +37,6 @@ public class Fpml510ProductIngestionServiceTest extends IngestionTest<TradeState
 
 	@SuppressWarnings("unused")//used by the junit parameterized test
 	private static Stream<Arguments> fpMLFiles() {
-		return readExpectationsFromPath(BASE_DIR);
+		return readExpectationsFromPath(INCOMPLETE_BASE);
 	}
 }

--- a/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510IncompleteProductIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510IncompleteProductIngestionServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.stream.Stream;
 
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
+import static com.regnosys.ingest.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
 
 public class Fpml510IncompleteProductIngestionServiceTest extends IngestionTest<TradeState> {
 

--- a/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510ProcessesIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510ProcessesIngestionServiceTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.net.URL;
 import java.util.stream.Stream;
 
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
+import static com.regnosys.ingest.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
 
 public class Fpml510ProcessesIngestionServiceTest extends IngestionTest<WorkflowStep> {
 

--- a/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510ProcessesIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510ProcessesIngestionServiceTest.java
@@ -1,11 +1,10 @@
-package com.regnosys.granite.ingestor.cme;
+package com.regnosys.ingest.fpml;
 
 import cdm.event.workflow.WorkflowStep;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTest;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTestUtil;
-import com.regnosys.ingest.test.framework.ingestor.service.IngestionFactory;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionService;
 import org.finos.cdm.CdmRuntimeModule;
 import org.junit.jupiter.api.BeforeAll;
@@ -14,21 +13,23 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.net.URL;
 import java.util.stream.Stream;
 
-class CMESubmissionTest extends IngestionTest<WorkflowStep>{
+import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
 
-	private static final String CME_SUBMISSION_1_17_FILES_DIR = "cdm-sample-files/cme-submission-irs-1-0/";
+public class Fpml510ProcessesIngestionServiceTest extends IngestionTest<WorkflowStep> {
+
+	private static final String PROCESSES = "cdm-sample-files/fpml-5-10/processes/";
 
 	private static ImmutableList<URL> EXPECTATION_FILES = ImmutableList.<URL>builder()
-			.add(Resources.getResource(CME_SUBMISSION_1_17_FILES_DIR + "expectations.json"))
+			.add(Resources.getResource(PROCESSES + "expectations.json"))
 			.build();
-	
+
 	private static IngestionService ingestionService;
 
 	@BeforeAll
 	static void setup() {
 		CdmRuntimeModule runtimeModule = new CdmRuntimeModule();
 		initialiseIngestionFactory(runtimeModule, IngestionTestUtil.getPostProcessors(runtimeModule));
-		ingestionService = IngestionFactory.getInstance().getCmeSubmissionIrs1();
+		ingestionService = getFpml5ConfirmationToWorkflowStep();
 	}
 	
 	@Override
@@ -45,5 +46,4 @@ class CMESubmissionTest extends IngestionTest<WorkflowStep>{
 	private static Stream<Arguments> fpMLFiles() {
 		return readExpectationsFrom(EXPECTATION_FILES);
 	}
-
 }

--- a/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510ProductIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510ProductIngestionServiceTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.Arguments;
 
 import java.util.stream.Stream;
 
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
+import static com.regnosys.ingest.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
 
 public class Fpml510ProductIngestionServiceTest extends IngestionTest<TradeState> {
 

--- a/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510ProductIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/Fpml510ProductIngestionServiceTest.java
@@ -1,8 +1,6 @@
-package com.regnosys.granite.ingestor.fpml;
+package com.regnosys.ingest.fpml;
 
-import cdm.event.workflow.WorkflowStep;
-import com.google.common.collect.ImmutableList;
-import com.google.common.io.Resources;
+import cdm.event.common.TradeState;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTest;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTestUtil;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionService;
@@ -10,18 +8,13 @@ import org.finos.cdm.CdmRuntimeModule;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
 
-import java.net.URL;
 import java.util.stream.Stream;
 
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
+import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
 
-public class Fpml510IncompleteProcessesIngestionServiceTest extends IngestionTest<WorkflowStep> {
+public class Fpml510ProductIngestionServiceTest extends IngestionTest<TradeState> {
 
-	private static final String INCOMPLETE_PROCESSES = "cdm-sample-files/fpml-5-10/incomplete-processes/";
-
-	private static ImmutableList<URL> EXPECTATION_FILES = ImmutableList.<URL>builder()
-			.add(Resources.getResource(INCOMPLETE_PROCESSES + "expectations.json"))
-			.build();
+	private static final String BASE_DIR = "cdm-sample-files/fpml-5-10/products/";
 
 	private static IngestionService ingestionService;
 
@@ -29,12 +22,12 @@ public class Fpml510IncompleteProcessesIngestionServiceTest extends IngestionTes
 	static void setup() {
 		CdmRuntimeModule runtimeModule = new CdmRuntimeModule();
 		initialiseIngestionFactory(runtimeModule, IngestionTestUtil.getPostProcessors(runtimeModule));
-		ingestionService = getFpml5ConfirmationToWorkflowStep();
+		ingestionService = getFpml5ConfirmationToTradeState();
 	}
 	
 	@Override
-	protected Class<WorkflowStep> getClazz() {
-		return WorkflowStep.class;
+	protected Class<TradeState> getClazz() {
+		return TradeState.class;
 	}
 
 	@Override
@@ -44,6 +37,6 @@ public class Fpml510IncompleteProcessesIngestionServiceTest extends IngestionTes
 
 	@SuppressWarnings("unused")//used by the junit parameterized test
 	private static Stream<Arguments> fpMLFiles() {
-		return readExpectationsFrom(EXPECTATION_FILES);
+		return readExpectationsFromPath(BASE_DIR);
 	}
 }

--- a/tests/src/test/java/com/regnosys/ingest/fpml/Fpml512ProductIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/Fpml512ProductIngestionServiceTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.net.URL;
 import java.util.stream.Stream;
 
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
+import static com.regnosys.ingest.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
 
 public class Fpml512ProductIngestionServiceTest extends IngestionTest<TradeState> {
 

--- a/tests/src/test/java/com/regnosys/ingest/fpml/Fpml512ProductIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/Fpml512ProductIngestionServiceTest.java
@@ -1,4 +1,4 @@
-package com.regnosys.granite.ingestor.fpml;
+package com.regnosys.ingest.fpml;
 
 import cdm.event.common.TradeState;
 import com.google.common.collect.ImmutableList;

--- a/tests/src/test/java/com/regnosys/ingest/fpml/InvalidProductTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/InvalidProductTest.java
@@ -1,4 +1,4 @@
-package com.regnosys.granite.ingestor.fpml;
+package com.regnosys.ingest.fpml;
 
 import cdm.event.common.TradeState;
 import com.google.common.collect.ImmutableList;

--- a/tests/src/test/java/com/regnosys/ingest/fpml/InvalidProductTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/InvalidProductTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.net.URL;
 import java.util.stream.Stream;
 
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
+import static com.regnosys.ingest.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
 
 class InvalidProductTest extends IngestionTest<TradeState> {
 

--- a/tests/src/test/java/com/regnosys/ingest/fpml/NativeCdmEventsIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/NativeCdmEventsIngestionServiceTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.net.URL;
 import java.util.stream.Stream;
 
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
+import static com.regnosys.ingest.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
 
 public class NativeCdmEventsIngestionServiceTest extends IngestionTest<WorkflowStep> {
 

--- a/tests/src/test/java/com/regnosys/ingest/fpml/NativeCdmEventsIngestionServiceTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/fpml/NativeCdmEventsIngestionServiceTest.java
@@ -1,6 +1,8 @@
-package com.regnosys.granite.ingestor.fpml;
+package com.regnosys.ingest.fpml;
 
-import cdm.event.common.TradeState;
+import cdm.event.workflow.WorkflowStep;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Resources;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTest;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTestUtil;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionService;
@@ -8,13 +10,18 @@ import org.finos.cdm.CdmRuntimeModule;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.provider.Arguments;
 
+import java.net.URL;
 import java.util.stream.Stream;
 
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
+import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
 
-public class Fpml510IncompleteProductIngestionServiceTest extends IngestionTest<TradeState> {
+public class NativeCdmEventsIngestionServiceTest extends IngestionTest<WorkflowStep> {
 
-	private static final String INCOMPLETE_BASE = "cdm-sample-files/fpml-5-10/incomplete-products/";
+	private static final String BASE_DIR = "cdm-sample-files/native-cdm-events/";
+
+	private static ImmutableList<URL> EXPECTATION_FILES = ImmutableList.<URL>builder()
+		.add(Resources.getResource(BASE_DIR + "expectations.json"))
+		.build();
 
 	private static IngestionService ingestionService;
 
@@ -22,12 +29,12 @@ public class Fpml510IncompleteProductIngestionServiceTest extends IngestionTest<
 	static void setup() {
 		CdmRuntimeModule runtimeModule = new CdmRuntimeModule();
 		initialiseIngestionFactory(runtimeModule, IngestionTestUtil.getPostProcessors(runtimeModule));
-		ingestionService = getFpml5ConfirmationToTradeState();
+		ingestionService = getFpml5ConfirmationToWorkflowStep();
 	}
 
 	@Override
-	protected Class<TradeState> getClazz() {
-		return TradeState.class;
+	protected Class<WorkflowStep> getClazz() {
+		return WorkflowStep.class;
 	}
 
 	@Override
@@ -37,6 +44,6 @@ public class Fpml510IncompleteProductIngestionServiceTest extends IngestionTest<
 
 	@SuppressWarnings("unused")//used by the junit parameterized test
 	private static Stream<Arguments> fpMLFiles() {
-		return readExpectationsFromPath(INCOMPLETE_BASE);
+		return readExpectationsFrom(EXPECTATION_FILES);
 	}
 }

--- a/tests/src/test/java/com/regnosys/ingest/ore/OreTradeTest.java
+++ b/tests/src/test/java/com/regnosys/ingest/ore/OreTradeTest.java
@@ -1,10 +1,11 @@
-package com.regnosys.granite.ingestor.fpml;
+package com.regnosys.ingest.ore;
 
-import cdm.event.workflow.WorkflowStep;
+import cdm.event.common.TradeState;
 import com.google.common.collect.ImmutableList;
 import com.google.common.io.Resources;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTest;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTestUtil;
+import com.regnosys.ingest.test.framework.ingestor.service.IngestionFactory;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionService;
 import org.finos.cdm.CdmRuntimeModule;
 import org.junit.jupiter.api.BeforeAll;
@@ -13,28 +14,26 @@ import org.junit.jupiter.params.provider.Arguments;
 import java.net.URL;
 import java.util.stream.Stream;
 
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToWorkflowStep;
+class OreTradeTest extends IngestionTest<TradeState>{
 
-public class Fpml510ProcessesIngestionServiceTest extends IngestionTest<WorkflowStep> {
-
-	private static final String PROCESSES = "cdm-sample-files/fpml-5-10/processes/";
+	private static final String ORE_1_0_39_FILES_DIR = "cdm-sample-files/ore-1-0-39/";
 
 	private static ImmutableList<URL> EXPECTATION_FILES = ImmutableList.<URL>builder()
-			.add(Resources.getResource(PROCESSES + "expectations.json"))
+			.add(Resources.getResource(ORE_1_0_39_FILES_DIR + "expectations.json"))
 			.build();
-
+	
 	private static IngestionService ingestionService;
 
 	@BeforeAll
 	static void setup() {
 		CdmRuntimeModule runtimeModule = new CdmRuntimeModule();
 		initialiseIngestionFactory(runtimeModule, IngestionTestUtil.getPostProcessors(runtimeModule));
-		ingestionService = getFpml5ConfirmationToWorkflowStep();
+		ingestionService = IngestionFactory.getInstance().getOre1039();
 	}
 	
 	@Override
-	protected Class<WorkflowStep> getClazz() {
-		return WorkflowStep.class;
+	protected Class<TradeState> getClazz() {
+		return TradeState.class;
 	}
 
 	@Override
@@ -46,4 +45,5 @@ public class Fpml510ProcessesIngestionServiceTest extends IngestionTest<Workflow
 	private static Stream<Arguments> fpMLFiles() {
 		return readExpectationsFrom(EXPECTATION_FILES);
 	}
+
 }

--- a/tests/src/test/java/com/regnosys/schemaimport/SchemeImporterTest.java
+++ b/tests/src/test/java/com/regnosys/schemaimport/SchemeImporterTest.java
@@ -1,4 +1,4 @@
-package com.regnosys.granite.ingestor.schemaimport;
+package com.regnosys.schemaimport;
 
 import com.regnosys.testing.schemaimport.SchemeImportInjectorProvider;
 import com.regnosys.testing.schemaimport.SchemeImporterTestHelper;

--- a/tests/src/test/java/com/regnosys/template/GenerateTemplateExampleJsonWriter.java
+++ b/tests/src/test/java/com/regnosys/template/GenerateTemplateExampleJsonWriter.java
@@ -1,4 +1,4 @@
-package com.regnosys.granite.ingestor.template;
+package com.regnosys.template;
 
 import cdm.base.staticdata.asset.common.Security;
 import cdm.event.common.TradeState;
@@ -13,7 +13,6 @@ import com.google.inject.Module;
 import com.google.inject.util.Modules;
 import com.regnosys.ingest.test.framework.ingestor.IngestionReport;
 import com.regnosys.ingest.test.framework.ingestor.IngestionTestUtil;
-import com.regnosys.ingest.test.framework.ingestor.postprocess.pathduplicates.PathCollector;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionFactory;
 import com.regnosys.ingest.test.framework.ingestor.service.IngestionService;
 import com.regnosys.rosetta.RosettaRuntimeModule;
@@ -40,8 +39,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-
-import static org.isda.cdm.util.IngestionEnvUtil.getFpml5ConfirmationToTradeState;
 
 /**
  * Generates sample json for com.regnosys.cdm.example.template.TemplateExample.

--- a/tests/src/test/java/com/regnosys/util/UnusedModelElementFinderTest.java
+++ b/tests/src/test/java/com/regnosys/util/UnusedModelElementFinderTest.java
@@ -1,4 +1,4 @@
-package org.isda.cdm.util;
+package com.regnosys.util;
 
 import com.google.common.collect.ImmutableList;
 import com.regnosys.rosetta.common.util.ClassPathUtils;


### PR DESCRIPTION
Consolidate ingest packages
* com.regnosys.granite.ingestor -> com.regnosys.ingest
* org.isda.cdm.util -> com.regnosys.ingest

Move non-ingest tests out of ingest package
* com.regnosys.granite.ingestor.functions -> com.regnosys.functions
* com.regnosys.granite.ingestor.schemaimport -> com.regnosys.schemaimport
* com.regnosys.granite.ingestor.template -> com.regnosys.template