### PR TITLE
InterestRateForwardDebtPriceMappingProcessor updated to handle 'Percentage' quoteUnits [6.x.x]

### DIFF
--- a/rosetta-source/src/main/java/cdm/product/template/processor/InterestRateForwardDebtPriceMappingProcessor.java
+++ b/rosetta-source/src/main/java/cdm/product/template/processor/InterestRateForwardDebtPriceMappingProcessor.java
@@ -69,8 +69,13 @@ public class InterestRateForwardDebtPriceMappingProcessor extends MappingProcess
 
     private void addPrice(Path genenicProductPath, PriceQuantityBuilder priceQuantityBuilder, Path quotePath, List<Mapping> quoteMappings) {
         Mapping valueMapping = getNonNullMapping(quoteMappings, quotePath.addElement("value")).orElse(null);
+        Mapping quoteUnitsMapping = getNonNullMapping(quoteMappings, quotePath.addElement("quoteUnits")).orElse(null);
+
         if (isPriceNotation(quotePath, quoteMappings) && valueMapping != null) {
             BigDecimal rate = new BigDecimal(String.valueOf(valueMapping.getXmlValue()));
+            if (quoteUnitsMapping != null && String.valueOf(quoteUnitsMapping.getXmlValue()).equals("Percentage")){
+                rate = rate.divide(BigDecimal.valueOf(100));
+            }
             UnitType.UnitTypeBuilder unitType = toCurrencyUnitType(genenicProductPath);
             PriceTypeEnum priceType = PriceTypeEnum.ASSET_PRICE;
 

--- a/rosetta-source/src/main/resources/cdm-sample-files/fpml-5-10/products/rates/bond-fwd-generic-ex01.xml
+++ b/rosetta-source/src/main/resources/cdm-sample-files/fpml-5-10/products/rates/bond-fwd-generic-ex01.xml
@@ -135,7 +135,7 @@
   <quote>
     <value>72.6600701</value>
     <measureType>PriceNotation</measureType>
-    <quoteUnits>Percent</quoteUnits>
+    <quoteUnits>Percentage</quoteUnits>
   </quote>
   <quote>
     <value>1</value>

--- a/rosetta-source/src/main/resources/cdm-sample-files/fpml-5-10/products/rates/bond-fwd-generic-ex02.xml
+++ b/rosetta-source/src/main/resources/cdm-sample-files/fpml-5-10/products/rates/bond-fwd-generic-ex02.xml
@@ -136,7 +136,7 @@
     <quote>
         <value>52.6600701</value>
         <measureType>PriceNotation</measureType>
-        <quoteUnits>Percent</quoteUnits>
+        <quoteUnits>Percentage</quoteUnits>
     </quote>
     <quote>
         <value>1</value>

--- a/rosetta-source/src/main/resources/result-json-files/fpml-5-10/products/rates/bond-fwd-generic-ex01.json
+++ b/rosetta-source/src/main/resources/result-json-files/fpml-5-10/products/rates/bond-fwd-generic-ex01.json
@@ -145,7 +145,7 @@
       "priceQuantity" : [ {
         "price" : [ {
           "value" : {
-            "value" : 72.6600701,
+            "value" : 0.726600701,
             "unit" : {
               "currency" : {
                 "value" : "JPY"
@@ -216,7 +216,7 @@
           }
         },
         "meta" : {
-          "globalKey" : "a8cff3b8"
+          "globalKey" : "6919d2d2"
         }
       } ]
     } ],
@@ -358,10 +358,10 @@
       }
     } ],
     "meta" : {
-      "globalKey" : "fa540ce1"
+      "globalKey" : "efc26a07"
     }
   },
   "meta" : {
-    "globalKey" : "fa540ce1"
+    "globalKey" : "efc26a07"
   }
 }

--- a/rosetta-source/src/main/resources/result-json-files/fpml-5-10/products/rates/bond-fwd-generic-ex02.json
+++ b/rosetta-source/src/main/resources/result-json-files/fpml-5-10/products/rates/bond-fwd-generic-ex02.json
@@ -145,7 +145,7 @@
       "priceQuantity" : [ {
         "price" : [ {
           "value" : {
-            "value" : 52.6600701,
+            "value" : 0.526600701,
             "unit" : {
               "currency" : {
                 "value" : "JPY"
@@ -216,7 +216,7 @@
           }
         },
         "meta" : {
-          "globalKey" : "d480fe1b"
+          "globalKey" : "b104d071"
         }
       } ]
     } ],
@@ -358,10 +358,10 @@
       }
     } ],
     "meta" : {
-      "globalKey" : "32e1d759"
+      "globalKey" : "f559cec3"
     }
   },
   "meta" : {
-    "globalKey" : "32e1d759"
+    "globalKey" : "f559cec3"
   }
 }


### PR DESCRIPTION
The InterestRateForwardDebtPriceMappingProcessor has been updated; this solves the incorrect mapping of Bond Forward prices. 
Issue: https://github.com/finos/common-domain-model/issues/3203