### PR TITLE
Prevent GitHub Actions from being triggered twice

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -3,7 +3,6 @@ name: CVE Scanning for Maven
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened, synchronize]
     paths:
       - 'pom.xml'
       - 'allow-list.xml'

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -3,7 +3,7 @@ name: CVE Scanning for Maven
 on:
   workflow_dispatch:
   pull_request:
-    types: [synchronize]
+    types: [opened, reopened, synchronize]
     paths:
       - 'pom.xml'
       - 'allow-list.xml'

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -2,12 +2,8 @@ name: CVE Scanning for Maven
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - 'pom.xml'
-      - 'allow-list.xml'
-      - '.github/workflows/cve-scanning.yml'
   pull_request:
+    types: [synchronize]
     paths:
       - 'pom.xml'
       - 'allow-list.xml'
@@ -27,6 +23,6 @@ jobs:
         distribution: 'temurin'
         cache: maven
     - name: Build with Maven
-      run: mvn clean install -DskipTests
+      run: mvn -B -U clean package -DskipTests
     - name: CVE scanning
       run: mvn org.owasp:dependency-check-maven:check -DfailBuildOnCVSS=7 -DsuppressionFile="allow-list.xml"

--- a/.github/workflows/license-scanning.yml
+++ b/.github/workflows/license-scanning.yml
@@ -2,7 +2,8 @@ name: License Scanning for Maven
 
 on:
   workflow_dispatch:
-  push:
+  pull_request:
+    types: [synchronize]
     paths:
       - 'pom.xml'
       - '.github/workflows/license-scanning.yml'
@@ -28,7 +29,7 @@ jobs:
     - name: Install XQ
       run: pip install xq
     - name: Build with Maven
-      run: mvn clean install -DskipTests
+      run: mvn -B -U clean install -DskipTests
     - name: License XML report
       run: mvn org.codehaus.mojo:license-maven-plugin:2.0.0:download-licenses
     - name: Validate XML report

--- a/.github/workflows/license-scanning.yml
+++ b/.github/workflows/license-scanning.yml
@@ -3,7 +3,7 @@ name: License Scanning for Maven
 on:
   workflow_dispatch:
   pull_request:
-    types: [synchronize]
+    types: [opened, reopened, synchronize]
     paths:
       - 'pom.xml'
       - '.github/workflows/license-scanning.yml'

--- a/.github/workflows/license-scanning.yml
+++ b/.github/workflows/license-scanning.yml
@@ -3,7 +3,6 @@ name: License Scanning for Maven
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened, synchronize]
     paths:
       - 'pom.xml'
       - '.github/workflows/license-scanning.yml'

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,6 +1,9 @@
 name: CDM Build on Windows machine
 
-on: [workflow_dispatch, push, pull_request]
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [synchronize]
 
 jobs:
   build:
@@ -13,5 +16,5 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
           cache: maven
-      - name: Maven install
-        run: mvn install
+      - name: Maven build
+        run: mvn -B -U clean package

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -6,7 +6,7 @@ on:
     types: [synchronize]
 
 jobs:
-  build: 
+  build:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -3,7 +3,7 @@ name: CDM Build on Windows machine
 on:
   workflow_dispatch:
   pull_request:
-    types: [synchronize]
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -3,7 +3,6 @@ name: CDM Build on Windows machine
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, reopened, synchronize]
 
 jobs:
   build:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -6,7 +6,7 @@ on:
     types: [synchronize]
 
 jobs:
-  build:
+  build: 
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixes https://github.com/finos/common-domain-model/issues/2399

Have tested by
- opening a PR (should trigger `opened` event)
- pushing to a PR (should trigger `synchronized` event)
- closing and reopening a PR (should trigger `reopened` event)

All seems to be working as expected.

Since types `opened`, `reopened` and `synchronized` of the `pull_request` trigger are the default, I've left out the list of types in the workflow files.