### PR TITLE
CDM Documentation - Remove old roadmap references

### DIFF
--- a/SCOPE.md
+++ b/SCOPE.md
@@ -1,5 +1,3 @@
 # Scope
 
-The Common Domain Model (CDM) is a standardised, machine-readable and machine-executable blueprint for how financial products are traded and managed across the transaction lifecycle. It is represented as a domain model and distributed in open source.
-
-There are no patents involved in the CDM.
+Please refer to the [CDM Overview page](docs/cdm-overview.md#scope)

--- a/docs/roadmap.mdx
+++ b/docs/roadmap.mdx
@@ -12,5 +12,4 @@ Release states are defined as follows:
 * Maintenance – when a new Production version is released then the current Production will go into Maintenance. Only critical bug fixes and changes related to critical regulatory requirements should be ported to Maintenance releases. Otherwise, functional changes would not be ported to maintenance releases.  The intention would be to have only 1 version at a time in maintenance, so each time a new Production version drops, the previous Maintenance release would go to Unsupported.
 * Unsupported/End of Life – There will be no bug fixes or other support for the version.  TBD: We may perform security scans on some more recent unsupported versions and report any identified vulnerabilities, but will not perform security remediations.
 
-
 At any point we want a maximum of 1 centrally supported development version, 1 production version, and one maintenance version.

--- a/website/versioned_docs/version-5.13.0/CDM-Collateral-WG.md
+++ b/website/versioned_docs/version-5.13.0/CDM-Collateral-WG.md
@@ -14,9 +14,6 @@ The Collateral Working Group plays a pivotal role in the CDM ecosystem by provid
 
 **Join us on the last Tuesday every month 10AM EST (3PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![Collateral WG Roadmap](/img/crwg-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-5.13.0/CDM-Contribution-Review-WG.md
+++ b/website/versioned_docs/version-5.13.0/CDM-Contribution-Review-WG.md
@@ -18,9 +18,6 @@ The CDM Contribution Review Working Group (CRWG) plays a crucial role in the CDM
 
 **Join us on the First and Third Tuesday at 10 AM EST (3 PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![CRWG Roadmap](/img/crwg-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-5.13.0/CDM-Steering-WG.md
+++ b/website/versioned_docs/version-5.13.0/CDM-Steering-WG.md
@@ -18,9 +18,6 @@ This working group serves as the driving force behind the strategic direction an
 
 **Join us Monthly on the Second Tuesday 11AM EST (4 PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![Steering WG Roadmap](/img/steering-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-5.13.0/CDM-Technology-Architecture-WG.md
+++ b/website/versioned_docs/version-5.13.0/CDM-Technology-Architecture-WG.md
@@ -16,9 +16,6 @@ The CDM Technology Architecture Working Group focuses on aligning the architectu
 
 **Join us every 2nd Thursday of Every Month, 9AM EST (2PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![TAWG Roadmap](/img/tawg-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-5.20.0/CDM-Collateral-WG.md
+++ b/website/versioned_docs/version-5.20.0/CDM-Collateral-WG.md
@@ -14,9 +14,6 @@ The Collateral Working Group plays a pivotal role in the CDM ecosystem by provid
 
 **Join us on the last Tuesday every month 10AM EST (3PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![Collateral WG Roadmap](/img/crwg-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-5.20.0/CDM-Contribution-Review-WG.md
+++ b/website/versioned_docs/version-5.20.0/CDM-Contribution-Review-WG.md
@@ -18,9 +18,6 @@ The CDM Contribution Review Working Group (CRWG) plays a crucial role in the CDM
 
 **Join us on the First and Third Tuesday at 10 AM EST (3 PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![CRWG Roadmap](/img/crwg-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-5.20.0/CDM-Steering-WG.md
+++ b/website/versioned_docs/version-5.20.0/CDM-Steering-WG.md
@@ -18,9 +18,6 @@ This working group serves as the driving force behind the strategic direction an
 
 **Join us Monthly on the Second Tuesday 11AM EST (4 PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![Steering WG Roadmap](/img/steering-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-5.20.0/CDM-Technology-Architecture-WG.md
+++ b/website/versioned_docs/version-5.20.0/CDM-Technology-Architecture-WG.md
@@ -16,9 +16,6 @@ The CDM Technology Architecture Working Group focuses on aligning the architectu
 
 **Join us every 2nd Thursday of Every Month, 9AM EST (2PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![TAWG Roadmap](/img/tawg-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-6.0.0/CDM-Collateral-WG.md
+++ b/website/versioned_docs/version-6.0.0/CDM-Collateral-WG.md
@@ -14,9 +14,6 @@ The Collateral Working Group plays a pivotal role in the CDM ecosystem by provid
 
 **Join us on the last Tuesday every month 10AM EST (3PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![Collateral WG Roadmap](/img/crwg-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-6.0.0/CDM-Contribution-Review-WG.md
+++ b/website/versioned_docs/version-6.0.0/CDM-Contribution-Review-WG.md
@@ -18,9 +18,6 @@ The CDM Contribution Review Working Group (CRWG) plays a crucial role in the CDM
 
 **Join us on the First and Third Tuesday at 10 AM EST (3 PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![CRWG Roadmap](/img/crwg-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-6.0.0/CDM-Steering-WG.md
+++ b/website/versioned_docs/version-6.0.0/CDM-Steering-WG.md
@@ -18,9 +18,6 @@ This working group serves as the driving force behind the strategic direction an
 
 **Join us Monthly on the Second Tuesday 11AM EST (4 PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![Steering WG Roadmap](/img/steering-roadmap.png)
 
 ## Subscribe
 

--- a/website/versioned_docs/version-6.0.0/CDM-Technology-Architecture-WG.md
+++ b/website/versioned_docs/version-6.0.0/CDM-Technology-Architecture-WG.md
@@ -16,9 +16,6 @@ The CDM Technology Architecture Working Group focuses on aligning the architectu
 
 **Join us every 2nd Thursday of Every Month, 9AM EST (2PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![TAWG Roadmap](/img/tawg-roadmap.png)
 
 ## Subscribe
 


### PR DESCRIPTION
Continued work for issue #3435 

- [x] Omit references to old roadmap
- [x] Update scope file (now absorbed into overview)