### PR TITLE
InterestRateForwardDebtPriceMappingProcessor updated to handle 'Percentage' quoteUnits [5.x.x]

### DIFF
--- a/rosetta-source/src/main/java/cdm/product/template/processor/InterestRateForwardDebtPriceMappingProcessor.java
+++ b/rosetta-source/src/main/java/cdm/product/template/processor/InterestRateForwardDebtPriceMappingProcessor.java
@@ -69,8 +69,13 @@ public class InterestRateForwardDebtPriceMappingProcessor extends MappingProcess
 
     private void addPrice(Path genenicProductPath, PriceQuantityBuilder priceQuantityBuilder, Path quotePath, List<Mapping> quoteMappings) {
         Mapping valueMapping = getNonNullMapping(quoteMappings, quotePath.addElement("value")).orElse(null);
+        Mapping quoteUnitsMapping = getNonNullMapping(quoteMappings, quotePath.addElement("quoteUnits")).orElse(null);
+
         if (isPriceNotation(quotePath, quoteMappings) && valueMapping != null) {
             BigDecimal rate = new BigDecimal(String.valueOf(valueMapping.getXmlValue()));
+            if (quoteUnitsMapping != null && String.valueOf(quoteUnitsMapping.getXmlValue()).equals("Percentage")){
+                rate = rate.divide(BigDecimal.valueOf(100));
+            }
             UnitType.UnitTypeBuilder unitType = toCurrencyUnitType(genenicProductPath);
             PriceTypeEnum priceType = PriceTypeEnum.ASSET_PRICE;
 

--- a/rosetta-source/src/main/resources/cdm-sample-files/fpml-5-10/products/rates/bond-fwd-generic-ex01.xml
+++ b/rosetta-source/src/main/resources/cdm-sample-files/fpml-5-10/products/rates/bond-fwd-generic-ex01.xml
@@ -135,7 +135,7 @@
   <quote>
     <value>72.6600701</value>
     <measureType>PriceNotation</measureType>
-    <quoteUnits>Percent</quoteUnits>
+    <quoteUnits>Percentage</quoteUnits>
   </quote>
   <quote>
     <value>1</value>

--- a/rosetta-source/src/main/resources/cdm-sample-files/fpml-5-10/products/rates/bond-fwd-generic-ex02.xml
+++ b/rosetta-source/src/main/resources/cdm-sample-files/fpml-5-10/products/rates/bond-fwd-generic-ex02.xml
@@ -136,7 +136,7 @@
     <quote>
         <value>52.6600701</value>
         <measureType>PriceNotation</measureType>
-        <quoteUnits>Percent</quoteUnits>
+        <quoteUnits>Percentage</quoteUnits>
     </quote>
     <quote>
         <value>1</value>

--- a/rosetta-source/src/main/resources/result-json-files/fpml-5-10/products/rates/bond-fwd-generic-ex01.json
+++ b/rosetta-source/src/main/resources/result-json-files/fpml-5-10/products/rates/bond-fwd-generic-ex01.json
@@ -206,7 +206,7 @@
         "priceQuantity" : [ {
           "price" : [ {
             "value" : {
-              "value" : 72.6600701,
+              "value" : 0.726600701,
               "unit" : {
                 "currency" : {
                   "value" : "JPY"
@@ -293,7 +293,7 @@
             }
           },
           "meta" : {
-            "globalKey" : "cd963b24"
+            "globalKey" : "8de01a3e"
           }
         } ]
       } ],
@@ -394,10 +394,10 @@
       }
     } ],
     "meta" : {
-      "globalKey" : "6b5f1e74"
+      "globalKey" : "3c625b8e"
     }
   },
   "meta" : {
-    "globalKey" : "6b5f1e74"
+    "globalKey" : "3c625b8e"
   }
 }

--- a/rosetta-source/src/main/resources/result-json-files/fpml-5-10/products/rates/bond-fwd-generic-ex02.json
+++ b/rosetta-source/src/main/resources/result-json-files/fpml-5-10/products/rates/bond-fwd-generic-ex02.json
@@ -206,7 +206,7 @@
         "priceQuantity" : [ {
           "price" : [ {
             "value" : {
-              "value" : 52.6600701,
+              "value" : 0.526600701,
               "unit" : {
                 "currency" : {
                   "value" : "JPY"
@@ -293,7 +293,7 @@
             }
           },
           "meta" : {
-            "globalKey" : "f9474587"
+            "globalKey" : "d5cb17dd"
           }
         } ]
       } ],
@@ -394,10 +394,10 @@
       }
     } ],
     "meta" : {
-      "globalKey" : "1163f6d6"
+      "globalKey" : "8ffc3b2c"
     }
   },
   "meta" : {
-    "globalKey" : "1163f6d6"
+    "globalKey" : "8ffc3b2c"
   }
 }


### PR DESCRIPTION
The InterestRateForwardDebtPriceMappingProcessor has been updated; this solves the incorrect mapping of Bond Forward prices.
Issue: https://github.com/finos/common-domain-model/issues/3203