### PR TITLE
TASK-6517 Fix 6 Securities Lending samples to supported updated Payout model (withdrawn)

### DIFF
--- a/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/allocation/allocation-sec-lending-func-input.json
+++ b/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/allocation/allocation-sec-lending-func-input.json
@@ -419,102 +419,6 @@
                         "globalKey" : "98fd77d9"
                       }
                     } ],
-                    "assetPayout" : [ {
-                      "payerReceiver" : {
-                        "payer" : "Party1",
-                        "receiver" : "Party2"
-                      },
-                      "assetLeg" : [ {
-                        "settlementDate" : {
-                          "adjustableDate" : {
-                            "dateAdjustments" : {
-                              "businessDayConvention" : "NONE",
-                              "meta" : {
-                                "globalKey" : "24a738"
-                              }
-                            },
-                            "adjustedDate" : {
-                              "value" : "2020-09-22",
-                              "meta" : {
-                                "globalKey" : "3f2256"
-                              }
-                            },
-                            "meta" : {
-                              "globalKey" : "24a738"
-                            }
-                          },
-                          "meta" : {
-                            "globalKey" : "24a738"
-                          }
-                        },
-                        "deliveryMethod" : "DeliveryVersusPayment"
-                      }, {
-                        "settlementDate" : {
-                          "adjustableDate" : {
-                            "dateAdjustments" : {
-                              "businessDayConvention" : "NONE",
-                              "meta" : {
-                                "globalKey" : "24a738"
-                              }
-                            },
-                            "adjustedDate" : {
-                              "value" : "2020-10-22",
-                              "meta" : {
-                                "globalKey" : "3f2296"
-                              }
-                            },
-                            "meta" : {
-                              "globalKey" : "24a738"
-                            }
-                          },
-                          "meta" : {
-                            "globalKey" : "24a738"
-                          }
-                        },
-                        "deliveryMethod" : "DeliveryVersusPayment"
-                      } ],
-                      "securityInformation" : {
-                        "security" : {
-                          "productIdentifier" : [ {
-                            "value" : {
-                              "identifier" : {
-                                "value" : "ST001"
-                              },
-                              "source" : "SEDOL",
-                              "meta" : {
-                                "globalKey" : "a4ff65ff"
-                              }
-                            }
-                          } ],
-                          "securityType" : "Equity"
-                        },
-                        "meta" : {
-                          "globalKey" : "7548eca6"
-                        }
-                      },
-                      "durationType" : {
-                        "durationType" : "Term"
-                      },
-                      "minimumFee" : {
-                        "value" : 0,
-                        "unit" : {
-                          "currency" : {
-                            "value" : "USD"
-                          }
-                        },
-                        "meta" : {
-                          "globalKey" : "171b36"
-                        }
-                      },
-                      "dividendTerms" : {
-                        "manufacturedIncomeRequirement" : {
-                          "totalRatio" : 1
-                        }
-                      },
-                      "meta" : {
-                        "globalKey" : "3b19750e"
-                      }
-                    } ],
                     "meta" : {
                       "globalKey" : "43b3b6a7"
                     }
@@ -534,7 +438,120 @@
                           "globalKey" : "168480"
                         }
                       } ]
-                    }
+                    } ,
+                    "collateralPortfolio": [
+                      {
+                        "value" : {
+                      "collateralPosition": [
+                      {
+                        "product": {
+                          "contractualProduct": {
+                            "economicTerms": {
+                              "payout": {                                
+                                "assetPayout" : [ {
+                                  "payerReceiver" : {
+                                    "payer" : "Party1",
+                                    "receiver" : "Party2"
+                                  },
+                                  "assetLeg" : [ {
+                                    "settlementDate" : {
+                                      "adjustableDate" : {
+                                        "dateAdjustments" : {
+                                          "businessDayConvention" : "NONE",
+                                          "meta" : {
+                                            "globalKey" : "24a738"
+                                          }
+                                        },
+                                        "adjustedDate" : {
+                                          "value" : "2020-09-22",
+                                          "meta" : {
+                                            "globalKey" : "3f2256"
+                                          }
+                                        },
+                                        "meta" : {
+                                          "globalKey" : "24a738"
+                                        }
+                                      },
+                                      "meta" : {
+                                        "globalKey" : "24a738"
+                                      }
+                                    },
+                                    "deliveryMethod" : "DeliveryVersusPayment"
+                                  }, {
+                                    "settlementDate" : {
+                                      "adjustableDate" : {
+                                        "dateAdjustments" : {
+                                          "businessDayConvention" : "NONE",
+                                          "meta" : {
+                                            "globalKey" : "24a738"
+                                          }
+                                        },
+                                        "adjustedDate" : {
+                                          "value" : "2020-10-22",
+                                          "meta" : {
+                                            "globalKey" : "3f2296"
+                                          }
+                                        },
+                                        "meta" : {
+                                          "globalKey" : "24a738"
+                                        }
+                                      },
+                                      "meta" : {
+                                        "globalKey" : "24a738"
+                                      }
+                                    },
+                                    "deliveryMethod" : "DeliveryVersusPayment"
+                                  } ],
+                                  "securityInformation" : {
+                                    "security" : {
+                                      "productIdentifier" : [ {
+                                        "value" : {
+                                          "identifier" : {
+                                            "value" : "ST001"
+                                          },
+                                          "source" : "SEDOL",
+                                          "meta" : {
+                                            "globalKey" : "a4ff65ff"
+                                          }
+                                        }
+                                      } ],
+                                      "securityType" : "Equity"
+                                    },
+                                    "meta" : {
+                                      "globalKey" : "7548eca6"
+                                    }
+                                  },
+                                  "durationType" : {
+                                    "durationType" : "Term"
+                                  },
+                                  "minimumFee" : {
+                                    "value" : 0,
+                                    "unit" : {
+                                      "currency" : {
+                                        "value" : "USD"
+                                      }
+                                    },
+                                    "meta" : {
+                                      "globalKey" : "171b36"
+                                    }
+                                  },
+                                  "dividendTerms" : {
+                                    "manufacturedIncomeRequirement" : {
+                                      "totalRatio" : 1
+                                    }
+                                  },
+                                  "meta" : {
+                                    "globalKey" : "3b19750e"
+                                  }
+                                } ]                                  
+                              }
+                            }
+                          }
+                        }
+                      } ]
+                        }  
+                      } ]
+                  }
                   }
                 },
                 "meta" : {

--- a/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/create-security-lending-invoice-func-input.json
+++ b/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/create-security-lending-invoice-func-input.json
@@ -261,12 +261,13 @@
                       } ,
                       "collateralPortfolio": [
                         {
+                          "value" : {
                         "collateralPosition": [
                         {
                           "product": {
                             "contractualProduct": {
                               "economicTerms": {
-                                "payout": [ {
+                                "payout": {
                                   "assetPayout":
                                   [
                                     {
@@ -374,11 +375,10 @@
                                   "meta": {
                                     "globalKey": "162450"
                                   }}
-                                ]
                               }
                             }
                           }
-                        } ]
+                        } ] }
                       } ]
                     }
                   },
@@ -1844,7 +1844,6 @@
           "meta": {
             "globalKey": "3faa2536"
           }
-        }
       },
       "observation": [
         {

--- a/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/create-security-lending-invoice-func-input.json
+++ b/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/create-security-lending-invoice-func-input.json
@@ -238,114 +238,7 @@
                             "globalKey": "98fd77d9"
                           }
                         }
-                      ],
-                      "assetPayout": [
-                        {
-                          "payerReceiver": {
-                            "payer": "Party1",
-                            "receiver": "Party2"
-                          },
-                          "assetLeg": [
-                            {
-                              "settlementDate": {
-                                "adjustableDate": {
-                                  "dateAdjustments": {
-                                    "businessDayConvention": "NONE",
-                                    "meta": {
-                                      "globalKey": "24a738"
-                                    }
-                                  },
-                                  "adjustedDate": {
-                                    "value": "2020-09-22",
-                                    "meta": {
-                                      "globalKey": "3f2256"
-                                    }
-                                  },
-                                  "meta": {
-                                    "globalKey": "24a738"
-                                  }
-                                },
-                                "meta": {
-                                  "globalKey": "24a738"
-                                }
-                              },
-                              "deliveryMethod": "DeliveryVersusPayment"
-                            },
-                            {
-                              "settlementDate": {
-                                "adjustableDate": {
-                                  "dateAdjustments": {
-                                    "businessDayConvention": "NONE",
-                                    "meta": {
-                                      "globalKey": "24a738"
-                                    }
-                                  },
-                                  "adjustedDate": {
-                                    "value": "2020-10-22",
-                                    "meta": {
-                                      "globalKey": "3f2296"
-                                    }
-                                  },
-                                  "meta": {
-                                    "globalKey": "24a738"
-                                  }
-                                },
-                                "meta": {
-                                  "globalKey": "24a738"
-                                }
-                              },
-                              "deliveryMethod": "DeliveryVersusPayment"
-                            }
-                          ],
-                          "securityInformation": {
-                            "security": {
-                              "productIdentifier": [
-                                {
-                                  "value": {
-                                    "identifier": {
-                                      "value": "ST001"
-                                    },
-                                    "source": "SEDOL",
-                                    "meta": {
-                                      "globalKey": "a4ff65ff"
-                                    }
-                                  }
-                                }
-                              ],
-                              "securityType": "Equity"
-                            },
-                            "meta": {
-                              "globalKey": "7548eca6"
-                            }
-                          },
-                          "durationType": {
-                            "durationType": "Term"
-                          },
-                          "minimumFee": {
-                            "value": 0,
-                            "unit": {
-                              "currency": {
-                                "value": "USD"
-                              }
-                            },
-                            "meta": {
-                              "globalKey": "171b36"
-                            }
-                          },
-                          "dividendTerms": {
-                            "manufacturedIncomeRequirement": {
-                              "totalRatio": 1
-                            }
-                          },
-                          "meta": {
-                            "globalKey": "3b19750e"
-                          }
-                        }
-                      ],
-                      "meta": {
-                        "globalKey": "43b3b6a7"
-                      }
-                    },
+                      ] } ,
                     "collateral": {
                       "collateralProvisions": {
                         "collateralType": "Cash",
@@ -365,7 +258,128 @@
                             }
                           }
                         ]
-                      }
+                      } ,
+                      "collateralPortfolio": [
+                        {
+                        "collateralPosition": [
+                        {
+                          "product": {
+                            "contractualProduct": {
+                              "economicTerms": {
+                                "payout": [ {
+                                  "assetPayout":
+                                  [
+                                    {
+                                      "payerReceiver": {
+                                        "payer": "Party1",
+                                        "receiver": "Party2"
+                                      },
+                                      "assetLeg": [
+                                        {
+                                          "settlementDate": {
+                                            "adjustableDate": {
+                                              "dateAdjustments": {
+                                                "businessDayConvention": "NONE",
+                                                "meta": {
+                                                  "globalKey": "24a738"
+                                                }
+                                              },
+                                              "adjustedDate": {
+                                                "value": "2020-09-22",
+                                                "meta": {
+                                                  "globalKey": "3f2256"
+                                                }
+                                              },
+                                              "meta": {
+                                                "globalKey": "24a738"
+                                              }
+                                            },
+                                            "meta": {
+                                              "globalKey": "24a738"
+                                            }
+                                          },
+                                          "deliveryMethod": "DeliveryVersusPayment"
+                                        },
+                                        {
+                                          "settlementDate": {
+                                            "adjustableDate": {
+                                              "dateAdjustments": {
+                                                "businessDayConvention": "NONE",
+                                                "meta": {
+                                                  "globalKey": "24a738"
+                                                }
+                                              },
+                                              "adjustedDate": {
+                                                "value": "2020-10-22",
+                                                "meta": {
+                                                  "globalKey": "3f2296"
+                                                }
+                                              },
+                                              "meta": {
+                                                "globalKey": "24a738"
+                                              }
+                                            },
+                                            "meta": {
+                                              "globalKey": "24a738"
+                                            }
+                                          },
+                                          "deliveryMethod": "DeliveryVersusPayment"
+                                        }
+                                      ],
+                                      "securityInformation": {
+                                        "security": {
+                                          "productIdentifier": [
+                                            {
+                                              "value": {
+                                                "identifier": {
+                                                  "value": "ST001"
+                                                },
+                                                "source": "SEDOL",
+                                                "meta": {
+                                                  "globalKey": "a4ff65ff"
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "securityType": "Equity"
+                                        },
+                                        "meta": {
+                                          "globalKey": "7548eca6"
+                                        }
+                                      },
+                                      "durationType": {
+                                        "durationType": "Term"
+                                      },
+                                      "minimumFee": {
+                                        "value": 0,
+                                        "unit": {
+                                          "currency": {
+                                            "value": "USD"
+                                          }
+                                        },
+                                        "meta": {
+                                          "globalKey": "171b36"
+                                        }
+                                      },
+                                      "dividendTerms": {
+                                        "manufacturedIncomeRequirement": {
+                                          "totalRatio": 1
+                                        }
+                                      },
+                                      "meta": {
+                                        "globalKey": "3b19750e"
+                                      }
+                                    }
+                                  ] ,
+                                  "meta": {
+                                    "globalKey": "162450"
+                                  }}
+                                ]
+                              }
+                            }
+                          }
+                        } ]
+                      } ]
                     }
                   },
                   "meta": {
@@ -1272,113 +1286,7 @@
                             "globalKey": "98fd77d9"
                           }
                         }
-                      ],
-                      "assetPayout": [
-                        {
-                          "payerReceiver": {
-                            "payer": "Party1",
-                            "receiver": "Party2"
-                          },
-                          "assetLeg": [
-                            {
-                              "settlementDate": {
-                                "adjustableDate": {
-                                  "dateAdjustments": {
-                                    "businessDayConvention": "NONE",
-                                    "meta": {
-                                      "globalKey": "24a738"
-                                    }
-                                  },
-                                  "adjustedDate": {
-                                    "value": "2020-09-22",
-                                    "meta": {
-                                      "globalKey": "3f2256"
-                                    }
-                                  },
-                                  "meta": {
-                                    "globalKey": "24a738"
-                                  }
-                                },
-                                "meta": {
-                                  "globalKey": "24a738"
-                                }
-                              },
-                              "deliveryMethod": "DeliveryVersusPayment"
-                            },
-                            {
-                              "settlementDate": {
-                                "adjustableDate": {
-                                  "dateAdjustments": {
-                                    "businessDayConvention": "NONE",
-                                    "meta": {
-                                      "globalKey": "24a738"
-                                    }
-                                  },
-                                  "adjustedDate": {
-                                    "value": "2020-10-22",
-                                    "meta": {
-                                      "globalKey": "3f2296"
-                                    }
-                                  },
-                                  "meta": {
-                                    "globalKey": "24a738"
-                                  }
-                                },
-                                "meta": {
-                                  "globalKey": "24a738"
-                                }
-                              },
-                              "deliveryMethod": "DeliveryVersusPayment"
-                            }
-                          ],
-                          "securityInformation": {
-                            "security": {
-                              "productIdentifier": [
-                                {
-                                  "value": {
-                                    "identifier": {
-                                      "value": "ST001"
-                                    },
-                                    "source": "SEDOL",
-                                    "meta": {
-                                      "globalKey": "a4ff65ff"
-                                    }
-                                  }
-                                }
-                              ],
-                              "securityType": "Equity"
-                            },
-                            "meta": {
-                              "globalKey": "7548eca6"
-                            }
-                          },
-                          "durationType": {
-                            "durationType": "Term"
-                          },
-                          "minimumFee": {
-                            "value": 0,
-                            "unit": {
-                              "currency": {
-                                "value": "USD"
-                              }
-                            },
-                            "meta": {
-                              "globalKey": "171b36"
-                            }
-                          },
-                          "dividendTerms": {
-                            "manufacturedIncomeRequirement": {
-                              "totalRatio": 1
-                            }
-                          },
-                          "meta": {
-                            "globalKey": "3b19750e"
-                          }
-                        }
-                      ],
-                      "meta": {
-                        "globalKey": "43b3b6a7"
-                      }
+                      ]
                     },
                     "collateral": {
                       "collateralProvisions": {
@@ -1399,7 +1307,132 @@
                             }
                           }
                         ]
-                      }
+                      }  ,
+                      "collateralPortfolio": [
+                        {
+                        "collateralPosition": [
+                        {
+                          "product": {
+                            "contractualProduct": {
+                              "economicTerms": {
+                                "payout": [ {
+                                  "assetPayout": [
+                                    {
+                                      "payerReceiver": {
+                                        "payer": "Party1",
+                                        "receiver": "Party2"
+                                      },
+                                      "assetLeg": [
+                                        {
+                                          "settlementDate": {
+                                            "adjustableDate": {
+                                              "dateAdjustments": {
+                                                "businessDayConvention": "NONE",
+                                                "meta": {
+                                                  "globalKey": "24a738"
+                                                }
+                                              },
+                                              "adjustedDate": {
+                                                "value": "2020-09-22",
+                                                "meta": {
+                                                  "globalKey": "3f2256"
+                                                }
+                                              },
+                                              "meta": {
+                                                "globalKey": "24a738"
+                                              }
+                                            },
+                                            "meta": {
+                                              "globalKey": "24a738"
+                                            }
+                                          },
+                                          "deliveryMethod": "DeliveryVersusPayment"
+                                        },
+                                        {
+                                          "settlementDate": {
+                                            "adjustableDate": {
+                                              "dateAdjustments": {
+                                                "businessDayConvention": "NONE",
+                                                "meta": {
+                                                  "globalKey": "24a738"
+                                                }
+                                              },
+                                              "adjustedDate": {
+                                                "value": "2020-10-22",
+                                                "meta": {
+                                                  "globalKey": "3f2296"
+                                                }
+                                              },
+                                              "meta": {
+                                                "globalKey": "24a738"
+                                              }
+                                            },
+                                            "meta": {
+                                              "globalKey": "24a738"
+                                            }
+                                          },
+                                          "deliveryMethod": "DeliveryVersusPayment"
+                                        }
+                                      ],
+                                      "securityInformation": {
+                                        "security": {
+                                          "productIdentifier": [
+                                            {
+                                              "value": {
+                                                "identifier": {
+                                                  "value": "ST001"
+                                                },
+                                                "source": "SEDOL",
+                                                "meta": {
+                                                  "globalKey": "a4ff65ff"
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "securityType": "Equity"
+                                        },
+                                        "meta": {
+                                          "globalKey": "7548eca6"
+                                        }
+                                      },
+                                      "durationType": {
+                                        "durationType": "Term"
+                                      },
+                                      "minimumFee": {
+                                        "value": 0,
+                                        "unit": {
+                                          "currency": {
+                                            "value": "USD"
+                                          }
+                                        },
+                                        "meta": {
+                                          "globalKey": "171b36"
+                                        }
+                                      },
+                                      "dividendTerms": {
+                                        "manufacturedIncomeRequirement": {
+                                          "totalRatio": 1
+                                        }
+                                      },
+                                      "meta": {
+                                        "globalKey": "3b19750e"
+                                      }
+                                    }
+                                  ],
+                                  "meta": {
+                                    "globalKey": "43b3b6a7"
+                                  }
+            
+                                }
+                                  ]
+                                  }
+                              }
+                              }
+                            }
+                        ]
+                      } ]
+
+                    }
                     }
                   },
                   "meta": {

--- a/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/full-return-settlement-workflow-func-input.json
+++ b/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/full-return-settlement-workflow-func-input.json
@@ -195,113 +195,7 @@
                       "globalKey": "98fd77d9"
                     }
                   }
-                ],
-                "assetPayout": [
-                  {
-                    "payerReceiver": {
-                      "payer": "Party1",
-                      "receiver": "Party2"
-                    },
-                    "assetLeg": [
-                      {
-                        "settlementDate": {
-                          "adjustableDate": {
-                            "dateAdjustments": {
-                              "businessDayConvention": "NONE",
-                              "meta": {
-                                "globalKey": "24a738"
-                              }
-                            },
-                            "adjustedDate": {
-                              "value": "2020-09-22",
-                              "meta": {
-                                "globalKey": "3f2256"
-                              }
-                            },
-                            "meta": {
-                              "globalKey": "24a738"
-                            }
-                          },
-                          "meta": {
-                            "globalKey": "24a738"
-                          }
-                        },
-                        "deliveryMethod": "DeliveryVersusPayment"
-                      },
-                      {
-                        "settlementDate": {
-                          "adjustableDate": {
-                            "dateAdjustments": {
-                              "businessDayConvention": "NONE",
-                              "meta": {
-                                "globalKey": "24a738"
-                              }
-                            },
-                            "adjustedDate": {
-                              "value": "2020-10-22",
-                              "meta": {
-                                "globalKey": "3f2296"
-                              }
-                            },
-                            "meta": {
-                              "globalKey": "24a738"
-                            }
-                          },
-                          "meta": {
-                            "globalKey": "24a738"
-                          }
-                        },
-                        "deliveryMethod": "DeliveryVersusPayment"
-                      }
-                    ],
-                    "securityInformation": {
-                      "security": {
-                        "productIdentifier": [
-                          {
-                            "value": {
-                              "identifier": {
-                                "value": "ST001"
-                              },
-                              "source": "SEDOL",
-                              "meta": {
-                                "globalKey": "a4ff65ff"
-                              }
-                            }
-                          }
-                        ],
-                        "securityType": "Equity"
-                      },
-                      "meta": {
-                        "globalKey": "7548eca6"
-                      }
-                    },
-                    "durationType": {
-                      "durationType": "Term"
-                    },
-                    "minimumFee": {
-                      "value": 0,
-                      "unit": {
-                        "currency": {
-                          "value": "USD"
-                        }
-                      },
-                      "meta": {
-                        "globalKey": "171b36"
-                      }
-                    },
-                    "dividendTerms": {
-                      "manufacturedIncomeRequirement": {
-                        "totalRatio": 1
-                      }
-                    },
-                    "meta": {
-                      "globalKey": "3b19750e"
-                    }
-                  }
-                ],
-                "meta": {
-                  "globalKey": "43b3b6a7"
-                }
+                ]
               },
               "collateral": {
                 "collateralProvisions": {
@@ -322,7 +216,129 @@
                       }
                     }
                   ]
-                }
+                } ,
+                "collateralPortfolio": [
+                  {
+                    "value" : {
+                  "collateralPosition": [
+                  {
+                    "product": {
+                      "contractualProduct": {
+                        "economicTerms": {
+                          "payout": {
+                             "assetPayout": [
+                              {
+                                "payerReceiver": {
+                                  "payer": "Party1",
+                                  "receiver": "Party2"
+                                },
+                                "assetLeg": [
+                                  {
+                                    "settlementDate": {
+                                      "adjustableDate": {
+                                        "dateAdjustments": {
+                                          "businessDayConvention": "NONE",
+                                          "meta": {
+                                            "globalKey": "24a738"
+                                          }
+                                        },
+                                        "adjustedDate": {
+                                          "value": "2020-09-22",
+                                          "meta": {
+                                            "globalKey": "3f2256"
+                                          }
+                                        },
+                                        "meta": {
+                                          "globalKey": "24a738"
+                                        }
+                                      },
+                                      "meta": {
+                                        "globalKey": "24a738"
+                                      }
+                                    },
+                                    "deliveryMethod": "DeliveryVersusPayment"
+                                  },
+                                  {
+                                    "settlementDate": {
+                                      "adjustableDate": {
+                                        "dateAdjustments": {
+                                          "businessDayConvention": "NONE",
+                                          "meta": {
+                                            "globalKey": "24a738"
+                                          }
+                                        },
+                                        "adjustedDate": {
+                                          "value": "2020-10-22",
+                                          "meta": {
+                                            "globalKey": "3f2296"
+                                          }
+                                        },
+                                        "meta": {
+                                          "globalKey": "24a738"
+                                        }
+                                      },
+                                      "meta": {
+                                        "globalKey": "24a738"
+                                      }
+                                    },
+                                    "deliveryMethod": "DeliveryVersusPayment"
+                                  }
+                                ],
+                                "securityInformation": {
+                                  "security": {
+                                    "productIdentifier": [
+                                      {
+                                        "value": {
+                                          "identifier": {
+                                            "value": "ST001"
+                                          },
+                                          "source": "SEDOL",
+                                          "meta": {
+                                            "globalKey": "a4ff65ff"
+                                          }
+                                        }
+                                      }
+                                    ],
+                                    "securityType": "Equity"
+                                  },
+                                  "meta": {
+                                    "globalKey": "7548eca6"
+                                  }
+                                },
+                                "durationType": {
+                                  "durationType": "Term"
+                                },
+                                "minimumFee": {
+                                  "value": 0,
+                                  "unit": {
+                                    "currency": {
+                                      "value": "USD"
+                                    }
+                                  },
+                                  "meta": {
+                                    "globalKey": "171b36"
+                                  }
+                                },
+                                "dividendTerms": {
+                                  "manufacturedIncomeRequirement": {
+                                    "totalRatio": 1
+                                  }
+                                },
+                                "meta": {
+                                  "globalKey": "3b19750e"
+                                }
+                              }
+                            ],
+                            "meta": {
+                              "globalKey": "43b3b6a7"
+                            }                            
+                          }
+                        }
+                      }
+                    }
+                  } ]
+                    }
+                } ]
               }
             },
             "meta": {

--- a/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/new-settlement-workflow-func-input.json
+++ b/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/new-settlement-workflow-func-input.json
@@ -101,76 +101,93 @@
                 }
               }
             }
-          ],
-          "assetPayout": [
-            {
-              "payerReceiver": {
-                "payer": "Party1",
-                "receiver": "Party2"
-              },
-              "assetLeg": [
-                {
-                  "settlementDate": {
-                    "adjustableDate": {
-                      "dateAdjustments": {
-                        "businessDayConvention": "NONE"
-                      },
-                      "adjustedDate": {
-                        "value": "2020-09-22"
-                      }
-                    }
-                  },
-                  "deliveryMethod": "DeliveryVersusPayment"
-                },
-                {
-                  "settlementDate": {
-                    "adjustableDate": {
-                      "dateAdjustments": {
-                        "businessDayConvention": "NONE"
-                      },
-                      "adjustedDate": {
-                        "value": "2020-10-22"
-                      }
-                    }
-                  },
-                  "deliveryMethod": "DeliveryVersusPayment"
-                }
-              ],
-              "securityInformation": {
-                "security": {
-                  "productIdentifier": [
-                    {
-                      "value": {
-                        "identifier": {
-                          "value": "ST001"
-                        },
-                        "source": "SEDOL"
-                      }
-                    }
-                  ],
-                  "securityType": "Equity"
-                }
-              },
-              "durationType": {
-                "durationType": "Term"
-              },
-              "minimumFee": {
-                "value": 0,
-                "unit": {
-                  "currency": {
-                    "value": "USD"
-                  }
-                }
-              },
-              "dividendTerms": {
-                "manufacturedIncomeRequirement": {
-                  "totalRatio": 1
-                }
-              }
-            }
           ]
         },
         "collateral": {
+          "collateralPortfolio": [
+            {
+              "value": {
+            "collateralPosition": [
+              {
+              "product": {
+                "contractualProduct": {
+                  "economicTerms": {
+                    "payout": {
+                      "assetPayout": [
+                        {
+                          "payerReceiver": {
+                            "payer": "Party1",
+                            "receiver": "Party2"
+                          },
+                          "assetLeg": [
+                            {
+                              "settlementDate": {
+                                "adjustableDate": {
+                                  "dateAdjustments": {
+                                    "businessDayConvention": "NONE"
+                                  },
+                                  "adjustedDate": {
+                                    "value": "2020-09-22"
+                                  }
+                                }
+                              },
+                              "deliveryMethod": "DeliveryVersusPayment"
+                            },
+                            {
+                              "settlementDate": {
+                                "adjustableDate": {
+                                  "dateAdjustments": {
+                                    "businessDayConvention": "NONE"
+                                  },
+                                  "adjustedDate": {
+                                    "value": "2020-10-22"
+                                  }
+                                }
+                              },
+                              "deliveryMethod": "DeliveryVersusPayment"
+                            }
+                          ],
+                          "securityInformation": {
+                            "security": {
+                              "productIdentifier": [
+                                {
+                                  "value": {
+                                    "identifier": {
+                                      "value": "ST001"
+                                    },
+                                    "source": "SEDOL"
+                                  }
+                                }
+                              ],
+                              "securityType": "Equity"
+                            }
+                          },
+                          "durationType": {
+                            "durationType": "Term"
+                          },
+                          "minimumFee": {
+                            "value": 0,
+                            "unit": {
+                              "currency": {
+                                "value": "USD"
+                              }
+                            }
+                          },
+                          "dividendTerms": {
+                            "manufacturedIncomeRequirement": {
+                              "totalRatio": 1
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            } ]
+          }
+          }
+          ] } ,
           "collateralProvisions": {
             "collateralType": "Cash",
             "eligibleCollateral": [
@@ -190,7 +207,7 @@
         }
       }
     }
-  },
+  ,
   "priceQuantity": [
     {
       "price": [

--- a/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/new-settlement-workflow-func-input.json
+++ b/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/new-settlement-workflow-func-input.json
@@ -187,7 +187,7 @@
             } ]
           }
           }
-          ] } ,
+          ]  ,
           "collateralProvisions": {
             "collateralType": "Cash",
             "eligibleCollateral": [
@@ -204,7 +204,7 @@
               }
             ]
           }
-        }
+        } }
       }
     }
   ,

--- a/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/part-return-settlement-workflow-func-input.json
+++ b/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/part-return-settlement-workflow-func-input.json
@@ -186,102 +186,6 @@
                     "globalKey" : "98fd77d9"
                   }
                 } ],
-                "assetPayout" : [ {
-                  "payerReceiver" : {
-                    "payer" : "Party1",
-                    "receiver" : "Party2"
-                  },
-                  "assetLeg" : [ {
-                    "settlementDate" : {
-                      "adjustableDate" : {
-                        "dateAdjustments" : {
-                          "businessDayConvention" : "NONE",
-                          "meta" : {
-                            "globalKey" : "24a738"
-                          }
-                        },
-                        "adjustedDate" : {
-                          "value" : "2020-09-22",
-                          "meta" : {
-                            "globalKey" : "3f2256"
-                          }
-                        },
-                        "meta" : {
-                          "globalKey" : "24a738"
-                        }
-                      },
-                      "meta" : {
-                        "globalKey" : "24a738"
-                      }
-                    },
-                    "deliveryMethod" : "DeliveryVersusPayment"
-                  }, {
-                    "settlementDate" : {
-                      "adjustableDate" : {
-                        "dateAdjustments" : {
-                          "businessDayConvention" : "NONE",
-                          "meta" : {
-                            "globalKey" : "24a738"
-                          }
-                        },
-                        "adjustedDate" : {
-                          "value" : "2020-10-22",
-                          "meta" : {
-                            "globalKey" : "3f2296"
-                          }
-                        },
-                        "meta" : {
-                          "globalKey" : "24a738"
-                        }
-                      },
-                      "meta" : {
-                        "globalKey" : "24a738"
-                      }
-                    },
-                    "deliveryMethod" : "DeliveryVersusPayment"
-                  } ],
-                  "securityInformation" : {
-                    "security" : {
-                      "productIdentifier" : [ {
-                        "value" : {
-                          "identifier" : {
-                            "value" : "ST001"
-                          },
-                          "source" : "SEDOL",
-                          "meta" : {
-                            "globalKey" : "a4ff65ff"
-                          }
-                        }
-                      } ],
-                      "securityType" : "Equity"
-                    },
-                    "meta" : {
-                      "globalKey" : "7548eca6"
-                    }
-                  },
-                  "durationType" : {
-                    "durationType" : "Term"
-                  },
-                  "minimumFee" : {
-                    "value" : 0,
-                    "unit" : {
-                      "currency" : {
-                        "value" : "USD"
-                      }
-                    },
-                    "meta" : {
-                      "globalKey" : "171b36"
-                    }
-                  },
-                  "dividendTerms" : {
-                    "manufacturedIncomeRequirement" : {
-                      "totalRatio" : 1
-                    }
-                  },
-                  "meta" : {
-                    "globalKey" : "3b19750e"
-                  }
-                } ],
                 "meta" : {
                   "globalKey" : "43b3b6a7"
                 }
@@ -301,7 +205,119 @@
                       "globalKey" : "168480"
                     }
                   } ]
-                }
+                } ,
+                "collateralPortfolio": [
+                  {
+                    "value" : {
+                  "collateralPosition": [
+                  {
+                    "product": {
+                      "contractualProduct": {
+                        "economicTerms": {
+                          "payout": {
+                            "assetPayout" : [ {
+                              "payerReceiver" : {
+                                "payer" : "Party1",
+                                "receiver" : "Party2"
+                              },
+                              "assetLeg" : [ {
+                                "settlementDate" : {
+                                  "adjustableDate" : {
+                                    "dateAdjustments" : {
+                                      "businessDayConvention" : "NONE",
+                                      "meta" : {
+                                        "globalKey" : "24a738"
+                                      }
+                                    },
+                                    "adjustedDate" : {
+                                      "value" : "2020-09-22",
+                                      "meta" : {
+                                        "globalKey" : "3f2256"
+                                      }
+                                    },
+                                    "meta" : {
+                                      "globalKey" : "24a738"
+                                    }
+                                  },
+                                  "meta" : {
+                                    "globalKey" : "24a738"
+                                  }
+                                },
+                                "deliveryMethod" : "DeliveryVersusPayment"
+                              }, {
+                                "settlementDate" : {
+                                  "adjustableDate" : {
+                                    "dateAdjustments" : {
+                                      "businessDayConvention" : "NONE",
+                                      "meta" : {
+                                        "globalKey" : "24a738"
+                                      }
+                                    },
+                                    "adjustedDate" : {
+                                      "value" : "2020-10-22",
+                                      "meta" : {
+                                        "globalKey" : "3f2296"
+                                      }
+                                    },
+                                    "meta" : {
+                                      "globalKey" : "24a738"
+                                    }
+                                  },
+                                  "meta" : {
+                                    "globalKey" : "24a738"
+                                  }
+                                },
+                                "deliveryMethod" : "DeliveryVersusPayment"
+                              } ],
+                              "securityInformation" : {
+                                "security" : {
+                                  "productIdentifier" : [ {
+                                    "value" : {
+                                      "identifier" : {
+                                        "value" : "ST001"
+                                      },
+                                      "source" : "SEDOL",
+                                      "meta" : {
+                                        "globalKey" : "a4ff65ff"
+                                      }
+                                    }
+                                  } ],
+                                  "securityType" : "Equity"
+                                },
+                                "meta" : {
+                                  "globalKey" : "7548eca6"
+                                }
+                              },
+                              "durationType" : {
+                                "durationType" : "Term"
+                              },
+                              "minimumFee" : {
+                                "value" : 0,
+                                "unit" : {
+                                  "currency" : {
+                                    "value" : "USD"
+                                  }
+                                },
+                                "meta" : {
+                                  "globalKey" : "171b36"
+                                }
+                              },
+                              "dividendTerms" : {
+                                "manufacturedIncomeRequirement" : {
+                                  "totalRatio" : 1
+                                }
+                              },
+                              "meta" : {
+                                "globalKey" : "3b19750e"
+                              }
+                            } ]                                               
+                          }
+                        }
+                      }
+                    }
+                  } ] }
+                } ]
+              }
               }
             },
             "meta" : {

--- a/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/reallocation/reallocation-pre-settled-func-input.json
+++ b/rosetta-source/src/main/resources/cdm-sample-files/functions/sec-lending/reallocation/reallocation-pre-settled-func-input.json
@@ -364,109 +364,6 @@
                           }
                         }
                       ],
-                      "assetPayout": [
-                        {
-                          "payerReceiver": {
-                            "payer": "Party1",
-                            "receiver": "Party2"
-                          },
-                          "assetLeg": [
-                            {
-                              "settlementDate": {
-                                "adjustableDate": {
-                                  "dateAdjustments": {
-                                    "businessDayConvention": "NONE",
-                                    "meta": {
-                                      "globalKey": "24a738"
-                                    }
-                                  },
-                                  "adjustedDate": {
-                                    "value": "2020-09-22",
-                                    "meta": {
-                                      "globalKey": "3f2256"
-                                    }
-                                  },
-                                  "meta": {
-                                    "globalKey": "24a738"
-                                  }
-                                },
-                                "meta": {
-                                  "globalKey": "24a738"
-                                }
-                              },
-                              "deliveryMethod": "DeliveryVersusPayment"
-                            },
-                            {
-                              "settlementDate": {
-                                "adjustableDate": {
-                                  "dateAdjustments": {
-                                    "businessDayConvention": "NONE",
-                                    "meta": {
-                                      "globalKey": "24a738"
-                                    }
-                                  },
-                                  "adjustedDate": {
-                                    "value": "2020-10-22",
-                                    "meta": {
-                                      "globalKey": "3f2296"
-                                    }
-                                  },
-                                  "meta": {
-                                    "globalKey": "24a738"
-                                  }
-                                },
-                                "meta": {
-                                  "globalKey": "24a738"
-                                }
-                              },
-                              "deliveryMethod": "DeliveryVersusPayment"
-                            }
-                          ],
-                          "securityInformation": {
-                            "security": {
-                              "productIdentifier": [
-                                {
-                                  "value": {
-                                    "identifier": {
-                                      "value": "ST001"
-                                    },
-                                    "source": "SEDOL",
-                                    "meta": {
-                                      "globalKey": "a4ff65ff"
-                                    }
-                                  }
-                                }
-                              ],
-                              "securityType": "Equity"
-                            },
-                            "meta": {
-                              "globalKey": "7548eca6"
-                            }
-                          },
-                          "durationType": {
-                            "durationType": "Term"
-                          },
-                          "minimumFee": {
-                            "value": 0,
-                            "unit": {
-                              "currency": {
-                                "value": "USD"
-                              }
-                            },
-                            "meta": {
-                              "globalKey": "171b36"
-                            }
-                          },
-                          "dividendTerms": {
-                            "manufacturedIncomeRequirement": {
-                              "totalRatio": 1
-                            }
-                          },
-                          "meta": {
-                            "globalKey": "3b19750e"
-                          }
-                        }
-                      ],
                       "meta": {
                         "globalKey": "43b3b6a7"
                       }
@@ -490,7 +387,127 @@
                             }
                           }
                         ]
-                      }
+                      } ,
+                      "collateralPortfolio": [
+                        {
+                        "value" : {
+                        "collateralPosition": [
+                        {
+                          "product": {
+                            "contractualProduct": {
+                              "economicTerms": {
+                                "payout":  {                                 
+                                  "assetPayout": [
+                                    {
+                                      "payerReceiver": {
+                                        "payer": "Party1",
+                                        "receiver": "Party2"
+                                      },
+                                      "assetLeg": [
+                                        {
+                                          "settlementDate": {
+                                            "adjustableDate": {
+                                              "dateAdjustments": {
+                                                "businessDayConvention": "NONE",
+                                                "meta": {
+                                                  "globalKey": "24a738"
+                                                }
+                                              },
+                                              "adjustedDate": {
+                                                "value": "2020-09-22",
+                                                "meta": {
+                                                  "globalKey": "3f2256"
+                                                }
+                                              },
+                                              "meta": {
+                                                "globalKey": "24a738"
+                                              }
+                                            },
+                                            "meta": {
+                                              "globalKey": "24a738"
+                                            }
+                                          },
+                                          "deliveryMethod": "DeliveryVersusPayment"
+                                        },
+                                        {
+                                          "settlementDate": {
+                                            "adjustableDate": {
+                                              "dateAdjustments": {
+                                                "businessDayConvention": "NONE",
+                                                "meta": {
+                                                  "globalKey": "24a738"
+                                                }
+                                              },
+                                              "adjustedDate": {
+                                                "value": "2020-10-22",
+                                                "meta": {
+                                                  "globalKey": "3f2296"
+                                                }
+                                              },
+                                              "meta": {
+                                                "globalKey": "24a738"
+                                              }
+                                            },
+                                            "meta": {
+                                              "globalKey": "24a738"
+                                            }
+                                          },
+                                          "deliveryMethod": "DeliveryVersusPayment"
+                                        }
+                                      ],
+                                      "securityInformation": {
+                                        "security": {
+                                          "productIdentifier": [
+                                            {
+                                              "value": {
+                                                "identifier": {
+                                                  "value": "ST001"
+                                                },
+                                                "source": "SEDOL",
+                                                "meta": {
+                                                  "globalKey": "a4ff65ff"
+                                                }
+                                              }
+                                            }
+                                          ],
+                                          "securityType": "Equity"
+                                        },
+                                        "meta": {
+                                          "globalKey": "7548eca6"
+                                        }
+                                      },
+                                      "durationType": {
+                                        "durationType": "Term"
+                                      },
+                                      "minimumFee": {
+                                        "value": 0,
+                                        "unit": {
+                                          "currency": {
+                                            "value": "USD"
+                                          }
+                                        },
+                                        "meta": {
+                                          "globalKey": "171b36"
+                                        }
+                                      },
+                                      "dividendTerms": {
+                                        "manufacturedIncomeRequirement": {
+                                          "totalRatio": 1
+                                        }
+                                      },
+                                      "meta": {
+                                        "globalKey": "3b19750e"
+                                      }
+                                    }
+                                  ]                         
+                                }
+                              }
+                            }
+                          }
+                        } ]
+                        }  
+                        } ]
+                    }
                     }
                   },
                   "meta": {


### PR DESCRIPTION
Securities Lending trades have one InterestRatePayout leg and one AssetPayout leg.  In the older version of CDM, the AssetPayout was a peer to the InterestRatePayoutLeg.  Now, it has been moved up to be in side Collateral as this more correctly represents the role of the underlying security instrument in the trade.

Old location:
economicTerms -> payout -> assetPayout

New location:
economicTerms -> collateral -> collateralPortfolio -> collateralPosition -> product -> contractualProduct -> economicTerms -> payout -> assetPayout

The samples have been run through Qualify_SecuritiesFinancing to ensure they correctly validate (see TASK-6157 and PR #2448 )