### PR TITLE
Added price and date references

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,8 +3,16 @@
 _Background_
 
 `PriceSchedule` does not include a reference to the price type needed to identify the pruchase (initial) price and repurchase (final price) of a repo.
+`effectiveDate` and `terminationDate` are defined by `AdjustableOrRelativeDate` but this data type does not include a date reference that is needed to related it to
+a contract, termsheet or legal agreement.
 
 _What is being released?_
 
-This enhancement adds `priceScheduleReference` to `PriceSchedule` and `PriceScheduleReferenceEnum` values `PurchasePrice` and `RepurchasePrice`. These values can
-be set in the `tradeLot` for cash or asset price types.
+This enhancement adds the following:
+
+`priceScheduleReference` to `PriceSchedule` and `PriceScheduleReferenceEnum` values `PurchasePrice` and `RepurchasePrice`. These values can
+be set in the `tradeLot` for cash or asset price types and in `payout` to define `priceQuantity`.
+
+`dateReference` defined by `DateReferenceEnum` to `AdjustableOrRelativeDate` that will be used in `economicTerms` to define pruchase date and repruchase date using 
+enums `PurchaseDate` and `RepurchaseDate`.
+

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,12 +1,10 @@
-# *Infrastructure - Dependency Update*
+# Observable Model - Add Repo Purchaseprice and Repurchaseprice Reference
+
+_Background_
+
+`PriceSchedule` does not include a reference to the price type needed to identify the pruchase (initial) price and repurchase (final price) of a repo.
 
 _What is being released?_
 
-This release updates the `rosetta-dsl` dependency.
-
-Version updates include:
-- `rosetta-dsl` 8.8.3: Improves stability and performance of the DSL. For further details see DSL release notes: https://github.com/REGnosys/rosetta-dsl/releases/tag/8.8.3.
-
-There are no changes to the model, and test expectations remain the same.
-
-The changes can be reviewed in PR [#2460](https://github.com/finos/common-domain-model/pull/2460).
+This enhancement adds `priceScheduleReference` to `PriceSchedule` and `PriceScheduleReferenceEnum` values `PurchasePrice` and `RepurchasePrice`. These values can
+be set in the `tradeLot` for cash or asset price types.

--- a/rosetta-source/src/main/rosetta/base-datetime-enum.rosetta
+++ b/rosetta-source/src/main/rosetta/base-datetime-enum.rosetta
@@ -446,3 +446,7 @@ enum CompoundingTypeEnum: <"The enumerated values to specify how the compounding
 enum RoundingFrequencyEnum: <"How often is rounding performed">
     Daily <"Rounding is done on each day">
     PeriodEnd <"Rounding is done only at the end of the period">
+
+enum DateReferenceEnum: <"A set of date references that can be related to a contract, term sheet or other legal agreement.">
+	PurchaseDate <"As defined in GMRA paragraph 2(mm) The date on which Purchased Securities are sold or are to be sold by Seller to Buyer.">
+	RepurchaseDate <"As defined in GMRA paragraph 2(qq) The date on which Buyer is to sell Equivalent Securities to Seller.">

--- a/rosetta-source/src/main/rosetta/base-datetime-type.rosetta
+++ b/rosetta-source/src/main/rosetta/base-datetime-type.rosetta
@@ -66,6 +66,7 @@ type AdjustableOrRelativeDates: <"A class giving the choice between defining a s
 
     adjustableDates AdjustableDates (0..1) <"A series of dates that shall be subject to adjustment if they would otherwise fall on a day that is not a business day in the specified business centers, together with the convention for adjusting the date.">
     relativeDates RelativeDates (0..1) <"A series of dates specified as some offset to another series of dates (the anchor dates).">
+	dateReference DateReferenceEnum (0..1) <"Defines a reference type to the date.">
 
     condition AdjustableOrRelativeDatesChoice: <"Choice rule to represent an FpML choice construct.">
         required choice adjustableDates, relativeDates

--- a/rosetta-source/src/main/rosetta/event-common-func.rosetta
+++ b/rosetta-source/src/main/rosetta/event-common-func.rosetta
@@ -1525,6 +1525,7 @@ func Create_OnDemandRateChangePriceChangeInstruction: <"Creates a price change i
             composite: currentRatePrice -> composite,
             arithmeticOperator: currentRatePrice -> arithmeticOperator,
             cashPrice: currentRatePrice -> cashPrice,
+			priceScheduleReference: empty,
             datedValue: empty
         }
     alias newPriceQuantity: <"Create the new price quantity object.">

--- a/rosetta-source/src/main/rosetta/event-common-func.rosetta
+++ b/rosetta-source/src/main/rosetta/event-common-func.rosetta
@@ -408,6 +408,7 @@ func Create_StockSplit: <"Function specification to create the fully-formed busi
             composite: preSplitPrice -> composite,
             arithmeticOperator: preSplitPrice -> arithmeticOperator,
             cashPrice: preSplitPrice -> cashPrice,
+			priceScheduleReference: empty,
             datedValue: empty
         }
     alias postSplitPriceQuantity:

--- a/rosetta-source/src/main/rosetta/observable-asset-enum.rosetta
+++ b/rosetta-source/src/main/rosetta/observable-asset-enum.rosetta
@@ -325,3 +325,7 @@ enum CsaTypeEnum: <"How is the Creadit Support Annex defined for this transactio
 enum OptionReferenceTypeEnum: <"The enumeration values to specify the reference source that determines the final settlement price of the option.">
     Future <"Reference from the price of a future contract.">
     Spot <"Reference from an underlyer spot price.">
+	
+enum PriceScheduleReferenceEnum: <"Describes the type and method that defines how the principal payment is set.">
+	PurchasePrice <"Defines the principal payment as the purchase price.">
+	RepurchasePrice <"Defines the principal payment as the repurchase price.">	

--- a/rosetta-source/src/main/rosetta/observable-asset-type.rosetta
+++ b/rosetta-source/src/main/rosetta/observable-asset-type.rosetta
@@ -129,6 +129,7 @@ type PriceSchedule extends MeasureSchedule: <"Specifies the price of a financial
     composite PriceComposite (0..1) <"(Optionally) Specifies the underlying price components if the price can be expressed as a composite: e.g. dirty price = clean price + accrued.">
     arithmeticOperator ArithmeticOperationEnum (0..1) <"(Optionally) When the price is to be understood as an operator to apply to an observable, i.e. a spread, multiplier or min/max.">
     cashPrice CashPrice (0..1) <"(Optionally when the price type is cash) Additional attributes that further define a cash price, e.g. what type of fee it is.">
+    priceScheduleReference PriceScheduleReferenceEnum (0..1) <"Defines a reference type to the price and how it can be applied.">
 
     condition UnitOfAmountExists: <"Requires that a unit of amount must be specified for price unless price type is Variance, Volatility or Correlation.">
         if priceType = PriceTypeEnum -> Variance

--- a/rosetta-source/src/main/rosetta/product-asset-func.rosetta
+++ b/rosetta-source/src/main/rosetta/product-asset-func.rosetta
@@ -100,6 +100,7 @@ func ResolveEquityInitialPrice: <"To be replaced by full resolve price function 
                     composite: item -> composite,
                     arithmeticOperator: item -> arithmeticOperator,
                     cashPrice: item -> cashPrice,
+					priceScheduleReference: empty,
                     datedValue: empty
                 }
             then only-element


### PR DESCRIPTION
`PriceSchedule` does not include a reference to the price type needed to identify the pruchase (initial) price and repurchase (final price) of a repo.
`effectiveDate` and `terminationDate` are defined by `AdjustableOrRelativeDate` but this data type does not include a date reference that is needed to related it to
a contract, termsheet or legal agreement.

This enhancement adds the following:

`priceScheduleReference` to `PriceSchedule` and `PriceScheduleReferenceEnum` values `PurchasePrice` and `RepurchasePrice`. These values can
be set in the `tradeLot` for cash or asset price types and in `payout` to define `priceQuantity`.

`dateReference` defined by `DateReferenceEnum` to `AdjustableOrRelativeDate` that will be used in `economicTerms` to define pruchase date and repruchase date using 
enums `PurchaseDate` and `RepurchaseDate`.