### PR TITLE
[6.x.x] FpML Ingest - Fix Intent and event qualification

### DIFF
--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-processes.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-processes.json
@@ -31,8 +31,8 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex52-execution-advice-trade-partial-novation-C02-00.json",
     "assertions" : {
       "inputPathCount" : 103,
-      "outputPathCount" : 119,
-      "modelValidationFailures" : 6,
+      "outputPathCount" : 121,
+      "modelValidationFailures" : 5,
       "runtimeError" : false
     }
   }, {
@@ -42,8 +42,8 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.json",
     "assertions" : {
       "inputPathCount" : 103,
-      "outputPathCount" : 119,
-      "modelValidationFailures" : 6,
+      "outputPathCount" : 121,
+      "modelValidationFailures" : 5,
       "runtimeError" : false
     }
   }, {
@@ -141,7 +141,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination.json",
     "assertions" : {
       "inputPathCount" : 141,
-      "outputPathCount" : 157,
+      "outputPathCount" : 156,
       "modelValidationFailures" : 3,
       "runtimeError" : false
     }
@@ -152,7 +152,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy.json",
     "assertions" : {
       "inputPathCount" : 130,
-      "outputPathCount" : 99,
+      "outputPathCount" : 98,
       "modelValidationFailures" : 5,
       "runtimeError" : false
     }
@@ -163,7 +163,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy-swap.json",
     "assertions" : {
       "inputPathCount" : 163,
-      "outputPathCount" : 173,
+      "outputPathCount" : 172,
       "modelValidationFailures" : 3,
       "runtimeError" : false
     }

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-13-incomplete-processes-execution-advice.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-13-incomplete-processes-execution-advice.json
@@ -9,8 +9,8 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex100-execution-advice-trs-partial-termination.json",
     "assertions" : {
       "inputPathCount" : 72,
-      "outputPathCount" : 40,
-      "modelValidationFailures" : 8,
+      "outputPathCount" : 39,
+      "modelValidationFailures" : 7,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-13-processes-execution-advice.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-13-processes-execution-advice.json
@@ -20,8 +20,8 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex52-execution-advice-trade-partial-novation-C02-00.json",
     "assertions" : {
       "inputPathCount" : 103,
-      "outputPathCount" : 119,
-      "modelValidationFailures" : 6,
+      "outputPathCount" : 121,
+      "modelValidationFailures" : 5,
       "runtimeError" : false
     }
   }, {
@@ -31,8 +31,8 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.json",
     "assertions" : {
       "inputPathCount" : 103,
-      "outputPathCount" : 119,
-      "modelValidationFailures" : 6,
+      "outputPathCount" : 121,
+      "modelValidationFailures" : 5,
       "runtimeError" : false
     }
   }, {
@@ -196,8 +196,8 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.json",
     "assertions" : {
       "inputPathCount" : 100,
-      "outputPathCount" : 97,
-      "modelValidationFailures" : 15,
+      "outputPathCount" : 95,
+      "modelValidationFailures" : 14,
       "runtimeError" : false
     }
   } ]

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex52-execution-advice-trade-partial-novation-C02-00.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex52-execution-advice-trade-partial-novation-C02-00.json
@@ -50,7 +50,7 @@
                   "globalKey" : "694c96e8"
                 }
               } ],
-              "direction" : "Decrease"
+              "direction" : "Replace"
             },
             "transfer" : {
               "transferState" : [ {
@@ -103,6 +103,21 @@
             }
           }, {
             "quantityChange" : {
+              "change" : [ {
+                "quantity" : [ {
+                  "value" : {
+                    "value" : 20000000.00,
+                    "unit" : {
+                      "currency" : {
+                        "value" : "USD"
+                      }
+                    }
+                  }
+                } ],
+                "meta" : {
+                  "globalKey" : "694c96e8"
+                }
+              } ],
               "direction" : "Decrease"
             }
           } ]
@@ -607,6 +622,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "ac599fd8"
+    "globalKey" : "c4b5f630"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.json
@@ -50,7 +50,7 @@
                   "globalKey" : "2ebbcc83"
                 }
               } ],
-              "direction" : "Decrease"
+              "direction" : "Replace"
             },
             "transfer" : {
               "transferState" : [ {
@@ -103,6 +103,21 @@
             }
           }, {
             "quantityChange" : {
+              "change" : [ {
+                "quantity" : [ {
+                  "value" : {
+                    "value" : 25000000.00,
+                    "unit" : {
+                      "currency" : {
+                        "value" : "USD"
+                      }
+                    }
+                  }
+                } ],
+                "meta" : {
+                  "globalKey" : "2ebbcc83"
+                }
+              } ],
               "direction" : "Decrease"
             }
           } ]
@@ -607,6 +622,6 @@
   } ],
   "action" : "Correct",
   "meta" : {
-    "globalKey" : "255d347d"
+    "globalKey" : "950e358a"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy-swap.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy-swap.json
@@ -1,6 +1,5 @@
 {
   "proposedEvent" : {
-    "intent" : "Clearing",
     "eventDate" : "2011-06-01",
     "effectiveDate" : "2011-06-03",
     "instruction" : [ {
@@ -880,6 +879,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "ef22ac50"
+    "globalKey" : "dc43a1b"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy.json
@@ -1,6 +1,5 @@
 {
   "proposedEvent" : {
-    "intent" : "Clearing",
     "eventDate" : "2011-06-01",
     "effectiveDate" : "2011-06-03",
     "instruction" : [ {
@@ -480,6 +479,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "93661cae"
+    "globalKey" : "e6b168f9"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination.json
@@ -1,6 +1,5 @@
 {
   "proposedEvent" : {
-    "intent" : "Clearing",
     "eventDate" : "2011-06-01",
     "effectiveDate" : "2011-06-03",
     "instruction" : [ {
@@ -787,6 +786,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "5b633a57"
+    "globalKey" : "e221aa22"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex100-execution-advice-trs-partial-termination.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex100-execution-advice-trs-partial-termination.json
@@ -4,9 +4,6 @@
     "effectiveDate" : "2013-04-04",
     "instruction" : [ {
       "primitiveInstruction" : {
-        "quantityChange" : {
-          "direction" : "Replace"
-        },
         "transfer" : {
           "transferState" : [ {
             "transfer" : {
@@ -190,6 +187,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "60fea23c"
+    "globalKey" : "19ef62a8"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex52-execution-advice-trade-partial-novation-C02-00.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex52-execution-advice-trade-partial-novation-C02-00.json
@@ -50,7 +50,7 @@
                   "globalKey" : "694c96e8"
                 }
               } ],
-              "direction" : "Decrease"
+              "direction" : "Replace"
             },
             "transfer" : {
               "transferState" : [ {
@@ -103,6 +103,21 @@
             }
           }, {
             "quantityChange" : {
+              "change" : [ {
+                "quantity" : [ {
+                  "value" : {
+                    "value" : 20000000.00,
+                    "unit" : {
+                      "currency" : {
+                        "value" : "USD"
+                      }
+                    }
+                  }
+                } ],
+                "meta" : {
+                  "globalKey" : "694c96e8"
+                }
+              } ],
               "direction" : "Decrease"
             }
           } ]
@@ -607,6 +622,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "d39aa6b4"
+    "globalKey" : "ebf6fd0c"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.json
@@ -50,7 +50,7 @@
                   "globalKey" : "2ebbcc83"
                 }
               } ],
-              "direction" : "Decrease"
+              "direction" : "Replace"
             },
             "transfer" : {
               "transferState" : [ {
@@ -103,6 +103,21 @@
             }
           }, {
             "quantityChange" : {
+              "change" : [ {
+                "quantity" : [ {
+                  "value" : {
+                    "value" : 25000000.00,
+                    "unit" : {
+                      "currency" : {
+                        "value" : "USD"
+                      }
+                    }
+                  }
+                } ],
+                "meta" : {
+                  "globalKey" : "2ebbcc83"
+                }
+              } ],
               "direction" : "Decrease"
             }
           } ]
@@ -607,6 +622,6 @@
   } ],
   "action" : "Correct",
   "meta" : {
-    "globalKey" : "4c9e3b59"
+    "globalKey" : "bc4f3c66"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.json
@@ -1,13 +1,9 @@
 {
   "proposedEvent" : {
-    "intent" : "PortfolioRebalancing",
     "eventDate" : "2009-05-25",
     "effectiveDate" : "2009-05-25",
     "instruction" : [ {
       "primitiveInstruction" : {
-        "quantityChange" : {
-          "direction" : "Replace"
-        },
         "transfer" : {
           "transferState" : [ {
             "transfer" : {
@@ -461,6 +457,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "45cbaabf"
+    "globalKey" : "b971f21c"
   }
 }

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-message-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-message-func.rosetta
@@ -162,12 +162,12 @@ func MapClearingConfirmedToWorkflowStep:
     alias effectiveDate: GetEffectiveDate(empty, fpmlTermination, empty)
 
     alias intent:
-        GetIntent(
-                empty,
-                empty,
+        MapIntent(
+                fpmlTrade,
                 fpmlTradingEventsBaseModel -> tradingEventsBaseModelSequence -> originatingEvent,
                 fpmlClearingConfirmed -> clearingResultsModel -> clearingResultsModelSequence -> terminatingEvent,
-                fpmlTrade
+                empty,
+                empty
             )
 
     set workflowStep:
@@ -214,12 +214,12 @@ func MapExecutionAdviceToWorkflowStep:
             )
 
     alias intent:
-        GetIntent(
-                fpmlNovation,
-                fpmlAmendment,
+        MapIntent(
+                fpmlTrade,
                 fpmlExecutionAdvice -> tradingEventsBaseModel -> tradingEventsBaseModelSequence -> originatingEvent,
                 fpmlExecutionAdvice -> postTradeEventsBaseModel -> postTradeEventsBaseModelSequence -> terminatingEvent,
-                fpmlTrade
+                fpmlExecutionAdvice -> postTradeEventsBaseModel,
+                fpmlExecutionAdvice -> optionsEventsBaseModel
             )
 
     alias eventDate: GetEventDate(fpmlAmendment, fpmlTermination, fpmlNovation, fpmlTrade)
@@ -270,12 +270,12 @@ func MapExecutionAdviceRetractedToWorkflowStep:
             )
 
     alias intent:
-        GetIntent(
-                fpmlNovation,
-                fpmlAmendment,
+        MapIntent(
+                fpmlTrade,
                 fpmlExecutionAdviceRetracted -> tradingEventsBaseModel -> tradingEventsBaseModelSequence -> originatingEvent,
                 fpmlExecutionAdviceRetracted -> postTradeEventsBaseModel -> postTradeEventsBaseModelSequence -> terminatingEvent,
-                fpmlTrade
+                fpmlExecutionAdviceRetracted -> postTradeEventsBaseModel,
+                fpmlExecutionAdviceRetracted -> optionsEventsBaseModel
             )
 
     alias eventDate: GetEventDate(fpmlAmendment, fpmlTermination, fpmlNovation, fpmlTrade)
@@ -315,12 +315,12 @@ func MapExecutionNotificationToWorkflowStep:
     alias action: MapMessageAction(fpmlExecutionNotification -> isCorrection, empty)
 
     alias intent:
-        GetIntent(
-                empty,
-                empty,
+        MapIntent(
+                fpmlTrade,
                 fpmlExecutionNotification -> tradingEventsBaseModel -> tradingEventsBaseModelSequence -> originatingEvent,
                 empty,
-                fpmlTrade
+                empty,
+                fpmlExecutionNotification -> optionsEventsBaseModel
             )
 
     alias eventDate: GetEventDate(empty, empty, empty, fpmlTrade)
@@ -357,12 +357,12 @@ func MapRequestClearingToWorkflowStep:
                 empty
             )
     alias intent:
-        GetIntent(
-                empty,
-                empty,
+        MapIntent(
+                fpmlTrade,
                 fpmlRequestClearing -> tradingEventsModel -> tradingEventsBaseModel -> tradingEventsBaseModelSequence -> originatingEvent,
                 empty,
-                fpmlTrade
+                empty,
+                empty
             )
 
     alias eventDate: GetEventDate(empty, empty, empty, fpmlTrade)
@@ -394,7 +394,7 @@ func MapTradeChangeAdviceToWorkflowStep:
 
     alias fpmlTrade: fpmlTradeChangeAdvice -> change -> trade
 
-    alias intent: GetIntent(empty, empty, empty, empty, fpmlTrade)
+    alias intent: MapIntent(fpmlTrade, empty, empty, empty, empty)
 
     alias eventDate: GetEventDate(empty, empty, empty, fpmlTrade)
     alias effectiveDate: GetEffectiveDate(empty, empty, empty)

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-workflowstep-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-workflowstep-func.rosetta
@@ -208,63 +208,60 @@ func MapBreakdown:
         fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmountsOldModel -> novationAmountsOldModelSequence0 -> novatedAmount
     alias changeInNotionalAmount:
         fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmount -> tradeLegNotionalChangeModel -> changeInNotionalAmount
+    alias newTradeAmount:
+        changeInNotionalAmount
+            extract MapNonNegativeMoneyNonNegativeQuantitySchedule
+            then default novatedAmount extract MapMoneyToNonNegativeQuantitySchedule
     alias outstandingNotionalAmount:
         fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmount -> tradeLegNotionalChangeModel -> outstandingNotionalAmount
     alias remainingAmount:
         fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmountsOldModel -> novationAmountsOldModelSequence0 -> remainingAmount
-
-    alias changeInstruction:
-        if outstandingNotionalAmount exists or remainingAmount exists
-        then QuantityChangeDirectionEnum -> Replace
-        else Decrease
-    alias changeAmount:
-        if outstandingNotionalAmount exists
-        then outstandingNotionalAmount
-        else if remainingAmount exists
-        then remainingAmount default novatedAmount
-
-    add breakdown:
-        PrimitiveInstruction {
-            quantityChange:
-                QuantityChangeInstruction {
-                    change:
-                        PriceQuantity {
-                            quantity: changeInNotionalAmount
-                                    extract MapNonNegativeMoneyNonNegativeQuantitySchedule
-                                    then default novatedAmount
-                                            extract MapMoneyToNonNegativeQuantitySchedule
-                            ,
-                            ...
-                        },
-                    direction: changeInstruction,
-                    ...
-                },
-            partyChange: MapPartyChangeInstruction(fpmlPostTradeEventsBaseModel),
-            transfer: MapTransferInstruction(
-                        fpmlPostTradeEventsBaseModel -> novation -> payment,
-                        Novation
-                    ),
-            ...
-        }
+    alias oldTradeAmount:
+        outstandingNotionalAmount
+            extract MapNonNegativeMoneyNonNegativeQuantitySchedule
+            then default remainingAmount extract MapMoneyToNonNegativeQuantitySchedule
+    alias partyChange: MapPartyChangeInstruction(fpmlPostTradeEventsBaseModel)
+    alias transfer:
+        MapTransferInstruction(
+                fpmlPostTradeEventsBaseModel -> novation -> payment,
+                Novation
+            )
 
     add breakdown:
-        PrimitiveInstruction {
-            quantityChange:
-                QuantityChangeInstruction {
-                    change:
-                        PriceQuantity {
-                            quantity: outstandingNotionalAmount
-                                    extract MapNonNegativeMoneyNonNegativeQuantitySchedule
-                                    then default remainingAmount
-                                            extract MapMoneyToNonNegativeQuantitySchedule
-                            ,
-                            ...
-                        },
-                    direction: changeInstruction,
-                    ...
-                },
-            ...
-        }
+        if newTradeAmount exists
+        then PrimitiveInstruction {
+                quantityChange:
+                    QuantityChangeInstruction {
+                        change:
+                            PriceQuantity {
+                                quantity: newTradeAmount,
+                                ...
+                            },
+                        direction: Replace,
+                        ...
+                    },
+                partyChange: partyChange,
+                transfer: transfer,
+                ...
+            }
+
+    add breakdown:
+        if oldTradeAmount exists or newTradeAmount exists
+        then PrimitiveInstruction {
+                quantityChange:
+                    QuantityChangeInstruction {
+                        change:
+                            PriceQuantity {
+                                quantity: oldTradeAmount default newTradeAmount,
+                                ...
+                            },
+                        direction: if oldTradeAmount exists
+                                then Replace
+                            else Decrease,
+                        ...
+                    },
+                ...
+            }
 
 func MapPartyChangeInstruction:
     inputs:
@@ -348,11 +345,12 @@ func MapQuantityChangeInstruction:
     alias changeAmount:
         MapPriceQuantity(fpmlTradeNotionalChange, fpmlPostTradeEventsBaseModel)
     set quantityChange:
-        QuantityChangeInstruction {
-            change: changeAmount,
-            direction: quantityChangeDirection,
-            ...
-        }
+        if changeAmount exists
+        then QuantityChangeInstruction {
+                change: changeAmount,
+                direction: quantityChangeDirection,
+                ...
+            }
 
 func MapPriceQuantity:
     inputs:
@@ -453,79 +451,58 @@ func MapMessageInformation:
             ...
         }
 
-func GetIntent:
+func MapIntent:
     inputs:
-        fpmlNovation fpml.TradeNovationContent (0..1)
-        fpmlAmendment fpml.TradeAmendmentContent (0..1)
-        fpmlOriginatingEvent fpml.OriginatingEvent (0..1)
-        fpmlTerminatingEvent fpml.TerminatingEvent (0..1)
         fpmlTrade fpml.Trade (0..1)
-    output:
-        intent EventIntentEnum (0..1)
-
-    alias intentToAllocate:
-        (fpmlTrade -> tradeHeader -> partyTradeInformation
-            filter intentToAllocate = True
-            )
-            then exists
-    alias intentToClear:
-        (fpmlTrade -> tradeHeader -> partyTradeInformation
-            filter intentToClear = True
-            )
-            then exists
-
-    set intent:
-        if intentToAllocate
-        then Allocation
-        else if intentToClear
-        then Clearing
-        else if fpmlNovation exists
-        then Novation
-        else if fpmlAmendment exists
-        then ContractTermsAmendment
-        else if MapOriginatingEventToIntent(fpmlOriginatingEvent) exists
-        then MapOriginatingEventToIntent(fpmlOriginatingEvent)
-        else if MapTerminatingEventToIntent(fpmlTerminatingEvent) exists
-        then MapTerminatingEventToIntent(fpmlTerminatingEvent)
-        else if fpmlTrade exists
-        then ContractFormation
-
-func MapOriginatingEventToIntent:
-    inputs:
         fpmlOriginatingEvent fpml.OriginatingEvent (0..1)
-    output:
-        intent EventIntentEnum (0..1)
-
-    alias originatingEventValue: fpmlOriginatingEvent -> value to-string
-
-    set intent:
-        originatingEventValue switch
-            "Allocation" then Allocation,
-            "Netting" then Compression,
-            "PortfolioCompression" then Compression,
-            "CreditEvent" then CreditEvent,
-            "Novation" then Novation,
-            "Exercise" then OptionExercise,
-            "PortfolioRebalancing" then PortfolioRebalancing,
-            "ForwardAgainstFixing" then ContractFormation,
-            "Trade" then ContractFormation,
-            default empty
-
-func MapTerminatingEventToIntent:
-    inputs:
         fpmlTerminatingEvent fpml.TerminatingEvent (0..1)
+        fpmlPostTradeEventsBaseModel fpml.PostTradeEventsBaseModel (0..1)
+        fpmlOptionsEventsBaseModel fpml.OptionsEventsBaseModel (0..1)
     output:
         intent EventIntentEnum (0..1)
 
-    alias terminatingEventValue: fpmlTerminatingEvent -> value to-string
+    alias partyTradeInformation: fpmlTrade -> tradeHeader -> partyTradeInformation
+
+    alias clearing:
+        fpmlTrade
+            extract tradeHeader -> partyTradeInformation
+            then filter intentToClear = True
+
+    alias intentToAllocate: partyTradeInformation extract intentToAllocate = True
+    alias postAllocation:
+        partyTradeInformation extract allocationStatus -> value = "PostAllocation"
 
     set intent:
-        terminatingEventValue switch
-            "Allocation" then Allocation,
-            "Netting" then Compression,
-            "PortfolioCompression" then Compression,
-            "PortfolioRebalancing" then PortfolioRebalancing,
-            default empty
+        if fpmlOriginatingEvent -> value = "Novation"
+                or fpmlPostTradeEventsBaseModel -> novation exists
+        then Novation
+        else if fpmlPostTradeEventsBaseModel -> postTradeEventsBaseModelSequence -> termination exists
+        then empty
+        else if fpmlOriginatingEvent -> value = "Netting"
+                or fpmlOriginatingEvent -> value = "PortfolioCompression"
+                or fpmlTerminatingEvent -> value = "PortfolioCompression"
+                or fpmlTerminatingEvent -> value = "Netting"
+        then Compression
+        else if postAllocation first and intentToAllocate exists
+                or fpmlOriginatingEvent -> value = "Allocation"
+                or fpmlTerminatingEvent -> value = "Allocation"
+        then Allocation
+        else if fpmlOriginatingEvent -> value = "PortfolioRebalancing"
+                or fpmlTerminatingEvent -> value = "PortfolioRebalancing"
+        then PortfolioRebalancing
+        else if fpmlOptionsEventsBaseModel -> optionExercise exists
+                or fpmlOriginatingEvent -> value = "Exercise"
+        then OptionExercise
+        else if fpmlPostTradeEventsBaseModel -> amendment exists
+        then ContractTermsAmendment
+        else if clearing exists
+        then Clearing
+        else if fpmlOriginatingEvent -> value = "CreditEvent"
+        then CreditEvent
+        else if fpmlOriginatingEvent -> value = "Trade"
+                or fpmlOriginatingEvent -> value = "ForwardAgainstFixing"
+                or fpmlTrade exists
+        then ContractFormation
 
 func GetEventDate:
     inputs:

--- a/tests/src/test/resources/ingest/diagnostics/product_diagnostics.md
+++ b/tests/src/test/resources/ingest/diagnostics/product_diagnostics.md
@@ -28,8 +28,8 @@
 | swaption | 25 | 98% |
 | bondOption | 12 | 98% |
 | commodityPerformanceSwap | 8 | 98% |
-| fxSingleLeg | 27 | 98% |
 | returnSwap | 36 | 98% |
+| fxSingleLeg | 27 | 98% |
 | correlationSwap | 8 | 97% |
 | creditDefaultSwapOption | 18 | 97% |
 | equityOption | 37 | 97% |

--- a/tests/src/test/resources/ingest/diagnostics/test_pack_diagnostics.md
+++ b/tests/src/test/resources/ingest/diagnostics/test_pack_diagnostics.md
@@ -4,10 +4,10 @@
 |:-----------------------------------------------------|:-------:|:-------:|
 | fpml-5-13-incomplete-processes-execution-advice | 3 | 270% |
 | fpml-5-10-incomplete-processes | 11 | 121% |
-| fpml-5-13-processes-execution-advice | 14 | 106% |
+| fpml-5-13-processes-execution-advice | 14 | 107% |
+| fpml-5-10-processes | 15 | 106% |
 | fpml-5-13-incomplete-products-repo | 2 | 106% |
 | fpml-5-12-products-repo | 2 | 106% |
-| fpml-5-10-processes | 15 | 106% |
 | fpml-5-13-incomplete-products-variance-swaps | 2 | 103% |
 | fpml-5-12-incomplete-products-equity | 1 | 100% |
 | fpml-5-10-incomplete-products-securities | 2 | 100% |

--- a/tests/src/test/resources/ingest/diagnostics/test_pack_product_diagnostics.md
+++ b/tests/src/test/resources/ingest/diagnostics/test_pack_product_diagnostics.md
@@ -101,7 +101,7 @@
 | fpml-5-13-incomplete-products-repo | securityLending | 2 | 106% |
 | fpml-5-13-incomplete-products-variance-swaps | varianceSwap | 2 | 103% |
 | fpml-5-13-processes-execution-advice | commoditySwap | 6 | 117% |
-| fpml-5-13-processes-execution-advice | creditDefaultSwap | 6 | 100% |
+| fpml-5-13-processes-execution-advice | creditDefaultSwap | 6 | 101% |
 | fpml-5-13-processes-execution-advice | swap | 2 | 103% |
 | fpml-5-13-products-bond-options | bondOption | 4 | 99% |
 | fpml-5-13-products-commodity-derivatives | commodityOption | 11 | 94% |

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex52-execution-advice-trade-partial-novation-C02-00.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex52-execution-advice-trade-partial-novation-C02-00.diff
@@ -4,23 +4,7 @@
 +                "issuerReference" : {
 +                  "externalReference" : "_fund"
 +                },
-@@ -42,1 +45,1 @@
--              "direction" : "Replace"
-+              "direction" : "Decrease"
-@@ -89,12 +92,0 @@
--              "change" : [ {
--                "quantity" : [ {
--                  "value" : {
--                    "value" : 20000000.00,
--                    "unit" : {
--                      "currency" : {
--                        "value" : "USD"
--                      }
--                    }
--                  }
--                } ]
--              } ],
-@@ -183,19 +174,0 @@
+@@ -183,19 +186,0 @@
 -                          },
 -                          "primaryObligor" : {
 -                            "entityId" : [ {
@@ -40,7 +24,7 @@
 -                                }
 -                              }
 -                            } ]
-@@ -226,3 +198,0 @@
+@@ -226,3 +210,0 @@
 -                      },
 -                      "meta" : {
 -                        "externalKey" : "calculationAmount"

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.diff
@@ -4,23 +4,7 @@
 +                "issuerReference" : {
 +                  "externalReference" : "_fund"
 +                },
-@@ -42,1 +45,1 @@
--              "direction" : "Replace"
-+              "direction" : "Decrease"
-@@ -89,12 +92,0 @@
--              "change" : [ {
--                "quantity" : [ {
--                  "value" : {
--                    "value" : 25000000.00,
--                    "unit" : {
--                      "currency" : {
--                        "value" : "USD"
--                      }
--                    }
--                  }
--                } ]
--              } ],
-@@ -183,19 +174,0 @@
+@@ -183,19 +186,0 @@
 -                          },
 -                          "primaryObligor" : {
 -                            "entityId" : [ {
@@ -40,7 +24,7 @@
 -                                }
 -                              }
 -                            } ]
-@@ -226,3 +198,0 @@
+@@ -226,3 +210,0 @@
 -                      },
 -                      "meta" : {
 -                        "externalKey" : "calculationAmount"

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy-swap.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy-swap.diff
@@ -1,23 +1,21 @@
 --- rosetta-source/src/main/resources/result-json-files/fpml-5-10/processes/msg-partial-termination-xccy-swap.json
 +++ rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy-swap.json
-@@ -3,0 +3,1 @@
-+    "intent" : "Clearing",
-@@ -21,1 +22,1 @@
+@@ -21,1 +21,1 @@
 -                  "value" : "quantity-2"
 +                  "value" : "quantity-1"
-@@ -181,3 +182,0 @@
+@@ -181,3 +181,0 @@
 -                      },
 -                      "meta" : {
 -                        "externalKey" : "notl1"
-@@ -313,3 +311,0 @@
+@@ -313,3 +310,0 @@
 -                      },
 -                      "meta" : {
 -                        "externalKey" : "notl2"
-@@ -427,0 +422,1 @@
+@@ -427,0 +421,1 @@
 +                            "assetClass" : "InterestRate",
-@@ -551,1 +547,0 @@
+@@ -551,1 +546,0 @@
 -                "firstName" : "jjone",
-@@ -556,0 +551,8 @@
+@@ -556,0 +550,8 @@
 +              "personRole" : [ {
 +                "personReference" : {
 +                  "externalReference" : "trader"
@@ -26,10 +24,10 @@
 +                  "value" : "Trader"
 +                } ]
 +              } ],
-@@ -630,0 +633,3 @@
+@@ -630,0 +632,3 @@
 +  "nextEvent" : {
 +    "intent" : "Clearing"
 +  },
-@@ -648,1 +654,1 @@
+@@ -648,1 +653,1 @@
 -    "dateTime" : "2011-06-01T10:12:34Z",
 +    "dateTime" : "2011-02-04T16:20:47Z",

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy.diff
@@ -1,22 +1,20 @@
 --- rosetta-source/src/main/resources/result-json-files/fpml-5-10/processes/msg-partial-termination-xccy.json
 +++ rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy.json
-@@ -3,0 +3,1 @@
-+    "intent" : "Clearing",
-@@ -21,1 +22,1 @@
+@@ -21,1 +21,1 @@
 -                  "value" : "quantity-2"
 +                  "value" : "quantity-1"
-@@ -105,1 +106,1 @@
+@@ -105,1 +105,1 @@
 -                          "value" : "quantity-2"
 +                          "value" : "quantity-1"
-@@ -169,1 +170,1 @@
+@@ -169,1 +169,1 @@
 -                      "value" : "quantity-2"
 +                      "value" : "quantity-1"
-@@ -184,1 +185,1 @@
+@@ -184,1 +184,1 @@
 -                      "value" : "quantity-1"
 +                      "value" : "quantity-2"
-@@ -268,1 +269,0 @@
+@@ -268,1 +268,0 @@
 -                "firstName" : "jjone",
-@@ -273,0 +273,8 @@
+@@ -273,0 +272,8 @@
 +              "personRole" : [ {
 +                "personReference" : {
 +                  "externalReference" : "trader"
@@ -25,10 +23,10 @@
 +                  "value" : "Trader"
 +                } ]
 +              } ],
-@@ -363,0 +371,3 @@
+@@ -363,0 +370,3 @@
 +  "nextEvent" : {
 +    "intent" : "Clearing"
 +  },
-@@ -381,1 +392,1 @@
+@@ -381,1 +391,1 @@
 -    "dateTime" : "2011-06-01T10:12:34Z",
 +    "dateTime" : "2011-02-04T16:20:47Z",

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination.diff
@@ -1,12 +1,10 @@
 --- rosetta-source/src/main/resources/result-json-files/fpml-5-10/processes/msg-partial-termination.json
 +++ rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination.json
-@@ -3,0 +3,1 @@
-+    "intent" : "Clearing",
-@@ -341,0 +342,1 @@
+@@ -341,0 +341,1 @@
 +                            "assetClass" : "InterestRate",
-@@ -474,1 +476,0 @@
+@@ -474,1 +475,0 @@
 -                "firstName" : "jjone",
-@@ -479,0 +480,8 @@
+@@ -479,0 +479,8 @@
 +              "personRole" : [ {
 +                "personReference" : {
 +                  "externalReference" : "trader"
@@ -15,10 +13,10 @@
 +                  "value" : "Trader"
 +                } ]
 +              } ],
-@@ -553,0 +562,3 @@
+@@ -553,0 +561,3 @@
 +  "nextEvent" : {
 +    "intent" : "Clearing"
 +  },
-@@ -571,1 +583,1 @@
+@@ -571,1 +582,1 @@
 -    "dateTime" : "2011-06-01T10:12:34Z",
 +    "dateTime" : "2011-02-04T16:20:47Z",

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex100-execution-advice-trs-partial-termination.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex100-execution-advice-trs-partial-termination.diff
@@ -1,10 +1,14 @@
 --- rosetta-source/src/main/resources/result-json-files/fpml-5-13/incomplete-processes/execution-advice/msg-ex100-execution-advice-trs-partial-termination.json
 +++ rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex100-execution-advice-trs-partial-termination.json
-@@ -47,0 +47,3 @@
+@@ -7,3 +7,0 @@
+-        "quantityChange" : {
+-          "direction" : "Replace"
+-        },
+@@ -47,0 +44,3 @@
 +            },
 +            "meta" : {
 +              "externalKey" : "TERMINATION_FEE"
-@@ -140,1 +143,4 @@
+@@ -140,1 +140,4 @@
 -      "value" : "ORIGUS33XXX"
 +      "value" : "ORIGUS33XXX",
 +      "meta" : {

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex52-execution-advice-trade-partial-novation-C02-00.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex52-execution-advice-trade-partial-novation-C02-00.diff
@@ -4,26 +4,10 @@
 +                "issuerReference" : {
 +                  "externalReference" : "_fund"
 +                },
-@@ -42,1 +45,1 @@
--              "direction" : "Replace"
-+              "direction" : "Decrease"
-@@ -89,12 +92,0 @@
--              "change" : [ {
--                "quantity" : [ {
--                  "value" : {
--                    "value" : 20000000.00,
--                    "unit" : {
--                      "currency" : {
--                        "value" : "USD"
--                      }
--                    }
--                  }
--                } ]
--              } ],
-@@ -168,1 +159,1 @@
+@@ -168,1 +171,1 @@
 -                            "identifierType" : "REDID"
 +                            "identifierType" : "Other"
-@@ -183,19 +174,0 @@
+@@ -183,19 +186,0 @@
 -                          },
 -                          "primaryObligor" : {
 -                            "entityId" : [ {
@@ -43,7 +27,7 @@
 -                                }
 -                              }
 -                            } ]
-@@ -226,3 +198,0 @@
+@@ -226,3 +210,0 @@
 -                      },
 -                      "meta" : {
 -                        "externalKey" : "calculationAmount"

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.diff
@@ -4,26 +4,10 @@
 +                "issuerReference" : {
 +                  "externalReference" : "_fund"
 +                },
-@@ -42,1 +45,1 @@
--              "direction" : "Replace"
-+              "direction" : "Decrease"
-@@ -89,12 +92,0 @@
--              "change" : [ {
--                "quantity" : [ {
--                  "value" : {
--                    "value" : 25000000.00,
--                    "unit" : {
--                      "currency" : {
--                        "value" : "USD"
--                      }
--                    }
--                  }
--                } ]
--              } ],
-@@ -168,1 +159,1 @@
+@@ -168,1 +171,1 @@
 -                            "identifierType" : "REDID"
 +                            "identifierType" : "Other"
-@@ -183,19 +174,0 @@
+@@ -183,19 +186,0 @@
 -                          },
 -                          "primaryObligor" : {
 -                            "entityId" : [ {
@@ -43,7 +27,7 @@
 -                                }
 -                              }
 -                            } ]
-@@ -226,3 +198,0 @@
+@@ -226,3 +210,0 @@
 -                      },
 -                      "meta" : {
 -                        "externalKey" : "calculationAmount"

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.diff
@@ -1,28 +1,34 @@
 --- rosetta-source/src/main/resources/result-json-files/fpml-5-13/processes/execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.json
 +++ rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.json
-@@ -48,0 +48,3 @@
+@@ -3,1 +3,0 @@
+-    "intent" : "PortfolioRebalancing",
+@@ -8,3 +7,0 @@
+-        "quantityChange" : {
+-          "direction" : "Replace"
+-        },
+@@ -48,0 +44,3 @@
 +            },
 +            "meta" : {
 +              "externalKey" : "TERMINATION_FEE"
-@@ -99,2 +102,2 @@
+@@ -99,2 +98,2 @@
 -                      "payer" : "Party1",
 -                      "receiver" : "Party2"
 +                      "payer" : "Party2",
 +                      "receiver" : "Party1"
-@@ -103,0 +106,1 @@
+@@ -103,0 +102,1 @@
 +                      "settlementType" : "Cash",
-@@ -117,1 +121,1 @@
+@@ -117,1 +117,1 @@
 -                          "value" : "observable-2"
 +                          "value" : "observable-1"
-@@ -125,2 +129,2 @@
+@@ -125,2 +125,2 @@
 -                      "payer" : "Party2",
 -                      "receiver" : "Party1"
 +                      "payer" : "Party1",
 +                      "receiver" : "Party2"
-@@ -132,1 +136,1 @@
+@@ -132,1 +132,1 @@
 -                          "value" : "observable-1"
 +                          "value" : "observable-2"
-@@ -142,0 +146,12 @@
+@@ -142,0 +142,12 @@
 +                "price" : [ {
 +                  "value" : {
 +                    "priceType" : "AssetPrice",
@@ -35,7 +41,7 @@
 +                    } ]
 +                  }
 +                } ],
-@@ -146,0 +162,25 @@
+@@ -146,0 +158,25 @@
 +                        "identifier" : [ {
 +                          "identifier" : {
 +                            "value" : "OIL-WTI-NYMEX",
@@ -61,7 +67,7 @@
 +                  "value" : {
 +                    "Asset" : {
 +                      "Commodity" : {
-@@ -181,25 +222,0 @@
+@@ -181,25 +218,0 @@
 -                      "value" : "observable-1"
 -                    } ]
 -                  }
@@ -87,13 +93,13 @@
 -                  "meta" : {
 -                    "location" : [ {
 -                      "scope" : "DOCUMENT",
-@@ -215,1 +231,1 @@
+@@ -215,1 +227,1 @@
 -                "externalReference" : "partyB"
 +                "externalReference" : "partyA"
-@@ -220,1 +236,1 @@
+@@ -220,1 +232,1 @@
 -                "externalReference" : "partyA"
 +                "externalReference" : "partyB"
-@@ -284,0 +300,8 @@
+@@ -284,0 +296,8 @@
 +            "partyRole" : [ {
 +              "partyReference" : {
 +                "externalReference" : "partyA"
@@ -102,19 +108,19 @@
 +                "externalReference" : "partyA"
 +              }
 +            } ],
-@@ -295,2 +319,0 @@
+@@ -295,2 +315,0 @@
 -                  "externalReference" : "partyB"
 -                }, {
-@@ -298,0 +320,2 @@
+@@ -298,0 +316,2 @@
 +                }, {
 +                  "externalReference" : "partyB"
-@@ -309,2 +333,0 @@
+@@ -309,2 +329,0 @@
 -                  "externalReference" : "partyB"
 -                }, {
-@@ -312,0 +334,2 @@
+@@ -312,0 +330,2 @@
 +                }, {
 +                  "externalReference" : "partyB"
-@@ -328,1 +352,4 @@
+@@ -328,1 +348,4 @@
 -      "value" : "ORIGUS33XXX"
 +      "value" : "ORIGUS33XXX",
 +      "meta" : {


### PR DESCRIPTION
# *Ingestion Framework for FpML - Improve Mapping Coverage*

_Background_

FpML to CDM mapping functions were contributed to CDM 7-dev as part of https://github.com/finos/common-domain-model/issues/3836.

During the DRR upgrade to CDM, several gaps were identified between the legacy synonym mappings and the ingest functions. Further details are documented in issue [#4640](https://github.com/finos/common-domain-model/issues/4640).

_What is being released?_

- Updating the FpML to CDM mapping functions related to mapping of Event Intent and Event Qualification to be more inline with synonym mappings, and bringing up the percentage completeness from [#4260](https://github.com/finos/common-domain-model/issues/4260).

_Review directions_

Changes can be reviewed in PR: https://github.com/finos/common-domain-model/pull/4699