### PR TITLE
Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -3,9 +3,8 @@ name: Feature Request
 about: I have a suggested enhancement to the CDM
 labels:
 assignees:
+title: Proposed change to the CDM
 ---
-
-# Proposed Enhancement to the Common Domain Model #
 
 > [!NOTE]
 > Any Issue must:

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,49 @@
+---
+name: Feature Request
+about: I have a suggested enhancement to the CDM
+labels:
+assignees:
+---
+
+# Proposed Enhancement to the Common Domain Model #
+
+> [!NOTE]
+> Any Issue must:
+> - include the source of the Issue i.e. is it from the Roadmap, from a Working Group recommendation, github discussions etc
+> - describe the scope of the change, work item or deliverable
+> - be written in “plain English” i.e. try not to use niche business or technical terminology
+> - describe the benefit to the model and/or the community
+> - identify the Working Group where community members can contribute to the change, if applicable
+> - include details of existing or proposed solutions in respect of this issue
+> - the version of the CDM that the Issue relates to
+> - be manageable i.e. larger proposals should be broken down into multiple smaller Issues to make them easier to digest
+> 
+> Sections are provided in this template to help create the Issue with the correct level of detail.
+>
+> All _Tips_, _Notes_ and other alerts can be deleted from the page when you are happy with the 
+> content.
+
+
+> [!TIP]
+> The more evidence that you can provide of prior approval for the proposed change from a 
+> CDM Working Group the better. This will assist the CDM maintainers and participants
+> when reviewing the proposal.
+
+## Background ##
+
+_Please provide the business context of the Issue i.e. what is required and why_
+
+## Proposal ##
+
+_Please put details of the proposed changes in here_
+_Splitting the changes into sections will improve comprehension of the proposal_
+_Use graphics where possible e.g. before/after pictures of the model enhancements_
+
+## Compatibility ##
+
+_If known, please describe any compatibility issues that this change may have_
+_with existing versions. Please review the list of backwardly incompatible_
+_changes and in the design principles for assistance._
+
+
+

--- a/.github/ISSUE_TEMPLATE/Support_question.md
+++ b/.github/ISSUE_TEMPLATE/Support_question.md
@@ -1,0 +1,11 @@
+---
+name: Support Question
+about: If you have a question about configuration, usage, missing functionality etc.
+labels: question,help-wanted
+---
+
+## Support Question
+
+...ask your question here.
+
+...be sure to search existing issues since someone might have already asked something similar.


### PR DESCRIPTION
This PR creates two Issue Templates:
- Feature Request template
- Support Question template

Github automatically creates a page where these two templates will be offered to the user when they choose to create a new Issue. The option to use a generic template is still available on this page too.

There are no model changes in this PR, just the addition of two templates. 

Note that additional templates can be created in the future.