### PR TITLE
[7-dev] Fix duplicate compilation in CDM builds 

### DIFF
--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -60,6 +60,30 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <additionalJOption>${maven-javadoc-plugin.option}</additionalJOption>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+
     <build>
         <plugins>
             <plugin>
@@ -90,24 +114,6 @@
                   </execution>
               </executions>
           </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <additionalJOption>${maven-javadoc-plugin.option}</additionalJOption>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -159,13 +159,13 @@
                         <artifactId>maven-source-plugin</artifactId>
                         <executions>
                             <execution>
-                                <id>attach-sources</id>
-                                <phase>none</phase> <!-- Disable this execution -->
+                                <id>default</id>
+                                <phase>none</phase>
                             </execution>
                             <execution>
-                                <id>default</id>
+                                <id>attach-sources</id>
                                 <goals>
-                                    <goal>jar</goal>
+                                    <goal>jar-no-fork</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/rosetta-source/pom.xml
+++ b/rosetta-source/pom.xml
@@ -18,6 +18,50 @@
 
     <profiles>
         <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default</id>
+                                <phase>none</phase>
+                            </execution>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <configuration>
+                            <sourcepath>
+                                ${project.build.sourceDirectory}:${project.basedir}/src/generated/java
+                            </sourcepath>
+                            <notimestamp>true</notimestamp>
+                            <quiet>true</quiet>
+                            <additionalJOption>${maven-javadoc-plugin.option}</additionalJOption>
+                            <maxmemory>2g</maxmemory>
+                            <excludePackageNames>fpml.*:cdm.ingest.*:cdm.mapping.*</excludePackageNames>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
             <id>format</id>
             <build>
                 <plugins>
@@ -1032,53 +1076,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>compile</id>
-                        <phase>compile</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                    </execution>
-                    <execution>
-                        <id>testCompile</id>
-                        <phase>test-compile</phase>
-                        <goals>
-                            <goal>testCompile</goal>
-                        </goals>
-                    </execution>
-                </executions>
                 <configuration>
                     <release>${maven.compiler.release}</release>
                     <excludes>
                         <exclude>**/*.rosetta</exclude>
                     </excludes><source>8</source><target>8</target>
                 </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <configuration>
-                    <sourcepath>
-                        ${project.build.sourceDirectory}:${project.basedir}/src/generated/java
-                    </sourcepath>
-                    <notimestamp>true</notimestamp>
-                    <quiet>true</quiet>
-                    <additionalJOption>${maven-javadoc-plugin.option}</additionalJOption>
-                    <maxmemory>2g</maxmemory>
-                    <excludePackageNames>fpml.*:cdm.ingest.*:cdm.mapping.*</excludePackageNames>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
4717: Made build improvements to remove duplicate compilation of the rosetta sources and preventing javadoc generation for each build, should only happen on release with profile