### PR TITLE
Netlify does not trigger new deployments on simple changes

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF . ../{src,website}/"


### PR DESCRIPTION
Found the infamous `"No changes detected in base directory. Returning early from build."` log message on the Netlify logs for this PR - https://github.com/finos/common-domain-model/pull/2321

I followed instructions on https://answers.netlify.com/t/builds-cancelled-for-a-new-branch-due-to-no-content-change/17169/2 and also took inspiration from FDC3 setup, see https://github.com/finos/FDC3/blob/master/netlify.toml

cc @dshoneisda 