### PR TITLE
CDM Website - Update derivative wg page

### DIFF
--- a/docs/CDM-Derivatives-WG.md
+++ b/docs/CDM-Derivatives-WG.md
@@ -10,16 +10,12 @@ Focused on swaps (IR, credit, equity, commodity, etc.), options, FX, post-trade 
 
 **Join us on the Second and Last Wednesday at 11:30 AM EST (4:30PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![CDM Derivatives Roadmap](/img/dpbe-roadmap.png)
-
 ## Subscribe
 
 To subscribe to the [CDM Derivatives mailing list](https://lists.finos.org/g/cdm-derivatives-wg) and stay updated on meetings and agenda, please send an email to [cdm-derivatives-wg+subscribe@lists.finos.org](mailto:cdm-derivatives-wg+subscribe@lists.finos.org). After sending the email, you will receive a confirmation message. Reply to confirm your subscription.
 
 ---
 
-To view meeting notes and agendas, view our [current](https://github.com/finos/common-domain-model/issues?q=is%3Aissue+is%3Aopen+%22CDM+Contribution+Review+Working+Group%22) and [past](https://github.com/finos/common-domain-model/issues?q=is%3Aissue+%22CDM+Derivatives+Products+and+Business+Events+Working+Group%22+is%3Aclosed) GitHub Meeting Issues. 
+To view the work of the Derivatives Working Group—both current and past—please visit our [Derivatives WG GitHub project](https://github.com/orgs/finos/projects/112/views/1).
 
 Click [here](working-groups.md) to return back to the Working Groups home page.

--- a/website/versioned_docs/version-5.20.0/CDM-Derivatives-WG.md
+++ b/website/versioned_docs/version-5.20.0/CDM-Derivatives-WG.md
@@ -10,13 +10,9 @@ Focused on swaps (IR, credit, equity, commodity, etc.), options, FX, post-trade 
 
 **Join us on the Second and Last Wednesday at 11:30 AM EST (4:30PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![CDM Derivatives Roadmap](/img/dpbe-roadmap.png)
-
 ## Subscribe
 
-To subscribe to the [CDM Derivatives mailing list](https://lists.finos.org/g/cdm-derivatives-wg) and stay updated on meetings and agenda, please send an email to [cdm-derivatives-wg+subscribe@lists.finos.org](mailto:cdm-derivatives-wg+subscribe@lists.finos.org). After sending the email, you will receive a confirmation message. Reply to confirm your subscription.
+To view the work of the Derivatives Working Group—both current and past—please visit our [Derivatives WG GitHub project](https://github.com/orgs/finos/projects/112/views/1).
 
 ---
 

--- a/website/versioned_docs/version-6.0.0/CDM-Derivatives-WG.md
+++ b/website/versioned_docs/version-6.0.0/CDM-Derivatives-WG.md
@@ -10,16 +10,12 @@ Focused on swaps (IR, credit, equity, commodity, etc.), options, FX, post-trade 
 
 **Join us on the Second and Last Wednesday at 11:30 AM EST (4:30PM GMT).** Email help@finos.org to be added to the meeting invites directly, or find the meeting in the [FINOS Community Calendar](https://calendar.google.com/calendar/embed?src=finos.org_fac8mo1rfc6ehscg0d80fi8jig%40group.calendar.google.com). 
 
-## 2024 Roadmap
-
-![CDM Derivatives Roadmap](/img/dpbe-roadmap.png)
-
 ## Subscribe
 
 To subscribe to the [CDM Derivatives mailing list](https://lists.finos.org/g/cdm-derivatives-wg) and stay updated on meetings and agenda, please send an email to [cdm-derivatives-wg+subscribe@lists.finos.org](mailto:cdm-derivatives-wg+subscribe@lists.finos.org). After sending the email, you will receive a confirmation message. Reply to confirm your subscription.
 
 ---
 
-To view meeting notes and agendas, view our [current](https://github.com/finos/common-domain-model/issues?q=is%3Aissue+is%3Aopen+%22CDM+Contribution+Review+Working+Group%22) and [past](https://github.com/finos/common-domain-model/issues?q=is%3Aissue+%22CDM+Derivatives+Products+and+Business+Events+Working+Group%22+is%3Aclosed) GitHub Meeting Issues. 
+To view the work of the Derivatives Working Group—both current and past—please visit our [Derivatives WG GitHub project](https://github.com/orgs/finos/projects/112/views/1).
 
 Click [here](working-groups.md) to return back to the Working Groups home page.


### PR DESCRIPTION
Took out outdated photo of the 2024 roadmap and added a link to the WG github project. 