### PR TITLE
CDM Documentation / Schemas - Navigation: Update link

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -119,7 +119,8 @@ module.exports = {
             },
             {
               label: 'Schemas',
-              href: 'https://github.com/finos/common-domain-model/schemas',
+//              href: 'https://github.com/finos/common-domain-model/schemas',
+              href: 'https://cdm.finos.org/schemas/',
             },
             {
               label: 'What Is The CDM?',


### PR DESCRIPTION
The footer link previously held the URL we had intended for schemas if served part of the repo, but this is not applicable for now, so we need to use the existing link to the schemas made available via the CDM microsite.
