### PR TITLE
Update use-cases.md

### DIFF
--- a/website/versioned_docs/version-6.0.0/use-cases.md
+++ b/website/versioned_docs/version-6.0.0/use-cases.md
@@ -21,6 +21,15 @@ haircut.
 
 Please see [Eligible Collateral Representation](/docs/eligible-collateral-representation) for more details.
 
+## Standardized Schedule Method for Initial Margin Calculation
+
+Standardized Schedule Method for Initial Margin Calculation is a simplified 
+approach to determine the required initial margin for derivatives transactions, 
+it assigns predefined margin rates to different asset classes based on their risk 
+and volatility, facilitating regulatory compliance.
+
+Please see [Standardized Functions](/docs/standardized-functions) for more details.
+
 ## Repurchase Agreement Representation
 
 Repurchase transactions and lifecycle events are represented in the CDM, with 


### PR DESCRIPTION
Documentation for the Standardized Schedule Method for Initial Margin calculation was added in version 5.13 and is now available in version 6.00.