### PR TITLE
Update to DSL 10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,8 +82,8 @@
         <maven.compiler.release>11</maven.compiler.release>
 
         <rune-fpml.version>1.5.3</rune-fpml.version>
-        <rosetta.dsl.version>9.78.0</rosetta.dsl.version>
-        <rosetta.bundle.version>11.119.1</rosetta.bundle.version>
+        <rosetta.dsl.version>10.0.0-dev.8</rosetta.dsl.version>
+        <rosetta.bundle.version>12.0.0-dev.6</rosetta.bundle.version>
         <rosetta.code-gen.version>${rosetta.bundle.version}</rosetta.code-gen.version>
 
         <xtext.version>2.38.0</xtext.version>
@@ -241,8 +241,8 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>com.regnosys.rosetta</groupId>
-                    <artifactId>rosetta-maven-plugin</artifactId>
+                    <groupId>org.finos.rune</groupId>
+                    <artifactId>rune-maven-plugin</artifactId>
                     <version>${rosetta.dsl.version}</version>
                     <dependencies>
                         <dependency>
@@ -251,13 +251,13 @@
                             <version>${rosetta.code-gen.version}</version>
                         </dependency>
                         <dependency>
-                            <groupId>com.regnosys.rosetta</groupId>
-                            <artifactId>com.regnosys.rosetta</artifactId>
+                            <groupId>org.finos.rune</groupId>
+                            <artifactId>rune-lang</artifactId>
                             <version>${rosetta.dsl.version}</version>
                         </dependency>
                         <dependency>
-                            <groupId>com.regnosys.rosetta</groupId>
-                            <artifactId>com.regnosys.rosetta.lib</artifactId>
+                            <groupId>org.finos.rune</groupId>
+                            <artifactId>rune-runtime</artifactId>
                             <version>${rosetta.dsl.version}</version>
                         </dependency>
                     </dependencies>
@@ -356,8 +356,8 @@
                 <version>${rune-fpml.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta</artifactId>
+                <groupId>org.finos.rune</groupId>
+                <artifactId>rune-lang</artifactId>
                 <version>${rosetta.dsl.version}</version>
                 <exclusions>
                     <exclusion>
@@ -367,8 +367,8 @@
                 </exclusions>
             </dependency>
             <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>com.regnosys.rosetta.lib</artifactId>
+                <groupId>org.finos.rune</groupId>
+                <artifactId>rune-runtime</artifactId>
                 <version>${rosetta.dsl.version}</version>
             </dependency>
             <dependency>
@@ -498,8 +498,8 @@
             </dependency>
             <!-- plugins START -->
             <dependency>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>rosetta-maven-plugin</artifactId>
+                <groupId>org.finos.rune</groupId>
+                <artifactId>rune-maven-plugin</artifactId>
                 <version>${rosetta.dsl.version}</version>
             </dependency>
             <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
         <rune-fpml.version>1.5.3</rune-fpml.version>
         <rosetta.dsl.version>10.0.0-dev.8</rosetta.dsl.version>
-        <rosetta.bundle.version>12.0.0-dev.6</rosetta.bundle.version>
+        <rosetta.bundle.version>12.0.0-dev.9</rosetta.bundle.version>
         <rosetta.code-gen.version>${rosetta.bundle.version}</rosetta.code-gen.version>
 
         <xtext.version>2.38.0</xtext.version>

--- a/rosetta-source/pom.xml
+++ b/rosetta-source/pom.xml
@@ -22,8 +22,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.regnosys.rosetta</groupId>
-                        <artifactId>rosetta-maven-plugin</artifactId>
+                        <groupId>org.finos.rune</groupId>
+                        <artifactId>rune-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>format-rosetta</id>
@@ -112,8 +112,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.regnosys.rosetta</groupId>
-                        <artifactId>rosetta-maven-plugin</artifactId>
+                        <groupId>org.finos.rune</groupId>
+                        <artifactId>rune-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>generate-daml-src</id>
@@ -197,8 +197,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.regnosys.rosetta</groupId>
-                        <artifactId>rosetta-maven-plugin</artifactId>
+                        <groupId>org.finos.rune</groupId>
+                        <artifactId>rune-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>generate-typescript-src</id>
@@ -262,8 +262,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.regnosys.rosetta</groupId>
-                        <artifactId>rosetta-maven-plugin</artifactId>
+                        <groupId>org.finos.rune</groupId>
+                        <artifactId>rune-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>generate-scala-src</id>
@@ -345,8 +345,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.regnosys.rosetta</groupId>
-                        <artifactId>rosetta-maven-plugin</artifactId>
+                        <groupId>org.finos.rune</groupId>
+                        <artifactId>rune-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>generate-golang-src</id>
@@ -428,8 +428,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.regnosys.rosetta</groupId>
-                        <artifactId>rosetta-maven-plugin</artifactId>
+                        <groupId>org.finos.rune</groupId>
+                        <artifactId>rune-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>generate-csharp8-src</id>
@@ -527,8 +527,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.regnosys.rosetta</groupId>
-                        <artifactId>rosetta-maven-plugin</artifactId>
+                        <groupId>org.finos.rune</groupId>
+                        <artifactId>rune-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>generate-csharp9-src</id>
@@ -625,8 +625,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.regnosys.rosetta</groupId>
-                        <artifactId>rosetta-maven-plugin</artifactId>
+                        <groupId>org.finos.rune</groupId>
+                        <artifactId>rune-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>generate-kotlin-src</id>
@@ -707,8 +707,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.regnosys.rosetta</groupId>
-                        <artifactId>rosetta-maven-plugin</artifactId>
+                        <groupId>org.finos.rune</groupId>
+                        <artifactId>rune-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>generate-excel-src</id>
@@ -747,8 +747,8 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.regnosys.rosetta</groupId>
-                        <artifactId>rosetta-maven-plugin</artifactId>
+                        <groupId>org.finos.rune</groupId>
+                        <artifactId>rune-maven-plugin</artifactId>
                         <executions>
                             <execution>
                                 <id>generate-json-schema-src</id>
@@ -994,8 +994,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>com.regnosys.rosetta</groupId>
-                <artifactId>rosetta-maven-plugin</artifactId>
+                <groupId>org.finos.rune</groupId>
+                <artifactId>rune-maven-plugin</artifactId>
                 <executions>
                     <execution>
                         <id>default-cli</id>
@@ -1085,8 +1085,8 @@
 
     <dependencies>
         <dependency>
-            <groupId>com.regnosys.rosetta</groupId>
-            <artifactId>com.regnosys.rosetta.lib</artifactId>
+            <groupId>org.finos.rune</groupId>
+            <artifactId>rune-runtime</artifactId>
         </dependency>
         <dependency>
             <groupId>com.regnosys.rune-fpml</groupId>

--- a/rosetta-source/src/test/java/org/isda/cdm/functions/ModelClassValidationTest.java
+++ b/rosetta-source/src/test/java/org/isda/cdm/functions/ModelClassValidationTest.java
@@ -5,12 +5,38 @@ import cdm.base.staticdata.party.PartyRoleEnum;
 import cdm.base.staticdata.party.metafields.ReferenceWithMetaParty;
 import cdm.event.common.Trade;
 import cdm.event.common.meta.TradeMeta;
+import com.google.inject.Guice;
+import com.google.inject.Injector;
 import com.rosetta.model.lib.validation.ValidationResult;
+import com.rosetta.model.lib.validation.ValidatorFactory;
+import org.finos.cdm.CdmRuntimeModule;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ModelClassValidationTest {
+	@Inject
+	ValidatorFactory validatorFactory;
+
+	private static Injector injector;
+
+	@BeforeAll
+	static void setUpOnce() {
+		injector = Guice.createInjector(new CdmRuntimeModule());
+	}
+
+	@BeforeEach
+	void setUp() {
+		injector.injectMembers(this);
+	}
 
 	@Test
 	void checkErrorMessages() {
@@ -26,13 +52,19 @@ public class ModelClassValidationTest {
                             .build())
                 .build();
 
-		ValidationResult<? super Trade> result = new TradeMeta().validator().validate(null, tradeState);
+		List<ValidationResult<?>> results = new TradeMeta().validator(validatorFactory).getValidationResults(null, tradeState);
+		String resultCombined = results.stream()
+				.map(ValidationResult::getFailureReason)
+				.filter(Optional::isPresent)
+				.map(Optional::get)
+				.collect(Collectors.joining("; "));
+
 		assertEquals("'product' is a required field but does not exist.; " +
 						"'tradeLot' is a required field but does not exist.; " +
 						"'counterparty' is a required field but does not exist.; " +
 						"'tradeIdentifier' is a required field but does not exist.; " +
 						"'tradeDate' is a required field but does not exist.",
-				result.getFailureReason().orElse("No error message"));
+				resultCombined);
 	}
 
 }

--- a/tests/src/test/java/org/finos/cdm/testpack/CdmTestPackCreator.java
+++ b/tests/src/test/java/org/finos/cdm/testpack/CdmTestPackCreator.java
@@ -1,10 +1,15 @@
 package org.finos.cdm.testpack;
 
+import cdm.event.common.TradeState;
+import cdm.event.workflow.WorkflowStep;
 import cdm.ingest.fpml.confirmation.message.functions.Ingest_FpmlConfirmationToTradeState;
 import cdm.ingest.fpml.confirmation.message.functions.Ingest_FpmlConfirmationToWorkflowStep;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.inject.Injector;
+import com.regnosys.rosetta.common.transform.PipelineModel;
 import com.regnosys.testing.TestingExpectationUtil;
+import fpml.consolidated.doc.Document;
 import org.finos.cdm.functions.FunctionCreator;
 import com.regnosys.rosetta.common.transform.TransformType;
 import com.regnosys.runefpml.RuneFpmlModelConfig;
@@ -80,10 +85,17 @@ public class CdmTestPackCreator {
         PipelineTestPackFilter filter = PipelineTestPackFilter.create()
                 .withTestPacksSpecificToFunctions(getEventsTestPackFilter());
 
+        ImmutableMap<Class<?>, PipelineModel.Serialisation.Format> outputSerialisationFormat =
+                ImmutableMap.<Class<?>, PipelineModel.Serialisation.Format>builder()
+                        .put(TradeState.class, PipelineModel.Serialisation.Format.RUNE_JSON)
+                        .put(WorkflowStep.class, PipelineModel.Serialisation.Format.RUNE_JSON)
+                        .build();
+
         return new PipelineTreeConfig()
                 .starting(TransformType.TRANSLATE, Ingest_FpmlConfirmationToTradeState.class)
                 .starting(TransformType.TRANSLATE, Ingest_FpmlConfirmationToWorkflowStep.class)
                 .withInputSerialisationFormatMap(RuneFpmlModelConfig.TYPE_TO_FORMAT_MAP)
+//                .withOutputSerialisationFormatMap(outputSerialisationFormat)
                 .withXmlConfigMap(RuneFpmlModelConfig.TYPE_TO_XML_CONFIG_MAP)
                 .withTestPackFilter(filter)
                 .strictUniqueIds()

--- a/tests/src/test/java/org/finos/cdm/testpack/CdmTestPackCreator.java
+++ b/tests/src/test/java/org/finos/cdm/testpack/CdmTestPackCreator.java
@@ -91,7 +91,7 @@ public class CdmTestPackCreator {
                         .put(WorkflowStep.class, PipelineModel.Serialisation.Format.RUNE_JSON)
                         .build();
 
-        //TODO: switch over to new serialiser when choice extension work has been completed in the model
+        //TODO: switch over to new serialiser when all cases of choice extensions have been removed the model
         return new PipelineTreeConfig()
                 .starting(TransformType.TRANSLATE, Ingest_FpmlConfirmationToTradeState.class)
                 .starting(TransformType.TRANSLATE, Ingest_FpmlConfirmationToWorkflowStep.class)

--- a/tests/src/test/java/org/finos/cdm/testpack/CdmTestPackCreator.java
+++ b/tests/src/test/java/org/finos/cdm/testpack/CdmTestPackCreator.java
@@ -91,6 +91,7 @@ public class CdmTestPackCreator {
                         .put(WorkflowStep.class, PipelineModel.Serialisation.Format.RUNE_JSON)
                         .build();
 
+        //TODO: switch over to new serialiser when choice extension work has been completed in the model
         return new PipelineTreeConfig()
                 .starting(TransformType.TRANSLATE, Ingest_FpmlConfirmationToTradeState.class)
                 .starting(TransformType.TRANSLATE, Ingest_FpmlConfirmationToWorkflowStep.class)

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19130,17 +19130,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -19130,9 +19130,14 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"

--- a/website/package.json
+++ b/website/package.json
@@ -27,7 +27,7 @@
     "trim": "0.0.3"
   },
   "overrides": {
-    "uuid": "^9.0.1"
+    "uuid": "^14.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/website/package.json
+++ b/website/package.json
@@ -26,6 +26,9 @@
     "react-dom": "^18.0.0",
     "trim": "0.0.3"
   },
+  "overrides": {
+    "uuid": "^9.0.1"
+  },
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
# _Infrastructure - Dependency Update_

Version updates include:

- `DSL` `10.0.0-dev.8` - Revert selected errors back to warnings. See DSL release notes: [10.0.0-dev.8](https://github.com/finos/rune-dsl/releases/tag/10.0.0-dev.8)
- `DSL` `10.0.0-dev.7` - Fix local scope memory leak. See DSL release notes: [10.0.0-dev.7](https://github.com/finos/rune-dsl/releases/tag/10.0.0-dev.7)
- `DSL` `10.0.0-dev.6` - Fix symbol reference serialization. See DSL release notes: [10.0.0-dev.6](https://github.com/finos/rune-dsl/releases/tag/10.0.0-dev.6)
- `DSL` `10.0.0-dev.5` - Optimize memory consumption in tests. See DSL release notes: [10.0.0-dev.5](https://github.com/finos/rune-dsl/releases/tag/10.0.0-dev.5)
- `DSL` `10.0.0-dev.4` - Optimize rename performance and bring back libs required by Rosetta. See DSL release notes: [10.0.0-dev.4](https://github.com/finos/rune-dsl/releases/tag/10.0.0-dev.4)
- `DSL` `10.0.0-dev.3` - Forbid extending choice type and fix CVE scanning. See DSL release notes: [10.0.0-dev.3](https://github.com/finos/rune-dsl/releases/tag/10.0.0-dev.3)
- `DSL` `10.0.0-dev.2` - Forbid extending choice type and fix CVE scanning. See DSL release notes: [10.0.0-dev.2](https://github.com/finos/rune-dsl/releases/tag/10.0.0-dev.2)
- `DSL` `10.0.0-dev.1` - Convert warnings to errors and remove deprecated syntax. See DSL release notes: [10.0.0-dev.1](https://github.com/finos/rune-dsl/releases/tag/10.0.0-dev.1)

_Review Directions_
Changes can be reviewed in PR: https://github.com/rosetta-models/common-domain-model/pull/4751