### PR TITLE
[6xx] FpML to CDM flattened ingestion functions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <!-- release version is overridden in rosetta-source -->
         <maven.compiler.release>11</maven.compiler.release>
 
-        <rune-fpml.version>1.5.3</rune-fpml.version>
+        <rune-fpml.version>2.0.0</rune-fpml.version>
         <rosetta.dsl.version>9.83.0</rosetta.dsl.version>
         <rosetta.bundle.version>11.120.2</rosetta.bundle.version>
         <rosetta.code-gen.version>${rosetta.bundle.version}</rosetta.code-gen.version>

--- a/pom.xml
+++ b/pom.xml
@@ -81,9 +81,9 @@
         <!-- release version is overridden in rosetta-source -->
         <maven.compiler.release>11</maven.compiler.release>
 
-        <rune-fpml.version>2.0.0</rune-fpml.version>
+        <rune-fpml.version>2.1.1</rune-fpml.version>
         <rosetta.dsl.version>9.83.0</rosetta.dsl.version>
-        <rosetta.bundle.version>11.120.2</rosetta.bundle.version>
+        <rosetta.bundle.version>11.121.2</rosetta.bundle.version>
         <rosetta.code-gen.version>${rosetta.bundle.version}</rosetta.code-gen.version>
 
         <xtext.version>2.38.0</xtext.version>

--- a/rosetta-source/src/main/java/cdm/ingest/fpml/confirmation/pricequantity/functions/CreateAssetKeyImpl.java
+++ b/rosetta-source/src/main/java/cdm/ingest/fpml/confirmation/pricequantity/functions/CreateAssetKeyImpl.java
@@ -9,7 +9,7 @@ public class CreateAssetKeyImpl extends CreateAssetKey {
 
     @Override
     protected String doEvaluate(String keyPrefix, Asset fpmlAsset) {
-        int index = Optional.ofNullable(fpmlAsset).map(Objects::hashCode).orElse(2) % 1000;
+        int index = Optional.ofNullable(fpmlAsset).map(Objects::hashCode).orElse(2) % 10000;
         return String.format("%s-$%d",
                 Optional.ofNullable(keyPrefix).orElse("empty"),
                 Math.abs(index));

--- a/rosetta-source/src/main/java/cdm/ingest/fpml/confirmation/pricequantity/functions/CreateKeyImpl.java
+++ b/rosetta-source/src/main/java/cdm/ingest/fpml/confirmation/pricequantity/functions/CreateKeyImpl.java
@@ -11,7 +11,7 @@ public class CreateKeyImpl extends CreateKey {
     protected String doEvaluate(String keyPrefix, String id, Leg fpmlLeg) {
         int index = (Optional.ofNullable(keyPrefix).map(Objects::hashCode).orElse(2) +
                 Optional.ofNullable(id).map(Objects::hashCode).orElse(3) +
-                Optional.ofNullable(fpmlLeg).map(Objects::hashCode).orElse(4)) % 1000;
+                Optional.ofNullable(fpmlLeg).map(Objects::hashCode).orElse(4)) % 10000;
         return String.format("%s-$%d",
                 Optional.ofNullable(keyPrefix).orElse("empty"),
                 Math.abs(index));

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-bond-options.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-bond-options.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-bond-options/bond-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-bond-options/bond-option.json",
     "assertions" : {
-      "inputPathCount" : 65,
+      "inputPathCount" : 63,
       "outputPathCount" : 69,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-bond-options/cb-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-bond-options/cb-option.json",
     "assertions" : {
-      "inputPathCount" : 78,
+      "inputPathCount" : 76,
       "outputPathCount" : 74,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-bond-options/cb-option-2.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-bond-options/cb-option-2.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 70,
       "outputPathCount" : 70,
       "modelValidationFailures" : 4,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-commodity-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-commodity-derivatives.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex10-physical-oil-pipeline-crude-wti-floating-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex10-physical-oil-pipeline-crude-wti-floating-price.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 52,
       "outputPathCount" : 50,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex11-physical-oil-pipeline-heating-oil-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex11-physical-oil-pipeline-heating-oil-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 53,
+      "inputPathCount" : 49,
       "outputPathCount" : 44,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex12-physical-gas-europe-zbt-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex12-physical-gas-europe-zbt-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 51,
+      "inputPathCount" : 47,
       "outputPathCount" : 44,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex13-physical-gas-us-tw-west-texas-pool-floating-price-4-days.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex13-physical-gas-us-tw-west-texas-pool-floating-price-4-days.json",
     "assertions" : {
-      "inputPathCount" : 54,
+      "inputPathCount" : 50,
       "outputPathCount" : 52,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex14-physical-gas-europe-ttf-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex14-physical-gas-europe-ttf-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 55,
+      "inputPathCount" : 51,
       "outputPathCount" : 40,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex15-physical-oil-pipeline-crude-wcs-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex15-physical-oil-pipeline-crude-wcs-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 52,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex16-physical-power-us-eei-floating-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex16-physical-power-us-eei-floating-price.json",
     "assertions" : {
-      "inputPathCount" : 69,
+      "inputPathCount" : 65,
       "outputPathCount" : 50,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex17-physical-power-uk-gtma-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex17-physical-power-uk-gtma-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 61,
+      "inputPathCount" : 57,
       "outputPathCount" : 29,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex18-physical-power-us-eei-fixed-price-shaped-volume.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex18-physical-power-us-eei-fixed-price-shaped-volume.json",
     "assertions" : {
-      "inputPathCount" : 105,
+      "inputPathCount" : 101,
       "outputPathCount" : 29,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex19-physical-bullion-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex19-physical-bullion-forward.json",
     "assertions" : {
-      "inputPathCount" : 51,
+      "inputPathCount" : 47,
       "outputPathCount" : 22,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex20-physical-coal-us-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex20-physical-coal-us-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 51,
+      "inputPathCount" : 47,
       "outputPathCount" : 36,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex21-physical-power-us-eei-fixed-price-shaped-volume-and-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex21-physical-power-us-eei-fixed-price-shaped-volume-and-price.json",
     "assertions" : {
-      "inputPathCount" : 121,
+      "inputPathCount" : 117,
       "outputPathCount" : 33,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex22-physical-gas-option-multiple-expiration.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex22-physical-gas-option-multiple-expiration.json",
     "assertions" : {
-      "inputPathCount" : 82,
+      "inputPathCount" : 78,
       "outputPathCount" : 55,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex23-physical-power-option-daily-expiration-efet.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex23-physical-power-option-daily-expiration-efet.json",
     "assertions" : {
-      "inputPathCount" : 101,
+      "inputPathCount" : 97,
       "outputPathCount" : 48,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex24-weather-index-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex24-weather-index-swap.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 81,
       "outputPathCount" : 27,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex25-physical-bullion-forward-average-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex25-physical-bullion-forward-average-price.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 22,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex26-physical-metal-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex26-physical-metal-forward.json",
     "assertions" : {
-      "inputPathCount" : 60,
+      "inputPathCount" : 56,
       "outputPathCount" : 21,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex29-physical-eu-emissions-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex29-physical-eu-emissions-option.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 70,
       "outputPathCount" : 54,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex30-physical-eu-emissions-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex30-physical-eu-emissions-forward.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 54,
       "outputPathCount" : 35,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex31-physical-us-emissions-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex31-physical-us-emissions-option.json",
     "assertions" : {
-      "inputPathCount" : 67,
+      "inputPathCount" : 65,
       "outputPathCount" : 54,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex32-CPD-weather-index-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex32-CPD-weather-index-option.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 70,
       "outputPathCount" : 51,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -239,7 +239,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex33-physical-bullion-forward-average-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex33-physical-bullion-forward-average-price.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 21,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -250,7 +250,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex34-gas-put-option-european-floating-strike.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex34-gas-put-option-european-floating-strike.json",
     "assertions" : {
-      "inputPathCount" : 107,
+      "inputPathCount" : 87,
       "outputPathCount" : 83,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -261,7 +261,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex35-call-option-gas-power-heat-rate-daily.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex35-call-option-gas-power-heat-rate-daily.json",
     "assertions" : {
-      "inputPathCount" : 98,
+      "inputPathCount" : 78,
       "outputPathCount" : 83,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -272,7 +272,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex36-gas-call-option-european-spread-negative-premium-floating-strike.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex36-gas-call-option-european-spread-negative-premium-floating-strike.json",
     "assertions" : {
-      "inputPathCount" : 99,
+      "inputPathCount" : 80,
       "outputPathCount" : 88,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -283,7 +283,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex37-gold-forward-offered-rate.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex37-gold-forward-offered-rate.json",
     "assertions" : {
-      "inputPathCount" : 104,
+      "inputPathCount" : 100,
       "outputPathCount" : 124,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -294,7 +294,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex40-gas-digital-option-storage-volume-trigger.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex40-gas-digital-option-storage-volume-trigger.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 69,
       "outputPathCount" : 14,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -305,7 +305,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex42-index-return-swap-reinvestment-feature.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex42-index-return-swap-reinvestment-feature.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 69,
       "outputPathCount" : 20,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -316,7 +316,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex43-WTI-variance-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex43-WTI-variance-swap.json",
     "assertions" : {
-      "inputPathCount" : 62,
+      "inputPathCount" : 60,
       "outputPathCount" : 19,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -327,7 +327,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex44-index-return-swap-fixed-notional.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex44-index-return-swap-fixed-notional.json",
     "assertions" : {
-      "inputPathCount" : 66,
+      "inputPathCount" : 64,
       "outputPathCount" : 20,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -338,7 +338,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex45-ag-variance-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex45-ag-variance-swap.json",
     "assertions" : {
-      "inputPathCount" : 53,
+      "inputPathCount" : 51,
       "outputPathCount" : 21,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -349,7 +349,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-commodity-derivatives/com-ex47-physical-eu-emissions-option-pred-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-commodity-derivatives/com-ex47-physical-eu-emissions-option-pred-clearing.json",
     "assertions" : {
-      "inputPathCount" : 78,
+      "inputPathCount" : 76,
       "outputPathCount" : 61,
       "modelValidationFailures" : 10,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-credit-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-credit-derivatives.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex01-long-asia-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex01-long-asia-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 84,
       "outputPathCount" : 119,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex02-2003-short-asia-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex02-2003-short-asia-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 43,
+      "inputPathCount" : 39,
       "outputPathCount" : 63,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex02-short-asia-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex02-short-asia-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 44,
+      "inputPathCount" : 40,
       "outputPathCount" : 65,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex03-long-aussie-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex03-long-aussie-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 92,
       "outputPathCount" : 118,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex04-short-aussie-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex04-short-aussie-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 45,
+      "inputPathCount" : 41,
       "outputPathCount" : 64,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex05-long-emasia-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex05-long-emasia-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 90,
       "outputPathCount" : 125,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex06-long-emeur-sov-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex06-long-emeur-sov-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 87,
+      "inputPathCount" : 83,
       "outputPathCount" : 118,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex07-2003-long-euro-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex07-2003-long-euro-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 86,
+      "inputPathCount" : 82,
       "outputPathCount" : 117,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex07-long-euro-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex07-long-euro-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 81,
       "outputPathCount" : 116,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex08-2003-short-euro-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex08-2003-short-euro-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 45,
+      "inputPathCount" : 41,
       "outputPathCount" : 62,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex08-short-euro-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex08-short-euro-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 45,
+      "inputPathCount" : 41,
       "outputPathCount" : 62,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex09-long-euro-sov-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex09-long-euro-sov-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 114,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex10-2003-long-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex10-2003-long-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 81,
       "outputPathCount" : 116,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex10-long-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex10-long-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 86,
+      "inputPathCount" : 82,
       "outputPathCount" : 117,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex11-2003-short-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex11-2003-short-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 43,
+      "inputPathCount" : 39,
       "outputPathCount" : 64,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex11-short-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex11-short-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 44,
+      "inputPathCount" : 40,
       "outputPathCount" : 65,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex12-long-emasia-sov-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex12-long-emasia-sov-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 91,
+      "inputPathCount" : 87,
       "outputPathCount" : 122,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex13-long-asia-sov-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex13-long-asia-sov-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 114,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex14-long-emlatin-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex14-long-emlatin-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 92,
+      "inputPathCount" : 88,
       "outputPathCount" : 123,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex15-long-emlatin-sov-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex15-long-emlatin-sov-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 84,
       "outputPathCount" : 119,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex16-short-us-corp-fixreg-recovery-factor.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex16-short-us-corp-fixreg-recovery-factor.json",
     "assertions" : {
-      "inputPathCount" : 45,
+      "inputPathCount" : 41,
       "outputPathCount" : 67,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -239,7 +239,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex17-short-us-corp-portfolio-compression.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex17-short-us-corp-portfolio-compression.json",
     "assertions" : {
-      "inputPathCount" : 49,
+      "inputPathCount" : 45,
       "outputPathCount" : 73,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -250,7 +250,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex18-standard-north-american-corp.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex18-standard-north-american-corp.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 43,
       "outputPathCount" : 73,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -261,7 +261,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-ex19-cdx-index-option-pred-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-ex19-cdx-index-option-pred-clearing.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 83,
       "outputPathCount" : 119,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -272,7 +272,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-indamt-ex01-short-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-indamt-ex01-short-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 43,
       "outputPathCount" : 66,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -283,7 +283,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-swaption-1.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-swaption-1.json",
     "assertions" : {
-      "inputPathCount" : 101,
+      "inputPathCount" : 99,
       "outputPathCount" : 123,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -294,7 +294,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cd-swaption-2.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cd-swaption-2.json",
     "assertions" : {
-      "inputPathCount" : 121,
+      "inputPathCount" : 119,
       "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -305,7 +305,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cdindex-ex01-cdx.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cdindex-ex01-cdx.json",
     "assertions" : {
-      "inputPathCount" : 37,
+      "inputPathCount" : 33,
       "outputPathCount" : 59,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -316,7 +316,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cdindex-ex02-iTraxx.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cdindex-ex02-iTraxx.json",
     "assertions" : {
-      "inputPathCount" : 35,
+      "inputPathCount" : 31,
       "outputPathCount" : 47,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -327,7 +327,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cdindex-ex03-iTraxx-contractual-supplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cdindex-ex03-iTraxx-contractual-supplement.json",
     "assertions" : {
-      "inputPathCount" : 49,
+      "inputPathCount" : 45,
       "outputPathCount" : 66,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -338,7 +338,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cdindex-ex04-iBoxx.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cdindex-ex04-iBoxx.json",
     "assertions" : {
-      "inputPathCount" : 48,
+      "inputPathCount" : 42,
       "outputPathCount" : 79,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -349,7 +349,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cdindex-ex05-SP.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cdindex-ex05-SP.json",
     "assertions" : {
-      "inputPathCount" : 49,
+      "inputPathCount" : 43,
       "outputPathCount" : 72,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -360,7 +360,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cds-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cds-basket.json",
     "assertions" : {
-      "inputPathCount" : 76,
+      "inputPathCount" : 74,
       "outputPathCount" : 89,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -371,7 +371,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cds-basket-tranche.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cds-basket-tranche.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 77,
       "outputPathCount" : 92,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -382,7 +382,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cds-custom-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cds-custom-basket.json",
     "assertions" : {
-      "inputPathCount" : 116,
+      "inputPathCount" : 114,
       "outputPathCount" : 129,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -393,7 +393,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cds-ELCDS-ReferenceObligation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cds-ELCDS-ReferenceObligation.json",
     "assertions" : {
-      "inputPathCount" : 66,
+      "inputPathCount" : 64,
       "outputPathCount" : 76,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -404,7 +404,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cds-index-tranche.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cds-index-tranche.json",
     "assertions" : {
-      "inputPathCount" : 37,
+      "inputPathCount" : 33,
       "outputPathCount" : 49,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -415,7 +415,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cds-loan-ReferenceObligation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cds-loan-ReferenceObligation.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 90,
       "outputPathCount" : 102,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -426,7 +426,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cds-loan-SecuredList.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cds-loan-SecuredList.json",
     "assertions" : {
-      "inputPathCount" : 87,
+      "inputPathCount" : 83,
       "outputPathCount" : 98,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -437,7 +437,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cds-mortgage-CMBS.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cds-mortgage-CMBS.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 80,
       "outputPathCount" : 84,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -448,7 +448,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cds-mortgage-RMBS.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cds-mortgage-RMBS.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 80,
       "outputPathCount" : 84,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -459,7 +459,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/cdx-index-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/cdx-index-option.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 77,
       "outputPathCount" : 110,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -470,7 +470,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-credit-derivatives/itraxx-index-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-credit-derivatives/itraxx-index-option.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 94,
       "outputPathCount" : 120,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-equity-options.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-equity-options.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex01-american-call-stock-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex01-american-call-stock-long-form.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 86,
       "outputPathCount" : 81,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex02-calendar-spread-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex02-calendar-spread-short-form.json",
     "assertions" : {
-      "inputPathCount" : 67,
+      "inputPathCount" : 65,
       "outputPathCount" : 77,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex03-call-or-put-spread-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex03-call-or-put-spread-short-form.json",
     "assertions" : {
-      "inputPathCount" : 67,
+      "inputPathCount" : 65,
       "outputPathCount" : 77,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex04-european-call-index-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex04-european-call-index-long-form.json",
     "assertions" : {
-      "inputPathCount" : 75,
+      "inputPathCount" : 73,
       "outputPathCount" : 78,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex05-asian-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex05-asian-long-form.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 74,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex06-averaging-in-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex06-averaging-in-long-form.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 74,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex07-barrier-knockout-rebate-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex07-barrier-knockout-rebate-long-form.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 113,
       "outputPathCount" : 77,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex08-basket-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex08-basket-long-form.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 82,
       "outputPathCount" : 84,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex09-bermuda-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex09-bermuda-long-form.json",
     "assertions" : {
-      "inputPathCount" : 91,
+      "inputPathCount" : 89,
       "outputPathCount" : 89,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex10-binary-barrier-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex10-binary-barrier-long-form.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 92,
       "outputPathCount" : 78,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex11-quanto-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex11-quanto-long-form.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 82,
       "outputPathCount" : 79,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex12-vanilla-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex12-vanilla-short-form.json",
     "assertions" : {
-      "inputPathCount" : 65,
+      "inputPathCount" : 63,
       "outputPathCount" : 77,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex13-1996-american-call-stock.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex13-1996-american-call-stock.json",
     "assertions" : {
-      "inputPathCount" : 62,
+      "inputPathCount" : 60,
       "outputPathCount" : 84,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex14-american-call-stock-passthrough-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex14-american-call-stock-passthrough-long-form.json",
     "assertions" : {
-      "inputPathCount" : 93,
+      "inputPathCount" : 91,
       "outputPathCount" : 82,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex15-basket-passthrough-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex15-basket-passthrough-long-form.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 92,
       "outputPathCount" : 84,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex16-equityOptionTransactionSupplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex16-equityOptionTransactionSupplement.json",
     "assertions" : {
-      "inputPathCount" : 52,
+      "inputPathCount" : 50,
       "outputPathCount" : 76,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex17-equityOptionTransactionSupplement-non-deliverable-share.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex17-equityOptionTransactionSupplement-non-deliverable-share.json",
     "assertions" : {
-      "inputPathCount" : 62,
+      "inputPathCount" : 58,
       "outputPathCount" : 73,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex18-equityOptionTransactionSupplement-non-deliverable-index.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex18-equityOptionTransactionSupplement-non-deliverable-index.json",
     "assertions" : {
-      "inputPathCount" : 60,
+      "inputPathCount" : 56,
       "outputPathCount" : 76,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex19-dividend-adjustment.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex19-dividend-adjustment.json",
     "assertions" : {
-      "inputPathCount" : 102,
+      "inputPathCount" : 100,
       "outputPathCount" : 79,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex20-nested-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex20-nested-basket.json",
     "assertions" : {
-      "inputPathCount" : 99,
+      "inputPathCount" : 97,
       "outputPathCount" : 81,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex21-flat-weight-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex21-flat-weight-basket.json",
     "assertions" : {
-      "inputPathCount" : 98,
+      "inputPathCount" : 96,
       "outputPathCount" : 100,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -239,7 +239,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex22-equityOptionTransactionSupplement-index-option-asian-dates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex22-equityOptionTransactionSupplement-index-option-asian-dates.json",
     "assertions" : {
-      "inputPathCount" : 110,
+      "inputPathCount" : 108,
       "outputPathCount" : 69,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -250,7 +250,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex23-equityOptionTransactionSupplement-index-option-cliquet.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex23-equityOptionTransactionSupplement-index-option-cliquet.json",
     "assertions" : {
-      "inputPathCount" : 80,
+      "inputPathCount" : 78,
       "outputPathCount" : 69,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -261,7 +261,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex24-equityOptionTransactionSupplement-index-option-asian-schedule.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex24-equityOptionTransactionSupplement-index-option-asian-schedule.json",
     "assertions" : {
-      "inputPathCount" : 80,
+      "inputPathCount" : 78,
       "outputPathCount" : 71,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -272,7 +272,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex25-equityOptionTransactionSupplement-index-option-knock-in-knock-out-features.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex25-equityOptionTransactionSupplement-index-option-knock-in-knock-out-features.json",
     "assertions" : {
-      "inputPathCount" : 87,
+      "inputPathCount" : 85,
       "outputPathCount" : 69,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -283,7 +283,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex26-mixed-asset-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex26-mixed-asset-basket.json",
     "assertions" : {
-      "inputPathCount" : 101,
+      "inputPathCount" : 99,
       "outputPathCount" : 94,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -294,7 +294,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-options/eqd-ex27-equityOptionTransactionSupplement-EMEA-interdealer.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-options/eqd-ex27-equityOptionTransactionSupplement-EMEA-interdealer.json",
     "assertions" : {
-      "inputPathCount" : 70,
+      "inputPathCount" : 66,
       "outputPathCount" : 75,
       "modelValidationFailures" : 2,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-equity-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-equity-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/eqs-ex03-index-quanto-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/eqs-ex03-index-quanto-long-form.json",
     "assertions" : {
-      "inputPathCount" : 168,
+      "inputPathCount" : 161,
       "outputPathCount" : 179,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/eqs-ex04-zero-strike-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/eqs-ex04-zero-strike-long-form.json",
     "assertions" : {
-      "inputPathCount" : 127,
+      "inputPathCount" : 120,
       "outputPathCount" : 96,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/eqs-ex05-single-stock-plus-fee-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/eqs-ex05-single-stock-plus-fee-long-form.json",
     "assertions" : {
-      "inputPathCount" : 164,
+      "inputPathCount" : 160,
       "outputPathCount" : 142,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/eqs-ex07-long-form-with-stub.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/eqs-ex07-long-form-with-stub.json",
     "assertions" : {
-      "inputPathCount" : 212,
+      "inputPathCount" : 208,
       "outputPathCount" : 206,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/eqs-ex08-composite-basket-long-form-separate-spreads.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/eqs-ex08-composite-basket-long-form-separate-spreads.json",
     "assertions" : {
-      "inputPathCount" : 222,
+      "inputPathCount" : 215,
       "outputPathCount" : 238,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 166,
+      "inputPathCount" : 163,
       "outputPathCount" : 164,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/eqs-ex17-cfd.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/eqs-ex17-cfd.json",
     "assertions" : {
-      "inputPathCount" : 108,
+      "inputPathCount" : 96,
       "outputPathCount" : 108,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/eqs-ex18-pan-asia-interdealer-index-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/eqs-ex18-pan-asia-interdealer-index-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 145,
+      "inputPathCount" : 139,
       "outputPathCount" : 145,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 144,
+      "inputPathCount" : 138,
       "outputPathCount" : 144,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/trs-ex01-equity-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/trs-ex01-equity-basket.json",
     "assertions" : {
-      "inputPathCount" : 200,
+      "inputPathCount" : 185,
       "outputPathCount" : 139,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/trs-ex02-single-equity.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/trs-ex02-single-equity.json",
     "assertions" : {
-      "inputPathCount" : 179,
+      "inputPathCount" : 172,
       "outputPathCount" : 139,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.json",
     "assertions" : {
-      "inputPathCount" : 185,
+      "inputPathCount" : 178,
       "outputPathCount" : 163,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-equity-swaps/trs-ex04-index-ios.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-equity-swaps/trs-ex04-index-ios.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 111,
       "outputPathCount" : 110,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-fx-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-fx-derivatives.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/dcd-ex01-dual-currency-deposit.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/dcd-ex01-dual-currency-deposit.json",
     "assertions" : {
-      "inputPathCount" : 51,
+      "inputPathCount" : 47,
       "outputPathCount" : 17,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex13-fx-dbl-barrier-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex13-fx-dbl-barrier-option.json",
     "assertions" : {
-      "inputPathCount" : 76,
+      "inputPathCount" : 72,
       "outputPathCount" : 60,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex14-euro-digital-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex14-euro-digital-option.json",
     "assertions" : {
-      "inputPathCount" : 55,
+      "inputPathCount" : 51,
       "outputPathCount" : 41,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex15-euro-range-digital-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex15-euro-range-digital-option.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 41,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex16-one-touch-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex16-one-touch-option.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 44,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex17-no-touch-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex17-no-touch-option.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 44,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex18-double-one-touch-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex18-double-one-touch-option.json",
     "assertions" : {
-      "inputPathCount" : 76,
+      "inputPathCount" : 72,
       "outputPathCount" : 44,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex19-double-no-touch-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex19-double-no-touch-option.json",
     "assertions" : {
-      "inputPathCount" : 76,
+      "inputPathCount" : 72,
       "outputPathCount" : 44,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex21-avg-rate-option-parametric-plus-rate-observation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex21-avg-rate-option-parametric-plus-rate-observation.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 68,
       "outputPathCount" : 65,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex23-straddle.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex23-straddle.json",
     "assertions" : {
-      "inputPathCount" : 74,
+      "inputPathCount" : 70,
       "outputPathCount" : 17,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex24-delta-hedge.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex24-delta-hedge.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 67,
       "outputPathCount" : 17,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex25-option-strategyComponentIdentifier.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex25-option-strategyComponentIdentifier.json",
     "assertions" : {
-      "inputPathCount" : 110,
+      "inputPathCount" : 98,
       "outputPathCount" : 37,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex26-fxswap-multiple-USIs.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex26-fxswap-multiple-USIs.json",
     "assertions" : {
-      "inputPathCount" : 73,
+      "inputPathCount" : 65,
       "outputPathCount" : 74,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex27-flexible-term-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex27-flexible-term-forward.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 45,
       "outputPathCount" : 13,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex29-fx-swap-with-multiple-identifiers.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex29-fx-swap-with-multiple-identifiers.json",
     "assertions" : {
-      "inputPathCount" : 87,
+      "inputPathCount" : 79,
       "outputPathCount" : 81,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex30-variance-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex30-variance-swap.json",
     "assertions" : {
-      "inputPathCount" : 60,
+      "inputPathCount" : 58,
       "outputPathCount" : 76,
       "modelValidationFailures" : 13,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex31-volatility-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex31-volatility-swap.json",
     "assertions" : {
-      "inputPathCount" : 58,
+      "inputPathCount" : 56,
       "outputPathCount" : 70,
       "modelValidationFailures" : 15,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/fx-ex32-forward-volatility-agreement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/fx-ex32-forward-volatility-agreement.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 54,
       "outputPathCount" : 16,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/td-ex01-simple-term-deposit.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/td-ex01-simple-term-deposit.json",
     "assertions" : {
-      "inputPathCount" : 39,
+      "inputPathCount" : 35,
       "outputPathCount" : 15,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-fx-derivatives/td-ex02-term-deposit-w-settlement-etc.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-fx-derivatives/td-ex02-term-deposit-w-settlement-etc.json",
     "assertions" : {
-      "inputPathCount" : 64,
+      "inputPathCount" : 60,
       "outputPathCount" : 17,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-inflation-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-inflation-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-inflation-swaps/v1_inflation-asset-swap-ex03-par-par.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-inflation-swaps/v1_inflation-asset-swap-ex03-par-par.json",
     "assertions" : {
-      "inputPathCount" : 163,
+      "inputPathCount" : 161,
       "outputPathCount" : 150,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-inflation-swaps/v2_inflation-asset-swap-ex03-par-par.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-inflation-swaps/v2_inflation-asset-swap-ex03-par-par.json",
     "assertions" : {
-      "inputPathCount" : 168,
+      "inputPathCount" : 166,
       "outputPathCount" : 155,
       "modelValidationFailures" : 10,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-securities.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-securities.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-securities/sec-ex001-trade-execution-future.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-securities/sec-ex001-trade-execution-future.json",
     "assertions" : {
-      "inputPathCount" : 33,
+      "inputPathCount" : 31,
       "outputPathCount" : 11,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-products-securities/sec-ex002-trade-execution-exchange-traded-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-incomplete-products-securities/sec-ex002-trade-execution-exchange-traded-option.json",
     "assertions" : {
-      "inputPathCount" : 35,
+      "inputPathCount" : 33,
       "outputPathCount" : 11,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-commodity.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-commodity.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex01-gas-swap-daily-delivery-prices-last.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex01-gas-swap-daily-delivery-prices-last.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 67,
       "outputPathCount" : 97,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex02-gas-swap-prices-first-day.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex02-gas-swap-prices-first-day.json",
     "assertions" : {
-      "inputPathCount" : 69,
+      "inputPathCount" : 65,
       "outputPathCount" : 94,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex03-gas-swap-prices-last-three-days.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex03-gas-swap-prices-last-three-days.json",
     "assertions" : {
-      "inputPathCount" : 73,
+      "inputPathCount" : 69,
       "outputPathCount" : 99,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex04-electricity-swap-hourly-off-peak.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex04-electricity-swap-hourly-off-peak.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 67,
       "outputPathCount" : 97,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex05-gas-v-electricity-spark-spread.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex05-gas-v-electricity-spark-spread.json",
     "assertions" : {
-      "inputPathCount" : 77,
+      "inputPathCount" : 73,
       "outputPathCount" : 109,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex06-gas-call-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex06-gas-call-option.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 62,
       "outputPathCount" : 85,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex07-gas-put-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex07-gas-put-option.json",
     "assertions" : {
-      "inputPathCount" : 75,
+      "inputPathCount" : 60,
       "outputPathCount" : 83,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex08-oil-call-option-strip.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex08-oil-call-option-strip.json",
     "assertions" : {
-      "inputPathCount" : 78,
+      "inputPathCount" : 65,
       "outputPathCount" : 83,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -96,9 +96,9 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex09-oil-put-option-american.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex09-oil-put-option-american.json",
     "assertions" : {
-      "inputPathCount" : 86,
-      "outputPathCount" : 70,
-      "modelValidationFailures" : 4,
+      "inputPathCount" : 67,
+      "outputPathCount" : 75,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex27-wti-put-option-asian-listedoption-date.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex27-wti-put-option-asian-listedoption-date.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 64,
       "outputPathCount" : 87,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex28-gas-swap-daily-delivery-prices-option-last.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex28-gas-swap-daily-delivery-prices-option-last.json",
     "assertions" : {
-      "inputPathCount" : 75,
+      "inputPathCount" : 71,
       "outputPathCount" : 100,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex39-basket-option-confirmation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex39-basket-option-confirmation.json",
     "assertions" : {
-      "inputPathCount" : 119,
+      "inputPathCount" : 115,
       "outputPathCount" : 25,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex41-oil-asian-barrier-option-strip.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex41-oil-asian-barrier-option-strip.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 84,
       "outputPathCount" : 77,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-commodity/com-ex46-simple-financial-put-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex46-simple-financial-put-option.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 63,
       "outputPathCount" : 89,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-correlation-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-correlation-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-correlation-swaps/eqcs-ex01-correlation-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-correlation-swaps/eqcs-ex01-correlation-swap.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 68,
       "outputPathCount" : 87,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-correlation-swaps/eqcs-ex02-correlation-swap-confirmation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-correlation-swaps/eqcs-ex02-correlation-swap-confirmation.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 89,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-correlation-swaps/eqcs-ex03-correlation-swap-confirmation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-correlation-swaps/eqcs-ex03-correlation-swap-confirmation.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 94,
       "outputPathCount" : 94,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-correlation-swaps/eqcs-ex04-correlation-swap-confirmation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-correlation-swaps/eqcs-ex04-correlation-swap-confirmation.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 86,
       "outputPathCount" : 93,
       "modelValidationFailures" : 9,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-credit.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-credit.json
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cd-swaption-usi.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cd-swaption-usi.json",
     "assertions" : {
-      "inputPathCount" : 112,
+      "inputPathCount" : 110,
       "outputPathCount" : 143,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cd-swaption-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cd-swaption-uti.json",
     "assertions" : {
-      "inputPathCount" : 93,
+      "inputPathCount" : 91,
       "outputPathCount" : 129,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cdindex-ex01-cdx-seniority-Senior.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cdindex-ex01-cdx-seniority-Senior.json",
     "assertions" : {
-      "inputPathCount" : 34,
+      "inputPathCount" : 32,
       "outputPathCount" : 59,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cdindex-ex01-cdx-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cdindex-ex01-cdx-uti.json",
     "assertions" : {
-      "inputPathCount" : 33,
+      "inputPathCount" : 31,
       "outputPathCount" : 58,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cdindex-ex02-cdx-seniority-Subordinate.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cdindex-ex02-cdx-seniority-Subordinate.json",
     "assertions" : {
-      "inputPathCount" : 34,
+      "inputPathCount" : 32,
       "outputPathCount" : 59,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cdindex-ex02-iTraxx-usi.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cdindex-ex02-iTraxx-usi.json",
     "assertions" : {
-      "inputPathCount" : 31,
+      "inputPathCount" : 29,
       "outputPathCount" : 48,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cdindex-ex03-cdx-seniority-Other.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cdindex-ex03-cdx-seniority-Other.json",
     "assertions" : {
-      "inputPathCount" : 34,
+      "inputPathCount" : 32,
       "outputPathCount" : 59,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cdindex-ex04-iBoxx-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cdindex-ex04-iBoxx-uti.json",
     "assertions" : {
-      "inputPathCount" : 42,
+      "inputPathCount" : 38,
       "outputPathCount" : 74,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cds-basket-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cds-basket-uti.json",
     "assertions" : {
-      "inputPathCount" : 68,
+      "inputPathCount" : 66,
       "outputPathCount" : 96,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cds-index-tranche.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cds-index-tranche.json",
     "assertions" : {
-      "inputPathCount" : 35,
+      "inputPathCount" : 31,
       "outputPathCount" : 47,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cds-loan-ReferenceObligation-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cds-loan-ReferenceObligation-uti.json",
     "assertions" : {
-      "inputPathCount" : 81,
+      "inputPathCount" : 79,
       "outputPathCount" : 102,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cds-loan-SecuredList-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cds-loan-SecuredList-uti.json",
     "assertions" : {
-      "inputPathCount" : 75,
+      "inputPathCount" : 73,
       "outputPathCount" : 98,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -250,7 +250,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/cdx-index-option-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/cdx-index-option-uti.json",
     "assertions" : {
-      "inputPathCount" : 73,
+      "inputPathCount" : 71,
       "outputPathCount" : 116,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -261,7 +261,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-credit/itraxx-index-option-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-credit/itraxx-index-option-uti.json",
     "assertions" : {
-      "inputPathCount" : 91,
+      "inputPathCount" : 89,
       "outputPathCount" : 130,
       "modelValidationFailures" : 4,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-dividend-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-dividend-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-dividend-swaps/div-ex01-dividend-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-dividend-swaps/div-ex01-dividend-swap.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 71,
       "modelValidationFailures" : 10,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-dividend-swaps/div-ex02-dividend-swap-collateral.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-dividend-swaps/div-ex02-dividend-swap-collateral.json",
     "assertions" : {
-      "inputPathCount" : 102,
+      "inputPathCount" : 98,
       "outputPathCount" : 76,
       "modelValidationFailures" : 10,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-dividend-swaps/div-ex03-dividend-swap-short-form-japanese-underlyer.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-dividend-swaps/div-ex03-dividend-swap-short-form-japanese-underlyer.json",
     "assertions" : {
-      "inputPathCount" : 92,
+      "inputPathCount" : 88,
       "outputPathCount" : 78,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-dividend-swaps/div-ex04-dividend-swap-option-transaction-supplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-dividend-swaps/div-ex04-dividend-swap-option-transaction-supplement.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 96,
       "outputPathCount" : 93,
       "modelValidationFailures" : 11,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-dividend-swaps/div-ex05-dividend-swap-option-gs-example.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-dividend-swaps/div-ex05-dividend-swap-option-gs-example.json",
     "assertions" : {
-      "inputPathCount" : 110,
+      "inputPathCount" : 106,
       "outputPathCount" : 98,
       "modelValidationFailures" : 12,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-dividend-swaps/div-ex06-dividend-swap-option-pred-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-dividend-swaps/div-ex06-dividend-swap-option-pred-clearing.json",
     "assertions" : {
-      "inputPathCount" : 116,
+      "inputPathCount" : 112,
       "outputPathCount" : 104,
       "modelValidationFailures" : 13,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-equity.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-equity.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqd-ex01-american-call-stock-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqd-ex01-american-call-stock-long-form.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 77,
       "outputPathCount" : 81,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqd-ex04-european-call-index-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqd-ex04-european-call-index-long-form.json",
     "assertions" : {
-      "inputPathCount" : 66,
+      "inputPathCount" : 64,
       "outputPathCount" : 78,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqs-ex01-single-underlyer-execution-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex01-single-underlyer-execution-long-form.json",
     "assertions" : {
-      "inputPathCount" : 155,
+      "inputPathCount" : 148,
       "outputPathCount" : 160,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqs-ex01-single-underlyer-execution-long-form-other-party.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex01-single-underlyer-execution-long-form-other-party.json",
     "assertions" : {
-      "inputPathCount" : 158,
+      "inputPathCount" : 151,
       "outputPathCount" : 163,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqs-ex03-european-call-price-return-Index.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex03-european-call-price-return-Index.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 92,
       "outputPathCount" : 99,
       "modelValidationFailures" : 60,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqs-ex06-single-index-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex06-single-index-long-form.json",
     "assertions" : {
-      "inputPathCount" : 145,
+      "inputPathCount" : 138,
       "outputPathCount" : 147,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqs-ex09-compounding-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex09-compounding-swap.json",
     "assertions" : {
-      "inputPathCount" : 90,
+      "inputPathCount" : 86,
       "outputPathCount" : 105,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqs-ex10-short-form-interestLeg-driving-schedule-dates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex10-short-form-interestLeg-driving-schedule-dates.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 93,
       "outputPathCount" : 113,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqs-ex11-on-european-single-stock-underlyer-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex11-on-european-single-stock-underlyer-short-form.json",
     "assertions" : {
-      "inputPathCount" : 138,
+      "inputPathCount" : 131,
       "outputPathCount" : 155,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqs-ex12-on-european-index-underlyer-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex12-on-european-index-underlyer-short-form.json",
     "assertions" : {
-      "inputPathCount" : 140,
+      "inputPathCount" : 133,
       "outputPathCount" : 157,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqs-ex13-pan-asia-interdealer-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex13-pan-asia-interdealer-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 168,
+      "inputPathCount" : 161,
       "outputPathCount" : 169,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-equity/eqs-ex14-european-interdealer-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex14-european-interdealer-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 164,
+      "inputPathCount" : 157,
       "outputPathCount" : 161,
       "modelValidationFailures" : 1,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-fx.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-fx.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex01-fx-spot.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex01-fx-spot.json",
     "assertions" : {
-      "inputPathCount" : 31,
+      "inputPathCount" : 27,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex02-spot-cross-w-side-rates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex02-spot-cross-w-side-rates.json",
     "assertions" : {
-      "inputPathCount" : 39,
+      "inputPathCount" : 35,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex03-fx-fwd.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex03-fx-fwd.json",
     "assertions" : {
-      "inputPathCount" : 33,
+      "inputPathCount" : 29,
       "outputPathCount" : 45,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex04-fx-fwd-w-settlement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex04-fx-fwd-w-settlement.json",
     "assertions" : {
-      "inputPathCount" : 44,
+      "inputPathCount" : 40,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex05-fx-fwd-w-ssi.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex05-fx-fwd-w-ssi.json",
     "assertions" : {
-      "inputPathCount" : 36,
+      "inputPathCount" : 32,
       "outputPathCount" : 45,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex06-fx-fwd-w-splits.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex06-fx-fwd-w-splits.json",
     "assertions" : {
-      "inputPathCount" : 60,
+      "inputPathCount" : 56,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex07-non-deliverable-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex07-non-deliverable-forward.json",
     "assertions" : {
-      "inputPathCount" : 42,
+      "inputPathCount" : 38,
       "outputPathCount" : 53,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex08-fx-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex08-fx-swap.json",
     "assertions" : {
-      "inputPathCount" : 46,
+      "inputPathCount" : 42,
       "outputPathCount" : 64,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex09-euro-opt.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex09-euro-opt.json",
     "assertions" : {
-      "inputPathCount" : 48,
+      "inputPathCount" : 44,
       "outputPathCount" : 61,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex10-amer-opt.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex10-amer-opt.json",
     "assertions" : {
-      "inputPathCount" : 61,
+      "inputPathCount" : 57,
       "outputPathCount" : 64,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex11-non-deliverable-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex11-non-deliverable-option.json",
     "assertions" : {
-      "inputPathCount" : 48,
+      "inputPathCount" : 44,
       "outputPathCount" : 70,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex12-fx-barrier-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex12-fx-barrier-option.json",
     "assertions" : {
-      "inputPathCount" : 49,
+      "inputPathCount" : 45,
       "outputPathCount" : 57,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex20-avg-rate-option-parametric.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex20-avg-rate-option-parametric.json",
     "assertions" : {
-      "inputPathCount" : 45,
+      "inputPathCount" : 41,
       "outputPathCount" : 65,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex22-avg-rate-option-specific.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex22-avg-rate-option-specific.json",
     "assertions" : {
-      "inputPathCount" : 140,
+      "inputPathCount" : 86,
       "outputPathCount" : 60,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-fx/fx-ex28-non-deliverable-w-disruption.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-fx/fx-ex28-non-deliverable-w-disruption.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 43,
       "outputPathCount" : 45,
       "modelValidationFailures" : 1,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-inflation-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-inflation-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-inflation-swaps/inflation-swap-ex01-yoy.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-inflation-swaps/inflation-swap-ex01-yoy.json",
     "assertions" : {
-      "inputPathCount" : 102,
+      "inputPathCount" : 98,
       "outputPathCount" : 100,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-inflation-swaps/inflation-swap-ex02-yoy-bond-reference.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-inflation-swaps/inflation-swap-ex02-yoy-bond-reference.json",
     "assertions" : {
-      "inputPathCount" : 129,
+      "inputPathCount" : 125,
       "outputPathCount" : 122,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-inflation-swaps/inflation-swap-ex03-yoy-initial-level.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-inflation-swaps/inflation-swap-ex03-yoy-initial-level.json",
     "assertions" : {
-      "inputPathCount" : 125,
+      "inputPathCount" : 121,
       "outputPathCount" : 122,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-inflation-swaps/inflation-swap-ex04-yoy-interp.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-inflation-swaps/inflation-swap-ex04-yoy-interp.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 111,
       "outputPathCount" : 109,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-inflation-swaps/inflation-swap-ex05-zc.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-inflation-swaps/inflation-swap-ex05-zc.json",
     "assertions" : {
-      "inputPathCount" : 95,
+      "inputPathCount" : 91,
       "outputPathCount" : 87,
       "modelValidationFailures" : 9,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-rates.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-rates.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/bond-fwd-generic-ex01.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/bond-fwd-generic-ex01.json",
     "assertions" : {
-      "inputPathCount" : 136,
+      "inputPathCount" : 132,
       "outputPathCount" : 84,
       "modelValidationFailures" : 16,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/bond-fwd-generic-ex02.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/bond-fwd-generic-ex02.json",
     "assertions" : {
-      "inputPathCount" : 138,
+      "inputPathCount" : 134,
       "outputPathCount" : 84,
       "modelValidationFailures" : 16,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/bond-option-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/bond-option-uti.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 54,
       "outputPathCount" : 78,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/cb-option-usi.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/cb-option-usi.json",
     "assertions" : {
-      "inputPathCount" : 60,
+      "inputPathCount" : 58,
       "outputPathCount" : 78,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/cdm-xccy-swap-after-usi-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/cdm-xccy-swap-after-usi-uti.json",
     "assertions" : {
-      "inputPathCount" : 173,
+      "inputPathCount" : 169,
       "outputPathCount" : 216,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/cdm-xccy-swap-before-usi-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/cdm-xccy-swap-before-usi-uti.json",
     "assertions" : {
-      "inputPathCount" : 166,
+      "inputPathCount" : 162,
       "outputPathCount" : 200,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/EUR-Long-Final-Stub-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-Long-Final-Stub-uti.json",
     "assertions" : {
-      "inputPathCount" : 102,
+      "inputPathCount" : 100,
       "outputPathCount" : 126,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/EUR-OIS-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-OIS-uti.json",
     "assertions" : {
-      "inputPathCount" : 98,
+      "inputPathCount" : 96,
       "outputPathCount" : 123,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/EUR-Vanilla-account.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-Vanilla-account.json",
     "assertions" : {
-      "inputPathCount" : 101,
+      "inputPathCount" : 99,
       "outputPathCount" : 124,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/EUR-Vanilla-multiple-accounts.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-Vanilla-multiple-accounts.json",
     "assertions" : {
-      "inputPathCount" : 104,
+      "inputPathCount" : 102,
       "outputPathCount" : 128,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/EUR-vanilla-reconciliation-partyA-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-vanilla-reconciliation-partyA-uti.json",
     "assertions" : {
-      "inputPathCount" : 80,
+      "inputPathCount" : 78,
       "outputPathCount" : 101,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/EUR-vanilla-reconciliation-partyB-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-vanilla-reconciliation-partyB-uti.json",
     "assertions" : {
-      "inputPathCount" : 80,
+      "inputPathCount" : 78,
       "outputPathCount" : 101,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/EUR-Vanilla-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-Vanilla-uti.json",
     "assertions" : {
-      "inputPathCount" : 91,
+      "inputPathCount" : 89,
       "outputPathCount" : 116,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/EUR-variable-notional-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-variable-notional-uti.json",
     "assertions" : {
-      "inputPathCount" : 189,
+      "inputPathCount" : 187,
       "outputPathCount" : 220,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/GBP-OIS-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/GBP-OIS-uti.json",
     "assertions" : {
-      "inputPathCount" : 95,
+      "inputPathCount" : 93,
       "outputPathCount" : 123,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/GBP-Vanilla-person-roles-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/GBP-Vanilla-person-roles-uti.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 94,
       "outputPathCount" : 120,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/GBP-Vanilla-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/GBP-Vanilla-uti.json",
     "assertions" : {
-      "inputPathCount" : 90,
+      "inputPathCount" : 88,
       "outputPathCount" : 115,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/GBP-VNS-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/GBP-VNS-uti.json",
     "assertions" : {
-      "inputPathCount" : 187,
+      "inputPathCount" : 185,
       "outputPathCount" : 218,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -250,7 +250,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex02-stub-amort-swap-versioned.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex02-stub-amort-swap-versioned.json",
     "assertions" : {
-      "inputPathCount" : 196,
+      "inputPathCount" : 194,
       "outputPathCount" : 216,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -272,7 +272,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex04-arrears-stepup-fee-swap-usi-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex04-arrears-stepup-fee-swap-usi-uti.json",
     "assertions" : {
-      "inputPathCount" : 93,
+      "inputPathCount" : 89,
       "outputPathCount" : 114,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -283,7 +283,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex05-long-stub-swap-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex05-long-stub-swap-uti.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 92,
       "outputPathCount" : 119,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -294,7 +294,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex06-xccy-swap-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex06-xccy-swap-uti.json",
     "assertions" : {
-      "inputPathCount" : 181,
+      "inputPathCount" : 179,
       "outputPathCount" : 212,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -305,7 +305,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex07-ois-swap-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex07-ois-swap-uti.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 77,
       "outputPathCount" : 100,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -316,7 +316,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex08-fra.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex08-fra.json",
     "assertions" : {
-      "inputPathCount" : 46,
+      "inputPathCount" : 42,
       "outputPathCount" : 79,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -327,7 +327,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex08-fra-no-discounting.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex08-fra-no-discounting.json",
     "assertions" : {
-      "inputPathCount" : 41,
+      "inputPathCount" : 37,
       "outputPathCount" : 70,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -360,7 +360,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex10-euro-swaption-relative-usi.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex10-euro-swaption-relative-usi.json",
     "assertions" : {
-      "inputPathCount" : 109,
+      "inputPathCount" : 107,
       "outputPathCount" : 129,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -371,7 +371,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex11-euro-swaption-partial-auto-ex.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex11-euro-swaption-partial-auto-ex.json",
     "assertions" : {
-      "inputPathCount" : 111,
+      "inputPathCount" : 107,
       "outputPathCount" : 130,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -404,7 +404,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex13-euro-swaption-cash-with-cfs.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex13-euro-swaption-cash-with-cfs.json",
     "assertions" : {
-      "inputPathCount" : 221,
+      "inputPathCount" : 217,
       "outputPathCount" : 229,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -415,7 +415,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex14-berm-swaption.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex14-berm-swaption.json",
     "assertions" : {
-      "inputPathCount" : 116,
+      "inputPathCount" : 112,
       "outputPathCount" : 139,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -426,7 +426,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex15-amer-swaption.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex15-amer-swaption.json",
     "assertions" : {
-      "inputPathCount" : 120,
+      "inputPathCount" : 116,
       "outputPathCount" : 143,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -437,7 +437,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex16-mand-term-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex16-mand-term-swap.json",
     "assertions" : {
-      "inputPathCount" : 103,
+      "inputPathCount" : 99,
       "outputPathCount" : 119,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -448,7 +448,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex17-opt-euro-term-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex17-opt-euro-term-swap.json",
     "assertions" : {
-      "inputPathCount" : 146,
+      "inputPathCount" : 111,
       "outputPathCount" : 126,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -459,7 +459,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex18-opt-berm-term-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex18-opt-berm-term-swap.json",
     "assertions" : {
-      "inputPathCount" : 261,
+      "inputPathCount" : 212,
       "outputPathCount" : 218,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -470,7 +470,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex19-opt-amer-term-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex19-opt-amer-term-swap.json",
     "assertions" : {
-      "inputPathCount" : 168,
+      "inputPathCount" : 122,
       "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -481,7 +481,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex20-euro-cancel-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex20-euro-cancel-swap.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 96,
       "outputPathCount" : 112,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -492,7 +492,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex21-euro-extend-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex21-euro-extend-swap.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 96,
       "outputPathCount" : 98,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -558,7 +558,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex25-fxnotional-swap-usi-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex25-fxnotional-swap-usi-uti.json",
     "assertions" : {
-      "inputPathCount" : 119,
+      "inputPathCount" : 115,
       "outputPathCount" : 137,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -569,7 +569,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex26-fxnotional-swap-with-cfs.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex26-fxnotional-swap-with-cfs.json",
     "assertions" : {
-      "inputPathCount" : 287,
+      "inputPathCount" : 283,
       "outputPathCount" : 281,
       "modelValidationFailures" : 22,
       "runtimeError" : false
@@ -580,7 +580,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex27-inverse-floater.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex27-inverse-floater.json",
     "assertions" : {
-      "inputPathCount" : 86,
+      "inputPathCount" : 82,
       "outputPathCount" : 111,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -591,7 +591,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex28-bullet-payments.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex28-bullet-payments.json",
     "assertions" : {
-      "inputPathCount" : 27,
+      "inputPathCount" : 23,
       "outputPathCount" : 13,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -602,7 +602,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex29-non-deliverable-settlement-swap-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex29-non-deliverable-settlement-swap-uti.json",
     "assertions" : {
-      "inputPathCount" : 109,
+      "inputPathCount" : 107,
       "outputPathCount" : 130,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -613,7 +613,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex30-swap-comp-avg-relative-date-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex30-swap-comp-avg-relative-date-uti.json",
     "assertions" : {
-      "inputPathCount" : 248,
+      "inputPathCount" : 246,
       "outputPathCount" : 241,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -624,7 +624,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex31-non-deliverable-settlement-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex31-non-deliverable-settlement-swap.json",
     "assertions" : {
-      "inputPathCount" : 127,
+      "inputPathCount" : 123,
       "outputPathCount" : 128,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -657,7 +657,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex34-MXN-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex34-MXN-swap.json",
     "assertions" : {
-      "inputPathCount" : 81,
+      "inputPathCount" : 77,
       "outputPathCount" : 97,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -668,7 +668,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex35-inverse-floater-inverse-vs-floating.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex35-inverse-floater-inverse-vs-floating.json",
     "assertions" : {
-      "inputPathCount" : 102,
+      "inputPathCount" : 98,
       "outputPathCount" : 128,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -679,7 +679,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-ex36-amer-swaption-pred-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-ex36-amer-swaption-pred-clearing.json",
     "assertions" : {
-      "inputPathCount" : 126,
+      "inputPathCount" : 122,
       "outputPathCount" : 152,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -701,7 +701,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-xccy-CNH-USD-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-xccy-CNH-USD-uti.json",
     "assertions" : {
-      "inputPathCount" : 181,
+      "inputPathCount" : 179,
       "outputPathCount" : 212,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -712,7 +712,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/ird-xccy-fixed-swap-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/ird-xccy-fixed-swap-uti.json",
     "assertions" : {
-      "inputPathCount" : 82,
+      "inputPathCount" : 80,
       "outputPathCount" : 98,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -723,7 +723,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/NDS-CNY-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/NDS-CNY-uti.json",
     "assertions" : {
-      "inputPathCount" : 120,
+      "inputPathCount" : 118,
       "outputPathCount" : 145,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -734,7 +734,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/NDS-INR-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/NDS-INR-uti.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 113,
       "outputPathCount" : 140,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -745,7 +745,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/NDS-KRW-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/NDS-KRW-uti.json",
     "assertions" : {
-      "inputPathCount" : 118,
+      "inputPathCount" : 116,
       "outputPathCount" : 143,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -767,7 +767,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/USD-Long-Final-Stub-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/USD-Long-Final-Stub-uti.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 98,
       "outputPathCount" : 125,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -778,7 +778,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/USD-OIS-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/USD-OIS-uti.json",
     "assertions" : {
-      "inputPathCount" : 105,
+      "inputPathCount" : 103,
       "outputPathCount" : 130,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -789,7 +789,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/USD-Vanilla-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/USD-Vanilla-swap.json",
     "assertions" : {
-      "inputPathCount" : 130,
+      "inputPathCount" : 126,
       "outputPathCount" : 128,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -800,7 +800,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/USD-Vanilla-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/USD-Vanilla-uti.json",
     "assertions" : {
-      "inputPathCount" : 91,
+      "inputPathCount" : 89,
       "outputPathCount" : 116,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -811,7 +811,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-rates/USD-VNS-uti.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/USD-VNS-uti.json",
     "assertions" : {
-      "inputPathCount" : 188,
+      "inputPathCount" : 186,
       "outputPathCount" : 219,
       "modelValidationFailures" : 1,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-rates.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-rates.json
@@ -130,7 +130,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-Vanilla-multiple-accounts.json",
     "assertions" : {
       "inputPathCount" : 102,
-      "outputPathCount" : 128,
+      "outputPathCount" : 127,
       "modelValidationFailures" : 1,
       "runtimeError" : false
     }

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-variance-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-variance-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-variance-swaps/eqvs-ex01-variance-swap-index.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-variance-swaps/eqvs-ex01-variance-swap-index.json",
     "assertions" : {
-      "inputPathCount" : 64,
+      "inputPathCount" : 60,
       "outputPathCount" : 72,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-variance-swaps/eqvs-ex02-variance-swap-single-stock.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-variance-swaps/eqvs-ex02-variance-swap-single-stock.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 71,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-variance-swaps/eqvs-ex03-conditional-variance-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-variance-swaps/eqvs-ex03-conditional-variance-swap.json",
     "assertions" : {
-      "inputPathCount" : 62,
+      "inputPathCount" : 58,
       "outputPathCount" : 63,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-variance-swaps/eqvs-ex04-dispersion-variance-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-variance-swaps/eqvs-ex04-dispersion-variance-swap.json",
     "assertions" : {
-      "inputPathCount" : 123,
+      "inputPathCount" : 121,
       "outputPathCount" : 111,
       "modelValidationFailures" : 15,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-variance-swaps/eqvs-ex05-dispersion-variance-swap-transaction-supplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-variance-swaps/eqvs-ex05-dispersion-variance-swap-transaction-supplement.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 82,
       "outputPathCount" : 89,
       "modelValidationFailures" : 16,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-variance-swaps/eqvs-ex06-variance-option-transaction-supplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-variance-swaps/eqvs-ex06-variance-option-transaction-supplement.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 75,
       "outputPathCount" : 87,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-variance-swaps/eqvs-ex07-variance-option-transaction-supplement-pred-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-variance-swaps/eqvs-ex07-variance-option-transaction-supplement-pred-clearing.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 81,
       "outputPathCount" : 96,
       "modelValidationFailures" : 6,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-volatility-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-volatility-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-volatility-swaps/eqvls-ex01-volatility-swap-index-matrix.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-volatility-swaps/eqvls-ex01-volatility-swap-index-matrix.json",
     "assertions" : {
-      "inputPathCount" : 59,
+      "inputPathCount" : 55,
       "outputPathCount" : 62,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-10-products-volatility-swaps/eqvls-ex02-volatility-swap-index-mca.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-volatility-swaps/eqvls-ex02-volatility-swap-index-mca.json",
     "assertions" : {
-      "inputPathCount" : 55,
+      "inputPathCount" : 51,
       "outputPathCount" : 58,
       "modelValidationFailures" : 5,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-incomplete-products-equity.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-incomplete-products-equity.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-12-incomplete-products-equity/eqs-ex04-zero-strike-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-incomplete-products-equity/eqs-ex04-zero-strike-long-form.json",
     "assertions" : {
-      "inputPathCount" : 127,
+      "inputPathCount" : 120,
       "outputPathCount" : 96,
       "modelValidationFailures" : 2,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-commodity.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-commodity.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-commodity/com-ex01-energy-oil-cash.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-commodity/com-ex01-energy-oil-cash.json",
     "assertions" : {
-      "inputPathCount" : 189,
+      "inputPathCount" : 194,
       "outputPathCount" : 97,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-commodity/com-ex02-energy-nat-gas-cash.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-commodity/com-ex02-energy-nat-gas-cash.json",
     "assertions" : {
-      "inputPathCount" : 140,
+      "inputPathCount" : 136,
       "outputPathCount" : 119,
       "modelValidationFailures" : 14,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-commodity/com-ex1-gas-swap-daily-delivery-prices-last.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-commodity/com-ex1-gas-swap-daily-delivery-prices-last.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 67,
       "outputPathCount" : 97,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-commodity/com-ex5-gas-v-electricity-spark-spread.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-commodity/com-ex5-gas-v-electricity-spark-spread.json",
     "assertions" : {
-      "inputPathCount" : 77,
+      "inputPathCount" : 73,
       "outputPathCount" : 109,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-commodity/com-ex8-oil-call-option-strip.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-commodity/com-ex8-oil-call-option-strip.json",
     "assertions" : {
-      "inputPathCount" : 78,
+      "inputPathCount" : 65,
       "outputPathCount" : 83,
       "modelValidationFailures" : 4,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-credit.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-credit.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cd-ex01-long-asia-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cd-ex01-long-asia-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 84,
       "outputPathCount" : 119,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cd-ex02-2003-short-asia-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cd-ex02-2003-short-asia-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 43,
+      "inputPathCount" : 39,
       "outputPathCount" : 63,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cd-ex16-short-us-corp-fixreg-recovery-factor.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cd-ex16-short-us-corp-fixreg-recovery-factor.json",
     "assertions" : {
-      "inputPathCount" : 45,
+      "inputPathCount" : 41,
       "outputPathCount" : 67,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cd-indamt-ex01-short-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cd-indamt-ex01-short-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 43,
       "outputPathCount" : 66,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cd-swaption-1.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cd-swaption-1.json",
     "assertions" : {
-      "inputPathCount" : 101,
+      "inputPathCount" : 99,
       "outputPathCount" : 123,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cd-swaption-2.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cd-swaption-2.json",
     "assertions" : {
-      "inputPathCount" : 121,
+      "inputPathCount" : 119,
       "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cdindex-ex01-cdx.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cdindex-ex01-cdx.json",
     "assertions" : {
-      "inputPathCount" : 37,
+      "inputPathCount" : 33,
       "outputPathCount" : 59,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cdindex-ex02-iTraxx.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cdindex-ex02-iTraxx.json",
     "assertions" : {
-      "inputPathCount" : 35,
+      "inputPathCount" : 31,
       "outputPathCount" : 47,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cdindex-ex03-iTraxx-contractual-supplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cdindex-ex03-iTraxx-contractual-supplement.json",
     "assertions" : {
-      "inputPathCount" : 49,
+      "inputPathCount" : 45,
       "outputPathCount" : 66,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cdindex-ex04-iBoxx.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cdindex-ex04-iBoxx.json",
     "assertions" : {
-      "inputPathCount" : 48,
+      "inputPathCount" : 42,
       "outputPathCount" : 79,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cdindex-ex05-SP.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cdindex-ex05-SP.json",
     "assertions" : {
-      "inputPathCount" : 49,
+      "inputPathCount" : 43,
       "outputPathCount" : 72,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cds-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cds-basket.json",
     "assertions" : {
-      "inputPathCount" : 76,
+      "inputPathCount" : 74,
       "outputPathCount" : 89,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cds-basket-tranche.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cds-basket-tranche.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 77,
       "outputPathCount" : 92,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cds-ELCDS-ReferenceObligation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cds-ELCDS-ReferenceObligation.json",
     "assertions" : {
-      "inputPathCount" : 66,
+      "inputPathCount" : 64,
       "outputPathCount" : 76,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cds-index-tranche.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cds-index-tranche.json",
     "assertions" : {
-      "inputPathCount" : 37,
+      "inputPathCount" : 33,
       "outputPathCount" : 49,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cds-loan-ReferenceObligation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cds-loan-ReferenceObligation.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 90,
       "outputPathCount" : 102,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cds-loan-SecuredList.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cds-loan-SecuredList.json",
     "assertions" : {
-      "inputPathCount" : 87,
+      "inputPathCount" : 83,
       "outputPathCount" : 98,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cds-mortgage-CMBS.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cds-mortgage-CMBS.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 80,
       "outputPathCount" : 84,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cds-mortgage-RMBS.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cds-mortgage-RMBS.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 80,
       "outputPathCount" : 84,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/cdx-index-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/cdx-index-option.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 77,
       "outputPathCount" : 110,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-credit/itraxx-index-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-credit/itraxx-index-option.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 94,
       "outputPathCount" : 120,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-equity.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-equity.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqd-ex01-american-call-stock-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqd-ex01-american-call-stock-long-form.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 86,
       "outputPathCount" : 81,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqd-ex04-european-call-index-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqd-ex04-european-call-index-long-form.json",
     "assertions" : {
-      "inputPathCount" : 75,
+      "inputPathCount" : 73,
       "outputPathCount" : 78,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex01-single-underlyer-execution-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex01-single-underlyer-execution-long-form.json",
     "assertions" : {
-      "inputPathCount" : 165,
+      "inputPathCount" : 158,
       "outputPathCount" : 160,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex05-single-stock-plus-fee-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex05-single-stock-plus-fee-long-form.json",
     "assertions" : {
-      "inputPathCount" : 164,
+      "inputPathCount" : 160,
       "outputPathCount" : 142,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex06-single-index-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex06-single-index-long-form.json",
     "assertions" : {
-      "inputPathCount" : 145,
+      "inputPathCount" : 138,
       "outputPathCount" : 147,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex09-compounding-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex09-compounding-swap.json",
     "assertions" : {
-      "inputPathCount" : 90,
+      "inputPathCount" : 86,
       "outputPathCount" : 105,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex10-short-form-interestLeg-driving-schedule-dates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex10-short-form-interestLeg-driving-schedule-dates.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 93,
       "outputPathCount" : 113,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex11-on-european-single-stock-underlyer-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex11-on-european-single-stock-underlyer-short-form.json",
     "assertions" : {
-      "inputPathCount" : 138,
+      "inputPathCount" : 131,
       "outputPathCount" : 155,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex12-on-european-index-underlyer-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex12-on-european-index-underlyer-short-form.json",
     "assertions" : {
-      "inputPathCount" : 140,
+      "inputPathCount" : 133,
       "outputPathCount" : 157,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex13-pan-asia-interdealer-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex13-pan-asia-interdealer-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 164,
+      "inputPathCount" : 157,
       "outputPathCount" : 173,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex14-european-interdealer-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex14-european-interdealer-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 159,
+      "inputPathCount" : 152,
       "outputPathCount" : 158,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 161,
+      "inputPathCount" : 158,
       "outputPathCount" : 168,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex17-cfd.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex17-cfd.json",
     "assertions" : {
-      "inputPathCount" : 106,
+      "inputPathCount" : 94,
       "outputPathCount" : 110,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex18-pan-asia-interdealer-index-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex18-pan-asia-interdealer-index-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 145,
+      "inputPathCount" : 139,
       "outputPathCount" : 145,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 144,
+      "inputPathCount" : 138,
       "outputPathCount" : 144,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/trs-ex02-single-equity.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/trs-ex02-single-equity.json",
     "assertions" : {
-      "inputPathCount" : 179,
+      "inputPathCount" : 172,
       "outputPathCount" : 139,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.json",
     "assertions" : {
-      "inputPathCount" : 185,
+      "inputPathCount" : 178,
       "outputPathCount" : 163,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-equity/trs-ex04-index-ios.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-equity/trs-ex04-index-ios.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 111,
       "outputPathCount" : 110,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-fx.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-fx.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex01-fx-spot.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex01-fx-spot.json",
     "assertions" : {
-      "inputPathCount" : 42,
+      "inputPathCount" : 38,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex02-spot-cross-w-side-rates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex02-spot-cross-w-side-rates.json",
     "assertions" : {
-      "inputPathCount" : 50,
+      "inputPathCount" : 46,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex03-fx-fwd.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex03-fx-fwd.json",
     "assertions" : {
-      "inputPathCount" : 44,
+      "inputPathCount" : 40,
       "outputPathCount" : 45,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex04-fx-fwd-w-settlement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex04-fx-fwd-w-settlement.json",
     "assertions" : {
-      "inputPathCount" : 55,
+      "inputPathCount" : 51,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex05-fx-fwd-w-ssi.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex05-fx-fwd-w-ssi.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 43,
       "outputPathCount" : 45,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex06-fx-fwd-w-splits.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex06-fx-fwd-w-splits.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 67,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex07-non-deliverable-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex07-non-deliverable-forward.json",
     "assertions" : {
-      "inputPathCount" : 53,
+      "inputPathCount" : 49,
       "outputPathCount" : 53,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex08-fx-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex08-fx-swap.json",
     "assertions" : {
-      "inputPathCount" : 57,
+      "inputPathCount" : 53,
       "outputPathCount" : 64,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex09-euro-opt.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex09-euro-opt.json",
     "assertions" : {
-      "inputPathCount" : 59,
+      "inputPathCount" : 55,
       "outputPathCount" : 61,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex10-amer-opt.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex10-amer-opt.json",
     "assertions" : {
-      "inputPathCount" : 61,
+      "inputPathCount" : 57,
       "outputPathCount" : 64,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex11-non-deliverable-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex11-non-deliverable-option.json",
     "assertions" : {
-      "inputPathCount" : 59,
+      "inputPathCount" : 55,
       "outputPathCount" : 70,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex12-fx-barrier-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex12-fx-barrier-option.json",
     "assertions" : {
-      "inputPathCount" : 60,
+      "inputPathCount" : 56,
       "outputPathCount" : 57,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex20-avg-rate-option-parametric.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex20-avg-rate-option-parametric.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 52,
       "outputPathCount" : 65,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex22-avg-rate-option-specific.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex22-avg-rate-option-specific.json",
     "assertions" : {
-      "inputPathCount" : 151,
+      "inputPathCount" : 97,
       "outputPathCount" : 60,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-fx/fx-ex28-non-deliverable-w-disruption.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-fx/fx-ex28-non-deliverable-w-disruption.json",
     "assertions" : {
-      "inputPathCount" : 58,
+      "inputPathCount" : 54,
       "outputPathCount" : 45,
       "modelValidationFailures" : 1,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-rates.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-rates.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/bond-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/bond-option.json",
     "assertions" : {
-      "inputPathCount" : 65,
+      "inputPathCount" : 63,
       "outputPathCount" : 69,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/cb-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/cb-option.json",
     "assertions" : {
-      "inputPathCount" : 78,
+      "inputPathCount" : 76,
       "outputPathCount" : 74,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/cb-option-2.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/cb-option-2.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 70,
       "outputPathCount" : 70,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex01-vanilla-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex01-vanilla-swap.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 101,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex02-stub-amort-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex02-stub-amort-swap.json",
     "assertions" : {
-      "inputPathCount" : 197,
+      "inputPathCount" : 193,
       "outputPathCount" : 215,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex03-compound-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex03-compound-swap.json",
     "assertions" : {
-      "inputPathCount" : 156,
+      "inputPathCount" : 152,
       "outputPathCount" : 171,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex04-arrears-stepup-fee-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex04-arrears-stepup-fee-swap.json",
     "assertions" : {
-      "inputPathCount" : 89,
+      "inputPathCount" : 85,
       "outputPathCount" : 107,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex05-long-stub-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex05-long-stub-swap.json",
     "assertions" : {
-      "inputPathCount" : 97,
+      "inputPathCount" : 93,
       "outputPathCount" : 119,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex06-xccy-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex06-xccy-swap.json",
     "assertions" : {
-      "inputPathCount" : 184,
+      "inputPathCount" : 180,
       "outputPathCount" : 212,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex07-ois-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex07-ois-swap.json",
     "assertions" : {
-      "inputPathCount" : 81,
+      "inputPathCount" : 77,
       "outputPathCount" : 98,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex08-fra.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex08-fra.json",
     "assertions" : {
-      "inputPathCount" : 41,
+      "inputPathCount" : 37,
       "outputPathCount" : 72,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex09-euro-swaption-explicit.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex09-euro-swaption-explicit.json",
     "assertions" : {
-      "inputPathCount" : 106,
+      "inputPathCount" : 102,
       "outputPathCount" : 129,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex10-euro-swaption-relative.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex10-euro-swaption-relative.json",
     "assertions" : {
-      "inputPathCount" : 113,
+      "inputPathCount" : 109,
       "outputPathCount" : 130,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex11-euro-swaption-partial-auto-ex.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex11-euro-swaption-partial-auto-ex.json",
     "assertions" : {
-      "inputPathCount" : 111,
+      "inputPathCount" : 107,
       "outputPathCount" : 130,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex12-euro-swaption-straddle-cash.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex12-euro-swaption-straddle-cash.json",
     "assertions" : {
-      "inputPathCount" : 122,
+      "inputPathCount" : 118,
       "outputPathCount" : 142,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex22-cap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex22-cap.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 68,
       "outputPathCount" : 84,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex23-floor.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex23-floor.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 68,
       "outputPathCount" : 84,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex24-collar.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex24-collar.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 99,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex25-fxnotional-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex25-fxnotional-swap.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 111,
       "outputPathCount" : 129,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex27-inverse-floater.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex27-inverse-floater.json",
     "assertions" : {
-      "inputPathCount" : 86,
+      "inputPathCount" : 82,
       "outputPathCount" : 111,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex29-non-deliverable-settlement-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex29-non-deliverable-settlement-swap.json",
     "assertions" : {
-      "inputPathCount" : 113,
+      "inputPathCount" : 109,
       "outputPathCount" : 128,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -239,7 +239,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex30-swap-comp-avg-relative-date.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex30-swap-comp-avg-relative-date.json",
     "assertions" : {
-      "inputPathCount" : 251,
+      "inputPathCount" : 247,
       "outputPathCount" : 240,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -250,7 +250,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex32-zero-coupon-swap-normal-rate.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex32-zero-coupon-swap-normal-rate.json",
     "assertions" : {
-      "inputPathCount" : 159,
+      "inputPathCount" : 149,
       "outputPathCount" : 136,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -261,7 +261,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex33-BRL-CDI-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex33-BRL-CDI-swap.json",
     "assertions" : {
-      "inputPathCount" : 112,
+      "inputPathCount" : 110,
       "outputPathCount" : 124,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -272,7 +272,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex40-rfr-avg-swap-obs-period-shift.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex40-rfr-avg-swap-obs-period-shift.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 83,
       "outputPathCount" : 97,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -283,7 +283,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex46-rfr-compound-swap-lookback-oet-mmviq.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex46-rfr-compound-swap-lookback-oet-mmviq.json",
     "assertions" : {
-      "inputPathCount" : 152,
+      "inputPathCount" : 116,
       "outputPathCount" : 135,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -294,7 +294,7 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex47-rfr-compound-swap-lookback-oet-rvfq.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex47-rfr-compound-swap-lookback-oet-rvfq.json",
     "assertions" : {
-      "inputPathCount" : 150,
+      "inputPathCount" : 115,
       "outputPathCount" : 134,
       "modelValidationFailures" : 2,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-rates.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-rates.json
@@ -250,8 +250,8 @@
     "inputPath" : "ingest/input/fpml-5-12-products-rates/ird-ex32-zero-coupon-swap-normal-rate.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex32-zero-coupon-swap-normal-rate.json",
     "assertions" : {
-      "inputPathCount" : 149,
-      "outputPathCount" : 136,
+      "inputPathCount" : 153,
+      "outputPathCount" : 140,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-commodity-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-commodity-derivatives.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex10-physical-oil-pipeline-crude-wti-floating-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex10-physical-oil-pipeline-crude-wti-floating-price.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 52,
       "outputPathCount" : 50,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex11-physical-oil-pipeline-heating-oil-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex11-physical-oil-pipeline-heating-oil-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 53,
+      "inputPathCount" : 49,
       "outputPathCount" : 44,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex12-physical-gas-europe-zbt-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex12-physical-gas-europe-zbt-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 51,
+      "inputPathCount" : 47,
       "outputPathCount" : 44,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex13-physical-gas-us-tw-west-texas-pool-floating-price-4-days.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex13-physical-gas-us-tw-west-texas-pool-floating-price-4-days.json",
     "assertions" : {
-      "inputPathCount" : 54,
+      "inputPathCount" : 50,
       "outputPathCount" : 52,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex14-physical-gas-europe-ttf-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex14-physical-gas-europe-ttf-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 55,
+      "inputPathCount" : 51,
       "outputPathCount" : 39,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex15-physical-oil-pipeline-crude-wcs-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex15-physical-oil-pipeline-crude-wcs-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 52,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex16-physical-power-us-eei-floating-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex16-physical-power-us-eei-floating-price.json",
     "assertions" : {
-      "inputPathCount" : 69,
+      "inputPathCount" : 65,
       "outputPathCount" : 50,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex17-physical-power-uk-gtma-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex17-physical-power-uk-gtma-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 61,
+      "inputPathCount" : 57,
       "outputPathCount" : 29,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex18-physical-power-us-eei-fixed-price-shaped-volume.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex18-physical-power-us-eei-fixed-price-shaped-volume.json",
     "assertions" : {
-      "inputPathCount" : 105,
+      "inputPathCount" : 101,
       "outputPathCount" : 29,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex19-physical-bullion-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex19-physical-bullion-forward.json",
     "assertions" : {
-      "inputPathCount" : 51,
+      "inputPathCount" : 47,
       "outputPathCount" : 22,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex20-physical-coal-us-fixed-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex20-physical-coal-us-fixed-price.json",
     "assertions" : {
-      "inputPathCount" : 51,
+      "inputPathCount" : 47,
       "outputPathCount" : 36,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex21-physical-power-us-eei-fixed-price-shaped-volume-and-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex21-physical-power-us-eei-fixed-price-shaped-volume-and-price.json",
     "assertions" : {
-      "inputPathCount" : 121,
+      "inputPathCount" : 117,
       "outputPathCount" : 33,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex22-physical-gas-option-multiple-expiration.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex22-physical-gas-option-multiple-expiration.json",
     "assertions" : {
-      "inputPathCount" : 82,
+      "inputPathCount" : 78,
       "outputPathCount" : 54,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex23-physical-power-option-daily-expiration-efet.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex23-physical-power-option-daily-expiration-efet.json",
     "assertions" : {
-      "inputPathCount" : 101,
+      "inputPathCount" : 97,
       "outputPathCount" : 48,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex24-weather-index-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex24-weather-index-swap.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 81,
       "outputPathCount" : 27,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex25-physical-bullion-forward-average-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex25-physical-bullion-forward-average-price.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 22,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex26-physical-metal-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex26-physical-metal-forward.json",
     "assertions" : {
-      "inputPathCount" : 60,
+      "inputPathCount" : 56,
       "outputPathCount" : 21,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex27-wti-put-option-asian-listedoption-date.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex27-wti-put-option-asian-listedoption-date.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 64,
       "outputPathCount" : 87,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex28-gas-swap-daily-delivery-prices-option-last.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex28-gas-swap-daily-delivery-prices-option-last.json",
     "assertions" : {
-      "inputPathCount" : 75,
+      "inputPathCount" : 71,
       "outputPathCount" : 99,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex29-physical-eu-emissions-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex29-physical-eu-emissions-option.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 70,
       "outputPathCount" : 54,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex30-physical-eu-emissions-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex30-physical-eu-emissions-forward.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 54,
       "outputPathCount" : 35,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -239,7 +239,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex31-physical-us-emissions-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex31-physical-us-emissions-option.json",
     "assertions" : {
-      "inputPathCount" : 67,
+      "inputPathCount" : 65,
       "outputPathCount" : 54,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -250,7 +250,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex32-CPD-weather-index-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex32-CPD-weather-index-option.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 70,
       "outputPathCount" : 51,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -261,7 +261,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex33-physical-bullion-forward-average-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex33-physical-bullion-forward-average-price.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 22,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -272,7 +272,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex39-basket-option-confirmation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex39-basket-option-confirmation.json",
     "assertions" : {
-      "inputPathCount" : 119,
+      "inputPathCount" : 115,
       "outputPathCount" : 25,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -283,7 +283,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex40-gas-digital-option-storage-volume-trigger.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex40-gas-digital-option-storage-volume-trigger.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 69,
       "outputPathCount" : 14,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -294,7 +294,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex42-index-return-swap-reinvestment-feature.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex42-index-return-swap-reinvestment-feature.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 69,
       "outputPathCount" : 20,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -305,7 +305,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex43-WTI-variance-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex43-WTI-variance-swap.json",
     "assertions" : {
-      "inputPathCount" : 62,
+      "inputPathCount" : 60,
       "outputPathCount" : 20,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -316,7 +316,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex44-index-return-swap-fixed-notional.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex44-index-return-swap-fixed-notional.json",
     "assertions" : {
-      "inputPathCount" : 66,
+      "inputPathCount" : 64,
       "outputPathCount" : 20,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -327,7 +327,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex45-ag-variance-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex45-ag-variance-swap.json",
     "assertions" : {
-      "inputPathCount" : 53,
+      "inputPathCount" : 51,
       "outputPathCount" : 21,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -338,7 +338,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-commodity-derivatives/com-ex47-physical-eu-emissions-option-pred-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-commodity-derivatives/com-ex47-physical-eu-emissions-option-pred-clearing.json",
     "assertions" : {
-      "inputPathCount" : 78,
+      "inputPathCount" : 76,
       "outputPathCount" : 61,
       "modelValidationFailures" : 10,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-correlation-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-correlation-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-correlation-swaps/eqcs-ex03-correlation-swap-confirmation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-correlation-swaps/eqcs-ex03-correlation-swap-confirmation.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 94,
       "outputPathCount" : 94,
       "modelValidationFailures" : 9,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-equity-options.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-equity-options.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex-27-equityOptionTransactionSupplement-EMEA-interdealer.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex-27-equityOptionTransactionSupplement-EMEA-interdealer.json",
     "assertions" : {
-      "inputPathCount" : 70,
+      "inputPathCount" : 66,
       "outputPathCount" : 75,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex01-american-call-stock-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex01-american-call-stock-long-form.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 86,
       "outputPathCount" : 81,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex04-european-call-index-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex04-european-call-index-long-form.json",
     "assertions" : {
-      "inputPathCount" : 75,
+      "inputPathCount" : 73,
       "outputPathCount" : 78,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex05-asian-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex05-asian-long-form.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 74,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex06-averaging-in-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex06-averaging-in-long-form.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 74,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex08-basket-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex08-basket-long-form.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 82,
       "outputPathCount" : 84,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex09-bermuda-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex09-bermuda-long-form.json",
     "assertions" : {
-      "inputPathCount" : 91,
+      "inputPathCount" : 89,
       "outputPathCount" : 89,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex11-quanto-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex11-quanto-long-form.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 82,
       "outputPathCount" : 79,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex14-american-call-stock-passthrough-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex14-american-call-stock-passthrough-long-form.json",
     "assertions" : {
-      "inputPathCount" : 93,
+      "inputPathCount" : 91,
       "outputPathCount" : 82,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex15-basket-passthrough-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex15-basket-passthrough-long-form.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 92,
       "outputPathCount" : 84,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex16-equityOptionTransactionSupplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex16-equityOptionTransactionSupplement.json",
     "assertions" : {
-      "inputPathCount" : 52,
+      "inputPathCount" : 50,
       "outputPathCount" : 76,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex17-equityOptionTransactionSupplement-non-deliverable-share.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex17-equityOptionTransactionSupplement-non-deliverable-share.json",
     "assertions" : {
-      "inputPathCount" : 62,
+      "inputPathCount" : 58,
       "outputPathCount" : 73,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex18-equityOptionTransactionSupplement-non-deliverable-index.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex18-equityOptionTransactionSupplement-non-deliverable-index.json",
     "assertions" : {
-      "inputPathCount" : 60,
+      "inputPathCount" : 56,
       "outputPathCount" : 76,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex19-dividend-adjustment.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex19-dividend-adjustment.json",
     "assertions" : {
-      "inputPathCount" : 102,
+      "inputPathCount" : 100,
       "outputPathCount" : 79,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex20-nested-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex20-nested-basket.json",
     "assertions" : {
-      "inputPathCount" : 99,
+      "inputPathCount" : 97,
       "outputPathCount" : 81,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex21-flat-weight-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex21-flat-weight-basket.json",
     "assertions" : {
-      "inputPathCount" : 98,
+      "inputPathCount" : 96,
       "outputPathCount" : 100,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex22-equityOptionTransactionSupplement-index-option-asian-dates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex22-equityOptionTransactionSupplement-index-option-asian-dates.json",
     "assertions" : {
-      "inputPathCount" : 110,
+      "inputPathCount" : 108,
       "outputPathCount" : 69,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex23-equityOptionTransactionSupplement-index-option-cliquet.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex23-equityOptionTransactionSupplement-index-option-cliquet.json",
     "assertions" : {
-      "inputPathCount" : 80,
+      "inputPathCount" : 78,
       "outputPathCount" : 69,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex24-equityOptionTransactionSupplement-index-option-asian-schedule.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex24-equityOptionTransactionSupplement-index-option-asian-schedule.json",
     "assertions" : {
-      "inputPathCount" : 80,
+      "inputPathCount" : 78,
       "outputPathCount" : 71,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-options/eqd-ex25-equityOptionTransactionSupplement-index-option-knock-in-knock-out-features.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-options/eqd-ex25-equityOptionTransactionSupplement-index-option-knock-in-knock-out-features.json",
     "assertions" : {
-      "inputPathCount" : 87,
+      "inputPathCount" : 85,
       "outputPathCount" : 69,
       "modelValidationFailures" : 6,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-equity-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-equity-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-swaps/eqs-ex04-zero-strike-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-swaps/eqs-ex04-zero-strike-long-form.json",
     "assertions" : {
-      "inputPathCount" : 127,
+      "inputPathCount" : 120,
       "outputPathCount" : 96,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-swaps/eqs-ex05-single-stock-plus-fee-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-swaps/eqs-ex05-single-stock-plus-fee-long-form.json",
     "assertions" : {
-      "inputPathCount" : 164,
+      "inputPathCount" : 160,
       "outputPathCount" : 142,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-equity-swaps/trs-ex01-equity-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-equity-swaps/trs-ex01-equity-basket.json",
     "assertions" : {
-      "inputPathCount" : 200,
+      "inputPathCount" : 185,
       "outputPathCount" : 139,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-fx-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-fx-derivatives.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/dcd-ex01-dual-currency-deposit.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/dcd-ex01-dual-currency-deposit.json",
     "assertions" : {
-      "inputPathCount" : 51,
+      "inputPathCount" : 47,
       "outputPathCount" : 17,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex04-fx-fwd-w-settlement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex04-fx-fwd-w-settlement.json",
     "assertions" : {
-      "inputPathCount" : 55,
+      "inputPathCount" : 51,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex06-fx-fwd-w-splits.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex06-fx-fwd-w-splits.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 67,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex12-fx-barrier-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex12-fx-barrier-option.json",
     "assertions" : {
-      "inputPathCount" : 60,
+      "inputPathCount" : 56,
       "outputPathCount" : 57,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex13-fx-dbl-barrier-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex13-fx-dbl-barrier-option.json",
     "assertions" : {
-      "inputPathCount" : 76,
+      "inputPathCount" : 72,
       "outputPathCount" : 60,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex14-euro-digital-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex14-euro-digital-option.json",
     "assertions" : {
-      "inputPathCount" : 55,
+      "inputPathCount" : 51,
       "outputPathCount" : 41,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex15-euro-range-digital-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex15-euro-range-digital-option.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 41,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex16-one-touch-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex16-one-touch-option.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 44,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex17-no-touch-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex17-no-touch-option.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 44,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex18-double-one-touch-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex18-double-one-touch-option.json",
     "assertions" : {
-      "inputPathCount" : 76,
+      "inputPathCount" : 72,
       "outputPathCount" : 44,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex19-double-no-touch-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex19-double-no-touch-option.json",
     "assertions" : {
-      "inputPathCount" : 76,
+      "inputPathCount" : 72,
       "outputPathCount" : 44,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex23-straddle.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex23-straddle.json",
     "assertions" : {
-      "inputPathCount" : 74,
+      "inputPathCount" : 70,
       "outputPathCount" : 17,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex24-delta-hedge.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex24-delta-hedge.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 67,
       "outputPathCount" : 17,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex25-option-strategyComponentIdentifier.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex25-option-strategyComponentIdentifier.json",
     "assertions" : {
-      "inputPathCount" : 110,
+      "inputPathCount" : 98,
       "outputPathCount" : 37,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex27-flexible-term-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex27-flexible-term-forward.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 45,
       "outputPathCount" : 13,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-fx-derivatives/fx-ex32-forward-volatility-agreement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-fx-derivatives/fx-ex32-forward-volatility-agreement.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 54,
       "outputPathCount" : 16,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-variance-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-variance-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-variance-swaps/eqvs-ex01-variance-swap-index.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-variance-swaps/eqvs-ex01-variance-swap-index.json",
     "assertions" : {
-      "inputPathCount" : 64,
+      "inputPathCount" : 60,
       "outputPathCount" : 72,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-products-variance-swaps/eqvs-ex03-conditional-variance-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-incomplete-products-variance-swaps/eqvs-ex03-conditional-variance-swap.json",
     "assertions" : {
-      "inputPathCount" : 62,
+      "inputPathCount" : 58,
       "outputPathCount" : 63,
       "modelValidationFailures" : 7,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-bond-options.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-bond-options.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-bond-options/bond-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-bond-options/bond-option.json",
     "assertions" : {
-      "inputPathCount" : 65,
+      "inputPathCount" : 63,
       "outputPathCount" : 69,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-bond-options/cb-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-bond-options/cb-option.json",
     "assertions" : {
-      "inputPathCount" : 78,
+      "inputPathCount" : 76,
       "outputPathCount" : 74,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-bond-options/cb-option-2.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-bond-options/cb-option-2.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 70,
       "outputPathCount" : 70,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-bond-options/cb-option-ois.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-bond-options/cb-option-ois.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 77,
       "outputPathCount" : 77,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-commodity-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-commodity-derivatives.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex1-gas-swap-daily-delivery-prices-last.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex1-gas-swap-daily-delivery-prices-last.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 67,
       "outputPathCount" : 97,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex2-gas-swap-prices-first-day.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex2-gas-swap-prices-first-day.json",
     "assertions" : {
-      "inputPathCount" : 69,
+      "inputPathCount" : 65,
       "outputPathCount" : 93,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex3-gas-swap-prices-last-three-days.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex3-gas-swap-prices-last-three-days.json",
     "assertions" : {
-      "inputPathCount" : 73,
+      "inputPathCount" : 69,
       "outputPathCount" : 98,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex34-gas-put-option-european-floating-strike.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex34-gas-put-option-european-floating-strike.json",
     "assertions" : {
-      "inputPathCount" : 107,
+      "inputPathCount" : 87,
       "outputPathCount" : 83,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex35-call-option-gas-power-heat-rate-daily.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex35-call-option-gas-power-heat-rate-daily.json",
     "assertions" : {
-      "inputPathCount" : 98,
+      "inputPathCount" : 78,
       "outputPathCount" : 83,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex36-gas-call-option-european-spread-negative-premium-floating-strike.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex36-gas-call-option-european-spread-negative-premium-floating-strike.json",
     "assertions" : {
-      "inputPathCount" : 99,
+      "inputPathCount" : 80,
       "outputPathCount" : 88,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex37-gold-forward-offered-rate.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex37-gold-forward-offered-rate.json",
     "assertions" : {
-      "inputPathCount" : 104,
+      "inputPathCount" : 100,
       "outputPathCount" : 124,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex4-electricity-swap-hourly-off-peak.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex4-electricity-swap-hourly-off-peak.json",
     "assertions" : {
-      "inputPathCount" : 71,
+      "inputPathCount" : 67,
       "outputPathCount" : 97,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex41-oil-asian-barrier-option-strip.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex41-oil-asian-barrier-option-strip.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 84,
       "outputPathCount" : 77,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex46-simple-financial-put-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex46-simple-financial-put-option.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 63,
       "outputPathCount" : 89,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex48-gold-forward-offered-rate-ois.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex48-gold-forward-offered-rate-ois.json",
     "assertions" : {
-      "inputPathCount" : 103,
+      "inputPathCount" : 99,
       "outputPathCount" : 125,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex5-gas-v-electricity-spark-spread.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex5-gas-v-electricity-spark-spread.json",
     "assertions" : {
-      "inputPathCount" : 77,
+      "inputPathCount" : 73,
       "outputPathCount" : 109,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex6-gas-call-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex6-gas-call-option.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 62,
       "outputPathCount" : 85,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex7-gas-put-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex7-gas-put-option.json",
     "assertions" : {
-      "inputPathCount" : 75,
+      "inputPathCount" : 60,
       "outputPathCount" : 83,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex8-oil-call-option-strip.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex8-oil-call-option-strip.json",
     "assertions" : {
-      "inputPathCount" : 78,
+      "inputPathCount" : 65,
       "outputPathCount" : 83,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -173,9 +173,9 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-ex9-oil-put-option-american.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex9-oil-put-option-american.json",
     "assertions" : {
-      "inputPathCount" : 86,
-      "outputPathCount" : 70,
-      "modelValidationFailures" : 4,
+      "inputPathCount" : 67,
+      "outputPathCount" : 75,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-mockup-ex1-strikePricePerUnitSchedule.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-mockup-ex1-strikePricePerUnitSchedule.json",
     "assertions" : {
-      "inputPathCount" : 97,
+      "inputPathCount" : 82,
       "outputPathCount" : 96,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-commodity-derivatives/com-mockup-ex2-strikePricePerUnitSchedule.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-mockup-ex2-strikePricePerUnitSchedule.json",
     "assertions" : {
-      "inputPathCount" : 97,
+      "inputPathCount" : 82,
       "outputPathCount" : 92,
       "modelValidationFailures" : 5,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-correlation-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-correlation-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-correlation-swaps/eqcs-ex01-correlation-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-correlation-swaps/eqcs-ex01-correlation-swap.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 68,
       "outputPathCount" : 87,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-correlation-swaps/eqcs-ex02-correlation-swap-confirmation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-correlation-swaps/eqcs-ex02-correlation-swap-confirmation.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 89,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-correlation-swaps/eqcs-ex04-correlation-swap-confirmation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-correlation-swaps/eqcs-ex04-correlation-swap-confirmation.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 86,
       "outputPathCount" : 93,
       "modelValidationFailures" : 9,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-credit-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-credit-derivatives.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex01-long-asia-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex01-long-asia-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 84,
       "outputPathCount" : 119,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex02-2003-short-asia-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex02-2003-short-asia-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 43,
+      "inputPathCount" : 39,
       "outputPathCount" : 63,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex02-short-asia-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex02-short-asia-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 44,
+      "inputPathCount" : 40,
       "outputPathCount" : 65,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex03-long-aussie-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex03-long-aussie-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 92,
       "outputPathCount" : 118,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex04-short-aussie-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex04-short-aussie-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 45,
+      "inputPathCount" : 41,
       "outputPathCount" : 64,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex05-long-emasia-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex05-long-emasia-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 90,
       "outputPathCount" : 125,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex06-long-emeur-sov-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex06-long-emeur-sov-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 87,
+      "inputPathCount" : 83,
       "outputPathCount" : 118,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex07-2003-long-euro-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex07-2003-long-euro-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 86,
+      "inputPathCount" : 82,
       "outputPathCount" : 117,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex07-long-euro-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex07-long-euro-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 81,
       "outputPathCount" : 116,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex08-2003-short-euro-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex08-2003-short-euro-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 45,
+      "inputPathCount" : 41,
       "outputPathCount" : 62,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex08-short-euro-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex08-short-euro-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 45,
+      "inputPathCount" : 41,
       "outputPathCount" : 62,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex09-long-euro-sov-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex09-long-euro-sov-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 114,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex10-2003-long-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex10-2003-long-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 81,
       "outputPathCount" : 116,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex10-long-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex10-long-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 86,
+      "inputPathCount" : 82,
       "outputPathCount" : 117,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex11-2003-short-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex11-2003-short-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 43,
+      "inputPathCount" : 39,
       "outputPathCount" : 64,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex11-short-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex11-short-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 44,
+      "inputPathCount" : 40,
       "outputPathCount" : 65,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex12-long-emasia-sov-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex12-long-emasia-sov-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 91,
+      "inputPathCount" : 87,
       "outputPathCount" : 122,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex13-long-asia-sov-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex13-long-asia-sov-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 114,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex14-long-emlatin-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex14-long-emlatin-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 92,
+      "inputPathCount" : 88,
       "outputPathCount" : 123,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex15-long-emlatin-sov-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex15-long-emlatin-sov-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 84,
       "outputPathCount" : 119,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex16-short-us-corp-fixreg-recovery-factor.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex16-short-us-corp-fixreg-recovery-factor.json",
     "assertions" : {
-      "inputPathCount" : 45,
+      "inputPathCount" : 41,
       "outputPathCount" : 67,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -239,7 +239,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex17-short-us-corp-portfolio-compression.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex17-short-us-corp-portfolio-compression.json",
     "assertions" : {
-      "inputPathCount" : 49,
+      "inputPathCount" : 45,
       "outputPathCount" : 73,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -250,7 +250,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex18-standard-north-american-corp.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex18-standard-north-american-corp.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 43,
       "outputPathCount" : 73,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -261,7 +261,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-ex19-cdx-index-option-pred-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-ex19-cdx-index-option-pred-clearing.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 83,
       "outputPathCount" : 119,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -272,7 +272,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-indamt-ex01-short-us-corp-fixreg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-indamt-ex01-short-us-corp-fixreg.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 43,
       "outputPathCount" : 66,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -283,7 +283,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-swaption-1.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-swaption-1.json",
     "assertions" : {
-      "inputPathCount" : 101,
+      "inputPathCount" : 99,
       "outputPathCount" : 123,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -294,7 +294,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cd-swaption-2.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cd-swaption-2.json",
     "assertions" : {
-      "inputPathCount" : 121,
+      "inputPathCount" : 119,
       "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -305,7 +305,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cdindex-ex01-cdx.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cdindex-ex01-cdx.json",
     "assertions" : {
-      "inputPathCount" : 37,
+      "inputPathCount" : 33,
       "outputPathCount" : 59,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -316,7 +316,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cdindex-ex02-iTraxx.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cdindex-ex02-iTraxx.json",
     "assertions" : {
-      "inputPathCount" : 35,
+      "inputPathCount" : 31,
       "outputPathCount" : 47,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -327,7 +327,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cdindex-ex03-iTraxx-contractual-supplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cdindex-ex03-iTraxx-contractual-supplement.json",
     "assertions" : {
-      "inputPathCount" : 49,
+      "inputPathCount" : 45,
       "outputPathCount" : 66,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -338,7 +338,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cdindex-ex04-iBoxx.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cdindex-ex04-iBoxx.json",
     "assertions" : {
-      "inputPathCount" : 48,
+      "inputPathCount" : 42,
       "outputPathCount" : 79,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -349,7 +349,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cdindex-ex05-SP.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cdindex-ex05-SP.json",
     "assertions" : {
-      "inputPathCount" : 49,
+      "inputPathCount" : 43,
       "outputPathCount" : 72,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -360,7 +360,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cdindex-ex06-iBoxx-ois.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cdindex-ex06-iBoxx-ois.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 41,
       "outputPathCount" : 77,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -371,7 +371,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cds-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cds-basket.json",
     "assertions" : {
-      "inputPathCount" : 76,
+      "inputPathCount" : 74,
       "outputPathCount" : 89,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -382,7 +382,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cds-basket-tranche.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cds-basket-tranche.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 77,
       "outputPathCount" : 92,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -393,7 +393,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cds-custom-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cds-custom-basket.json",
     "assertions" : {
-      "inputPathCount" : 116,
+      "inputPathCount" : 114,
       "outputPathCount" : 129,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -404,7 +404,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cds-ELCDS-ReferenceObligation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cds-ELCDS-ReferenceObligation.json",
     "assertions" : {
-      "inputPathCount" : 66,
+      "inputPathCount" : 64,
       "outputPathCount" : 76,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -415,7 +415,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cds-index-tranche.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cds-index-tranche.json",
     "assertions" : {
-      "inputPathCount" : 37,
+      "inputPathCount" : 33,
       "outputPathCount" : 49,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -426,7 +426,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cds-loan-ReferenceObligation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cds-loan-ReferenceObligation.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 90,
       "outputPathCount" : 102,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -437,7 +437,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cds-loan-SecuredList.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cds-loan-SecuredList.json",
     "assertions" : {
-      "inputPathCount" : 87,
+      "inputPathCount" : 83,
       "outputPathCount" : 98,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -448,7 +448,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cds-mortgage-CMBS.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cds-mortgage-CMBS.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 80,
       "outputPathCount" : 84,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -459,7 +459,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cds-mortgage-RMBS.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cds-mortgage-RMBS.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 80,
       "outputPathCount" : 84,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -470,7 +470,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/cdx-index-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/cdx-index-option.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 77,
       "outputPathCount" : 110,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -481,7 +481,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-credit-derivatives/itraxx-index-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-credit-derivatives/itraxx-index-option.json",
     "assertions" : {
-      "inputPathCount" : 96,
+      "inputPathCount" : 94,
       "outputPathCount" : 120,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-dividend-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-dividend-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-dividend-swaps/div-ex01-dividend-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-dividend-swaps/div-ex01-dividend-swap.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 71,
       "modelValidationFailures" : 10,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-dividend-swaps/div-ex02-dividend-swap-collateral.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-dividend-swaps/div-ex02-dividend-swap-collateral.json",
     "assertions" : {
-      "inputPathCount" : 102,
+      "inputPathCount" : 98,
       "outputPathCount" : 76,
       "modelValidationFailures" : 10,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-dividend-swaps/div-ex03-dividend-swap-short-form-japanese-underlyer.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-dividend-swaps/div-ex03-dividend-swap-short-form-japanese-underlyer.json",
     "assertions" : {
-      "inputPathCount" : 92,
+      "inputPathCount" : 88,
       "outputPathCount" : 78,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-dividend-swaps/div-ex04-dividend-swap-option-transaction-supplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-dividend-swaps/div-ex04-dividend-swap-option-transaction-supplement.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 96,
       "outputPathCount" : 93,
       "modelValidationFailures" : 11,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-dividend-swaps/div-ex05-dividend-swap-option-gs-example.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-dividend-swaps/div-ex05-dividend-swap-option-gs-example.json",
     "assertions" : {
-      "inputPathCount" : 110,
+      "inputPathCount" : 106,
       "outputPathCount" : 98,
       "modelValidationFailures" : 12,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-dividend-swaps/div-ex06-dividend-swap-option-pred-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-dividend-swaps/div-ex06-dividend-swap-option-pred-clearing.json",
     "assertions" : {
-      "inputPathCount" : 116,
+      "inputPathCount" : 112,
       "outputPathCount" : 103,
       "modelValidationFailures" : 15,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-equity-options.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-equity-options.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-options/eqd-ex02-calendar-spread-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-options/eqd-ex02-calendar-spread-short-form.json",
     "assertions" : {
-      "inputPathCount" : 67,
+      "inputPathCount" : 65,
       "outputPathCount" : 77,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-options/eqd-ex03-call-or-put-spread-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-options/eqd-ex03-call-or-put-spread-short-form.json",
     "assertions" : {
-      "inputPathCount" : 67,
+      "inputPathCount" : 65,
       "outputPathCount" : 77,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-options/eqd-ex07-barrier-knockout-rebate-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-options/eqd-ex07-barrier-knockout-rebate-long-form.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 113,
       "outputPathCount" : 77,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-options/eqd-ex10-binary-barrier-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-options/eqd-ex10-binary-barrier-long-form.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 92,
       "outputPathCount" : 78,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-options/eqd-ex12-vanilla-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-options/eqd-ex12-vanilla-short-form.json",
     "assertions" : {
-      "inputPathCount" : 65,
+      "inputPathCount" : 63,
       "outputPathCount" : 77,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-options/eqd-ex13-1996-american-call-stock.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-options/eqd-ex13-1996-american-call-stock.json",
     "assertions" : {
-      "inputPathCount" : 62,
+      "inputPathCount" : 60,
       "outputPathCount" : 84,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-options/eqd-ex26-mixed-asset-basket.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-options/eqd-ex26-mixed-asset-basket.json",
     "assertions" : {
-      "inputPathCount" : 101,
+      "inputPathCount" : 99,
       "outputPathCount" : 94,
       "modelValidationFailures" : 6,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-equity-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-equity-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex01-single-underlyer-execution-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex01-single-underlyer-execution-long-form.json",
     "assertions" : {
-      "inputPathCount" : 165,
+      "inputPathCount" : 158,
       "outputPathCount" : 160,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex02-composite-basket-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex02-composite-basket-long-form.json",
     "assertions" : {
-      "inputPathCount" : 198,
+      "inputPathCount" : 191,
       "outputPathCount" : 200,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex03-index-quanto-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex03-index-quanto-long-form.json",
     "assertions" : {
-      "inputPathCount" : 168,
+      "inputPathCount" : 161,
       "outputPathCount" : 179,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex06-single-index-long-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex06-single-index-long-form.json",
     "assertions" : {
-      "inputPathCount" : 145,
+      "inputPathCount" : 138,
       "outputPathCount" : 147,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex07-long-form-with-stub.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex07-long-form-with-stub.json",
     "assertions" : {
-      "inputPathCount" : 212,
+      "inputPathCount" : 208,
       "outputPathCount" : 206,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex08-composite-basket-long-form-separate-spreads.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex08-composite-basket-long-form-separate-spreads.json",
     "assertions" : {
-      "inputPathCount" : 222,
+      "inputPathCount" : 215,
       "outputPathCount" : 238,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex09-compounding-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex09-compounding-swap.json",
     "assertions" : {
-      "inputPathCount" : 90,
+      "inputPathCount" : 86,
       "outputPathCount" : 105,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex10-short-form-interestLeg-driving-schedule-dates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex10-short-form-interestLeg-driving-schedule-dates.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 93,
       "outputPathCount" : 113,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex11-on-european-single-stock-underlyer-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex11-on-european-single-stock-underlyer-short-form.json",
     "assertions" : {
-      "inputPathCount" : 138,
+      "inputPathCount" : 131,
       "outputPathCount" : 155,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex12-on-european-index-underlyer-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex12-on-european-index-underlyer-short-form.json",
     "assertions" : {
-      "inputPathCount" : 140,
+      "inputPathCount" : 133,
       "outputPathCount" : 157,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex13-pan-asia-interdealer-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex13-pan-asia-interdealer-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 164,
+      "inputPathCount" : 157,
       "outputPathCount" : 173,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex14-european-interdealer-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex14-european-interdealer-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 159,
+      "inputPathCount" : 152,
       "outputPathCount" : 158,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex16-forward-starting-post-european-interdealer-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 161,
+      "inputPathCount" : 158,
       "outputPathCount" : 168,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex17-cfd.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex17-cfd.json",
     "assertions" : {
-      "inputPathCount" : 106,
+      "inputPathCount" : 94,
       "outputPathCount" : 110,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex18-pan-asia-interdealer-index-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex18-pan-asia-interdealer-index-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 145,
+      "inputPathCount" : 139,
       "outputPathCount" : 145,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex19-european-interdealer-fair-value-share-swap-short-form.json",
     "assertions" : {
-      "inputPathCount" : 144,
+      "inputPathCount" : 138,
       "outputPathCount" : 144,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/eqs-ex20-single-underlyer-execution-long-form-ois.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/eqs-ex20-single-underlyer-execution-long-form-ois.json",
     "assertions" : {
-      "inputPathCount" : 157,
+      "inputPathCount" : 150,
       "outputPathCount" : 151,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/trs-ex02-single-equity.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/trs-ex02-single-equity.json",
     "assertions" : {
-      "inputPathCount" : 179,
+      "inputPathCount" : 172,
       "outputPathCount" : 139,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/trs-ex03-single-stock-execution-swap-with-fixing-and-dividend-payment-dates.json",
     "assertions" : {
-      "inputPathCount" : 185,
+      "inputPathCount" : 178,
       "outputPathCount" : 163,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/trs-ex04-index-ios.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/trs-ex04-index-ios.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 111,
       "outputPathCount" : 110,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -239,7 +239,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-equity-swaps/trs-ex05-single-equity-with-calculation-parameters.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-equity-swaps/trs-ex05-single-equity-with-calculation-parameters.json",
     "assertions" : {
-      "inputPathCount" : 127,
+      "inputPathCount" : 121,
       "outputPathCount" : 128,
       "modelValidationFailures" : 2,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-fx-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-fx-derivatives.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex01-fx-spot.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex01-fx-spot.json",
     "assertions" : {
-      "inputPathCount" : 42,
+      "inputPathCount" : 38,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex02-spot-cross-w-side-rates.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex02-spot-cross-w-side-rates.json",
     "assertions" : {
-      "inputPathCount" : 50,
+      "inputPathCount" : 46,
       "outputPathCount" : 41,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex03-fx-fwd.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex03-fx-fwd.json",
     "assertions" : {
-      "inputPathCount" : 44,
+      "inputPathCount" : 40,
       "outputPathCount" : 45,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex05-fx-fwd-w-ssi.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex05-fx-fwd-w-ssi.json",
     "assertions" : {
-      "inputPathCount" : 47,
+      "inputPathCount" : 43,
       "outputPathCount" : 45,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex07-non-deliverable-forward.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex07-non-deliverable-forward.json",
     "assertions" : {
-      "inputPathCount" : 53,
+      "inputPathCount" : 49,
       "outputPathCount" : 53,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex08-fx-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex08-fx-swap.json",
     "assertions" : {
-      "inputPathCount" : 57,
+      "inputPathCount" : 53,
       "outputPathCount" : 64,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex09-euro-opt.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex09-euro-opt.json",
     "assertions" : {
-      "inputPathCount" : 59,
+      "inputPathCount" : 55,
       "outputPathCount" : 61,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex10-amer-opt.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex10-amer-opt.json",
     "assertions" : {
-      "inputPathCount" : 61,
+      "inputPathCount" : 57,
       "outputPathCount" : 64,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex11-non-deliverable-option.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex11-non-deliverable-option.json",
     "assertions" : {
-      "inputPathCount" : 59,
+      "inputPathCount" : 55,
       "outputPathCount" : 70,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex20-avg-rate-option-parametric.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex20-avg-rate-option-parametric.json",
     "assertions" : {
-      "inputPathCount" : 56,
+      "inputPathCount" : 52,
       "outputPathCount" : 65,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex21-avg-rate-option-parametric-plus-rate-observation.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex21-avg-rate-option-parametric-plus-rate-observation.json",
     "assertions" : {
-      "inputPathCount" : 88,
+      "inputPathCount" : 68,
       "outputPathCount" : 65,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex22-avg-rate-option-specific.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex22-avg-rate-option-specific.json",
     "assertions" : {
-      "inputPathCount" : 151,
+      "inputPathCount" : 97,
       "outputPathCount" : 60,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex26-fxswap-multiple-USIs.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex26-fxswap-multiple-USIs.json",
     "assertions" : {
-      "inputPathCount" : 73,
+      "inputPathCount" : 65,
       "outputPathCount" : 74,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex28-non-deliverable-w-disruption.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex28-non-deliverable-w-disruption.json",
     "assertions" : {
-      "inputPathCount" : 58,
+      "inputPathCount" : 54,
       "outputPathCount" : 45,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex29-fx-swap-with-multiple-identifiers.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex29-fx-swap-with-multiple-identifiers.json",
     "assertions" : {
-      "inputPathCount" : 87,
+      "inputPathCount" : 79,
       "outputPathCount" : 81,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex30-variance-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex30-variance-swap.json",
     "assertions" : {
-      "inputPathCount" : 60,
+      "inputPathCount" : 58,
       "outputPathCount" : 76,
       "modelValidationFailures" : 13,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-ex31-volatility-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-ex31-volatility-swap.json",
     "assertions" : {
-      "inputPathCount" : 58,
+      "inputPathCount" : 56,
       "outputPathCount" : 70,
       "modelValidationFailures" : 15,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-inflation-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-inflation-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-asset-swap-ex01-ratio-zc-floored.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-asset-swap-ex01-ratio-zc-floored.json",
     "assertions" : {
-      "inputPathCount" : 116,
+      "inputPathCount" : 112,
       "outputPathCount" : 109,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-asset-swap-ex02-ratio-zc-floored.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-asset-swap-ex02-ratio-zc-floored.json",
     "assertions" : {
-      "inputPathCount" : 183,
+      "inputPathCount" : 154,
       "outputPathCount" : 151,
       "modelValidationFailures" : 10,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-asset-swap-ex03-par-par.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-asset-swap-ex03-par-par.json",
     "assertions" : {
-      "inputPathCount" : 163,
+      "inputPathCount" : 161,
       "outputPathCount" : 147,
       "modelValidationFailures" : 12,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-asset-swap-ex04-proceeds.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-asset-swap-ex04-proceeds.json",
     "assertions" : {
-      "inputPathCount" : 155,
+      "inputPathCount" : 153,
       "outputPathCount" : 137,
       "modelValidationFailures" : 12,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-swap-ex01-yoy.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex01-yoy.json",
     "assertions" : {
-      "inputPathCount" : 102,
+      "inputPathCount" : 98,
       "outputPathCount" : 100,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-swap-ex02-yoy-bond-reference.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex02-yoy-bond-reference.json",
     "assertions" : {
-      "inputPathCount" : 129,
+      "inputPathCount" : 125,
       "outputPathCount" : 122,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-swap-ex03-yoy-initial-level.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex03-yoy-initial-level.json",
     "assertions" : {
-      "inputPathCount" : 125,
+      "inputPathCount" : 121,
       "outputPathCount" : 122,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-swap-ex04-yoy-interp.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex04-yoy-interp.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 111,
       "outputPathCount" : 109,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-swap-ex05-zc.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex05-zc.json",
     "assertions" : {
-      "inputPathCount" : 95,
+      "inputPathCount" : 91,
       "outputPathCount" : 87,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-swap-ex06-zc.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex06-zc.json",
     "assertions" : {
-      "inputPathCount" : 152,
+      "inputPathCount" : 140,
       "outputPathCount" : 119,
       "modelValidationFailures" : 12,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-swap-ex10-float-v-float-BRL.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex10-float-v-float-BRL.json",
     "assertions" : {
-      "inputPathCount" : 128,
+      "inputPathCount" : 122,
       "outputPathCount" : 130,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-swap-ex11-CLP-fixed-v-fixed-fx-linked-notional.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex11-CLP-fixed-v-fixed-fx-linked-notional.json",
     "assertions" : {
-      "inputPathCount" : 126,
+      "inputPathCount" : 120,
       "outputPathCount" : 139,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-swap-ex12-CLP-fixed-v-ICP-fx-linked-notional.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex12-CLP-fixed-v-ICP-fx-linked-notional.json",
     "assertions" : {
-      "inputPathCount" : 140,
+      "inputPathCount" : 134,
       "outputPathCount" : 154,
       "modelValidationFailures" : 0,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-inflation-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-inflation-swaps.json
@@ -107,8 +107,8 @@
     "inputPath" : "ingest/input/fpml-5-13-products-inflation-swaps/inflation-swap-ex06-zc.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex06-zc.json",
     "assertions" : {
-      "inputPathCount" : 140,
-      "outputPathCount" : 119,
+      "inputPathCount" : 150,
+      "outputPathCount" : 129,
       "modelValidationFailures" : 12,
       "runtimeError" : false
     }

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-interest-rate-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-interest-rate-derivatives.json
@@ -448,8 +448,8 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex32-zero-coupon-swap-normal-rate.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex32-zero-coupon-swap-normal-rate.json",
     "assertions" : {
-      "inputPathCount" : 149,
-      "outputPathCount" : 136,
+      "inputPathCount" : 153,
+      "outputPathCount" : 140,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -503,8 +503,8 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex37-zero-coupon-swap-known-amount-schedule.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex37-zero-coupon-swap-known-amount-schedule.json",
     "assertions" : {
-      "inputPathCount" : 160,
-      "outputPathCount" : 142,
+      "inputPathCount" : 164,
+      "outputPathCount" : 146,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-interest-rate-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-interest-rate-derivatives.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex01-vanilla-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex01-vanilla-swap.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 101,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex01a-vanilla-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex01a-vanilla-swap.json",
     "assertions" : {
-      "inputPathCount" : 86,
+      "inputPathCount" : 84,
       "outputPathCount" : 104,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex02-stub-amort-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex02-stub-amort-swap.json",
     "assertions" : {
-      "inputPathCount" : 197,
+      "inputPathCount" : 193,
       "outputPathCount" : 215,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex03-compound-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex03-compound-swap.json",
     "assertions" : {
-      "inputPathCount" : 156,
+      "inputPathCount" : 152,
       "outputPathCount" : 171,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex04-arrears-stepup-fee-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex04-arrears-stepup-fee-swap.json",
     "assertions" : {
-      "inputPathCount" : 89,
+      "inputPathCount" : 85,
       "outputPathCount" : 107,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex04a-arrears-stepup-fee-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex04a-arrears-stepup-fee-swap.json",
     "assertions" : {
-      "inputPathCount" : 106,
+      "inputPathCount" : 104,
       "outputPathCount" : 130,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex05-long-stub-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex05-long-stub-swap.json",
     "assertions" : {
-      "inputPathCount" : 97,
+      "inputPathCount" : 93,
       "outputPathCount" : 119,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex05a-long-stub-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex05a-long-stub-swap.json",
     "assertions" : {
-      "inputPathCount" : 99,
+      "inputPathCount" : 97,
       "outputPathCount" : 124,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex06-xccy-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex06-xccy-swap.json",
     "assertions" : {
-      "inputPathCount" : 184,
+      "inputPathCount" : 180,
       "outputPathCount" : 212,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex06a-xccy-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex06a-xccy-swap.json",
     "assertions" : {
-      "inputPathCount" : 122,
+      "inputPathCount" : 120,
       "outputPathCount" : 159,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -118,7 +118,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex07-ois-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex07-ois-swap.json",
     "assertions" : {
-      "inputPathCount" : 81,
+      "inputPathCount" : 77,
       "outputPathCount" : 98,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -129,7 +129,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex07a-ois-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex07a-ois-swap.json",
     "assertions" : {
-      "inputPathCount" : 93,
+      "inputPathCount" : 91,
       "outputPathCount" : 117,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex07b-ois-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex07b-ois-swap.json",
     "assertions" : {
-      "inputPathCount" : 94,
+      "inputPathCount" : 92,
       "outputPathCount" : 116,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex07c-ois-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex07c-ois-swap.json",
     "assertions" : {
-      "inputPathCount" : 80,
+      "inputPathCount" : 78,
       "outputPathCount" : 101,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex08-fra.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex08-fra.json",
     "assertions" : {
-      "inputPathCount" : 41,
+      "inputPathCount" : 37,
       "outputPathCount" : 72,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex08a-fra.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex08a-fra.json",
     "assertions" : {
-      "inputPathCount" : 42,
+      "inputPathCount" : 40,
       "outputPathCount" : 80,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex09-euro-swaption-explicit.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex09-euro-swaption-explicit.json",
     "assertions" : {
-      "inputPathCount" : 106,
+      "inputPathCount" : 102,
       "outputPathCount" : 129,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex09a-euro-swaption-explicit.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex09a-euro-swaption-explicit.json",
     "assertions" : {
-      "inputPathCount" : 109,
+      "inputPathCount" : 107,
       "outputPathCount" : 142,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -206,7 +206,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex10-euro-swaption-relative.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex10-euro-swaption-relative.json",
     "assertions" : {
-      "inputPathCount" : 113,
+      "inputPathCount" : 109,
       "outputPathCount" : 130,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -217,7 +217,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex11-euro-swaption-partial-auto-ex.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex11-euro-swaption-partial-auto-ex.json",
     "assertions" : {
-      "inputPathCount" : 111,
+      "inputPathCount" : 107,
       "outputPathCount" : 130,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -228,7 +228,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex12-euro-swaption-straddle-cash.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex12-euro-swaption-straddle-cash.json",
     "assertions" : {
-      "inputPathCount" : 122,
+      "inputPathCount" : 118,
       "outputPathCount" : 142,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -239,7 +239,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex13-euro-swaption-cash-with-cfs.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex13-euro-swaption-cash-with-cfs.json",
     "assertions" : {
-      "inputPathCount" : 221,
+      "inputPathCount" : 217,
       "outputPathCount" : 229,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -250,7 +250,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex14-berm-swaption.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex14-berm-swaption.json",
     "assertions" : {
-      "inputPathCount" : 116,
+      "inputPathCount" : 112,
       "outputPathCount" : 139,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -261,7 +261,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex15-amer-swaption.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex15-amer-swaption.json",
     "assertions" : {
-      "inputPathCount" : 120,
+      "inputPathCount" : 116,
       "outputPathCount" : 143,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -272,7 +272,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex16-mand-term-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex16-mand-term-swap.json",
     "assertions" : {
-      "inputPathCount" : 103,
+      "inputPathCount" : 99,
       "outputPathCount" : 119,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -283,7 +283,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex17-opt-euro-term-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex17-opt-euro-term-swap.json",
     "assertions" : {
-      "inputPathCount" : 146,
+      "inputPathCount" : 111,
       "outputPathCount" : 126,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -294,7 +294,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex18-opt-berm-term-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex18-opt-berm-term-swap.json",
     "assertions" : {
-      "inputPathCount" : 261,
+      "inputPathCount" : 212,
       "outputPathCount" : 218,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -305,7 +305,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex19-opt-amer-term-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex19-opt-amer-term-swap.json",
     "assertions" : {
-      "inputPathCount" : 168,
+      "inputPathCount" : 122,
       "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -316,7 +316,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex20-euro-cancel-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex20-euro-cancel-swap.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 96,
       "outputPathCount" : 112,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -327,7 +327,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex21-euro-extend-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex21-euro-extend-swap.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 96,
       "outputPathCount" : 98,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -338,7 +338,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex22-cap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex22-cap.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 68,
       "outputPathCount" : 84,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -349,7 +349,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex23-floor.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex23-floor.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 68,
       "outputPathCount" : 84,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -360,7 +360,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex24-collar.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex24-collar.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 99,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -371,7 +371,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex25-fxnotional-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex25-fxnotional-swap.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 111,
       "outputPathCount" : 129,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -382,7 +382,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex26-fxnotional-swap-with-cfs.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex26-fxnotional-swap-with-cfs.json",
     "assertions" : {
-      "inputPathCount" : 287,
+      "inputPathCount" : 283,
       "outputPathCount" : 281,
       "modelValidationFailures" : 22,
       "runtimeError" : false
@@ -393,7 +393,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex27-inverse-floater.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex27-inverse-floater.json",
     "assertions" : {
-      "inputPathCount" : 86,
+      "inputPathCount" : 82,
       "outputPathCount" : 111,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -404,7 +404,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex28-bullet-payments.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex28-bullet-payments.json",
     "assertions" : {
-      "inputPathCount" : 27,
+      "inputPathCount" : 23,
       "outputPathCount" : 13,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -415,7 +415,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex29-non-deliverable-settlement-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex29-non-deliverable-settlement-swap.json",
     "assertions" : {
-      "inputPathCount" : 113,
+      "inputPathCount" : 109,
       "outputPathCount" : 128,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -426,7 +426,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex30-swap-comp-avg-relative-date.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex30-swap-comp-avg-relative-date.json",
     "assertions" : {
-      "inputPathCount" : 251,
+      "inputPathCount" : 247,
       "outputPathCount" : 240,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -437,7 +437,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex31-non-deliverable-settlement-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex31-non-deliverable-settlement-swap.json",
     "assertions" : {
-      "inputPathCount" : 127,
+      "inputPathCount" : 123,
       "outputPathCount" : 128,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -448,7 +448,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex32-zero-coupon-swap-normal-rate.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex32-zero-coupon-swap-normal-rate.json",
     "assertions" : {
-      "inputPathCount" : 159,
+      "inputPathCount" : 149,
       "outputPathCount" : 136,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -459,7 +459,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex33-BRL-CDI-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex33-BRL-CDI-swap.json",
     "assertions" : {
-      "inputPathCount" : 112,
+      "inputPathCount" : 110,
       "outputPathCount" : 124,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -470,7 +470,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex34-MXN-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex34-MXN-swap.json",
     "assertions" : {
-      "inputPathCount" : 81,
+      "inputPathCount" : 77,
       "outputPathCount" : 97,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -481,7 +481,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex35-inverse-floater-inverse-vs-floating.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex35-inverse-floater-inverse-vs-floating.json",
     "assertions" : {
-      "inputPathCount" : 102,
+      "inputPathCount" : 98,
       "outputPathCount" : 128,
       "modelValidationFailures" : 0,
       "runtimeError" : false
@@ -492,7 +492,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex36-amer-swaption-pred-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex36-amer-swaption-pred-clearing.json",
     "assertions" : {
-      "inputPathCount" : 126,
+      "inputPathCount" : 122,
       "outputPathCount" : 152,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -503,7 +503,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex37-zero-coupon-swap-known-amount-schedule.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex37-zero-coupon-swap-known-amount-schedule.json",
     "assertions" : {
-      "inputPathCount" : 172,
+      "inputPathCount" : 160,
       "outputPathCount" : 142,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -514,7 +514,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex38-rfr-avg-swap-pmt-delay.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex38-rfr-avg-swap-pmt-delay.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 100,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -525,7 +525,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex39-rfr-avg-swap-rate-cutoff.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex39-rfr-avg-swap-rate-cutoff.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 83,
       "outputPathCount" : 101,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -536,7 +536,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex40-rfr-avg-swap-obs-period-shift.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex40-rfr-avg-swap-obs-period-shift.json",
     "assertions" : {
-      "inputPathCount" : 86,
+      "inputPathCount" : 84,
       "outputPathCount" : 100,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -547,7 +547,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex41-rfr-avg-swap-lookback.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex41-rfr-avg-swap-lookback.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 82,
       "outputPathCount" : 100,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -558,7 +558,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex42-rfr-compound-swap-pmt-delay.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex42-rfr-compound-swap-pmt-delay.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 100,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -569,7 +569,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex43-rfr-compound-swap-rate-cutoff.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex43-rfr-compound-swap-rate-cutoff.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 100,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -580,7 +580,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex44-rfr-compound-swap-obs-period-shift.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex44-rfr-compound-swap-obs-period-shift.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 82,
       "outputPathCount" : 100,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -591,7 +591,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex45-rfr-compound-swap-lookback.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex45-rfr-compound-swap-lookback.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 100,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -602,7 +602,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex46-rfr-compound-swap-lookback-oet-mmviq.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex46-rfr-compound-swap-lookback-oet-mmviq.json",
     "assertions" : {
-      "inputPathCount" : 152,
+      "inputPathCount" : 116,
       "outputPathCount" : 131,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -613,7 +613,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex47-rfr-compound-swap-lookback-oet-rvfq.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex47-rfr-compound-swap-lookback-oet-rvfq.json",
     "assertions" : {
-      "inputPathCount" : 150,
+      "inputPathCount" : 115,
       "outputPathCount" : 130,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -624,7 +624,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex48-rfr-compound-swap-lookback-oet-ccp.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex48-rfr-compound-swap-lookback-oet-ccp.json",
     "assertions" : {
-      "inputPathCount" : 150,
+      "inputPathCount" : 115,
       "outputPathCount" : 130,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -635,7 +635,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex49-rfr-euro-swaption-cash.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex49-rfr-euro-swaption-cash.json",
     "assertions" : {
-      "inputPathCount" : 126,
+      "inputPathCount" : 122,
       "outputPathCount" : 151,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -646,7 +646,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex50-rfr-euro-swaption-cleared-physical_with_met.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex50-rfr-euro-swaption-cleared-physical_with_met.json",
     "assertions" : {
-      "inputPathCount" : 131,
+      "inputPathCount" : 127,
       "outputPathCount" : 155,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -657,7 +657,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex51-vanilla-swap-with-fallback.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex51-vanilla-swap-with-fallback.json",
     "assertions" : {
-      "inputPathCount" : 95,
+      "inputPathCount" : 93,
       "outputPathCount" : 107,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -668,7 +668,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex52-xccy-swap-fallback.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex52-xccy-swap-fallback.json",
     "assertions" : {
-      "inputPathCount" : 123,
+      "inputPathCount" : 121,
       "outputPathCount" : 155,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -679,7 +679,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex53-xccy-swap-OIS.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex53-xccy-swap-OIS.json",
     "assertions" : {
-      "inputPathCount" : 121,
+      "inputPathCount" : 119,
       "outputPathCount" : 160,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -690,7 +690,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex54-CP-H.15-basis-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex54-CP-H.15-basis-swap.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 111,
       "outputPathCount" : 138,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -701,7 +701,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex55-muni-basis-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex55-muni-basis-swap.json",
     "assertions" : {
-      "inputPathCount" : 110,
+      "inputPathCount" : 106,
       "outputPathCount" : 129,
       "modelValidationFailures" : 2,
       "runtimeError" : false
@@ -712,7 +712,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex56-CNREPOFIX-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex56-CNREPOFIX-swap.json",
     "assertions" : {
-      "inputPathCount" : 107,
+      "inputPathCount" : 103,
       "outputPathCount" : 125,
       "modelValidationFailures" : 4,
       "runtimeError" : false
@@ -723,7 +723,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex57-compound-index-obs-period-shift.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex57-compound-index-obs-period-shift.json",
     "assertions" : {
-      "inputPathCount" : 86,
+      "inputPathCount" : 84,
       "outputPathCount" : 100,
       "modelValidationFailures" : 1,
       "runtimeError" : false
@@ -734,7 +734,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-interest-rate-derivatives/ird-ex58-xccy-swap-lookback_compound.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex58-xccy-swap-lookback_compound.json",
     "assertions" : {
-      "inputPathCount" : 108,
+      "inputPathCount" : 106,
       "outputPathCount" : 145,
       "modelValidationFailures" : 7,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-variance-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-variance-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-variance-swaps/eqvs-ex02-variance-swap-single-stock.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-variance-swaps/eqvs-ex02-variance-swap-single-stock.json",
     "assertions" : {
-      "inputPathCount" : 63,
+      "inputPathCount" : 59,
       "outputPathCount" : 71,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-variance-swaps/eqvs-ex04-dispersion-variance-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-variance-swaps/eqvs-ex04-dispersion-variance-swap.json",
     "assertions" : {
-      "inputPathCount" : 123,
+      "inputPathCount" : 121,
       "outputPathCount" : 111,
       "modelValidationFailures" : 15,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-variance-swaps/eqvs-ex05-dispersion-variance-swap-transaction-supplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-variance-swaps/eqvs-ex05-dispersion-variance-swap-transaction-supplement.json",
     "assertions" : {
-      "inputPathCount" : 84,
+      "inputPathCount" : 82,
       "outputPathCount" : 89,
       "modelValidationFailures" : 16,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-variance-swaps/eqvs-ex06-variance-option-transaction-supplement.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-variance-swaps/eqvs-ex06-variance-option-transaction-supplement.json",
     "assertions" : {
-      "inputPathCount" : 79,
+      "inputPathCount" : 75,
       "outputPathCount" : 87,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-variance-swaps/eqvs-ex07-variance-option-transaction-supplement-pred-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-variance-swaps/eqvs-ex07-variance-option-transaction-supplement-pred-clearing.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 81,
       "outputPathCount" : 96,
       "modelValidationFailures" : 6,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-volatility-swaps.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-volatility-swaps.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-volatility-swaps/eqvls-ex01-volatility-swap-index-matrix.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-volatility-swaps/eqvls-ex01-volatility-swap-index-matrix.json",
     "assertions" : {
-      "inputPathCount" : 59,
+      "inputPathCount" : 55,
       "outputPathCount" : 62,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-products-volatility-swaps/eqvls-ex02-volatility-swap-index-mca.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-volatility-swaps/eqvls-ex02-volatility-swap-index-mca.json",
     "assertions" : {
-      "inputPathCount" : 55,
+      "inputPathCount" : 51,
       "outputPathCount" : 58,
       "modelValidationFailures" : 5,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-incomplete-processes.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-incomplete-processes.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-processes/msg-ex19-cds-execution-allocations.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/msg-ex19-cds-execution-allocations.json",
     "assertions" : {
-      "inputPathCount" : 144,
+      "inputPathCount" : 138,
       "outputPathCount" : 187,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -63,7 +63,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-processes/msg-ex59-execution-advice-trade-amendment-F02-00.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/msg-ex59-execution-advice-trade-amendment-F02-00.json",
     "assertions" : {
-      "inputPathCount" : 81,
+      "inputPathCount" : 79,
       "outputPathCount" : 107,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-processes/msg-ex60-execution-advice-trade-amendment-correction-F02-10.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/msg-ex60-execution-advice-trade-amendment-correction-F02-10.json",
     "assertions" : {
-      "inputPathCount" : 81,
+      "inputPathCount" : 79,
       "outputPathCount" : 107,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-processes/msg-ex61-execution-advice-trade-change-F03-00.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/msg-ex61-execution-advice-trade-change-F03-00.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 102,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-processes/msg-ex62-execution-advice-trade-change-correction-F03-10.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/msg-ex62-execution-advice-trade-change-correction-F03-10.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 102,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-processes/pkg-ex01-pkge-execution-notification.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex01-pkge-execution-notification.json",
     "assertions" : {
-      "inputPathCount" : 177,
+      "inputPathCount" : 173,
       "outputPathCount" : 27,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.json",
     "assertions" : {
-      "inputPathCount" : 108,
+      "inputPathCount" : 106,
       "outputPathCount" : 121,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-processes/pkg-ex55-execution-notification.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex55-execution-notification.json",
     "assertions" : {
-      "inputPathCount" : 195,
+      "inputPathCount" : 191,
       "outputPathCount" : 56,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-processes/pkg-ex60-request-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex60-request-clearing.json",
     "assertions" : {
-      "inputPathCount" : 187,
+      "inputPathCount" : 183,
       "outputPathCount" : 37,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-10-incomplete-processes/pkg-ex61-clearing-confirmed.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex61-clearing-confirmed.json",
     "assertions" : {
-      "inputPathCount" : 111,
+      "inputPathCount" : 109,
       "outputPathCount" : 126,
       "modelValidationFailures" : 5,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-processes.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-processes.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-cleared-alpha-trade-CFTC-SEC-and-canada.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-cleared-alpha-trade-CFTC-SEC-and-canada.json",
     "assertions" : {
-      "inputPathCount" : 275,
+      "inputPathCount" : 265,
       "outputPathCount" : 252,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-ex52-execution-advice-trade-partial-novation-C02-00.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex52-execution-advice-trade-partial-novation-C02-00.json",
     "assertions" : {
-      "inputPathCount" : 103,
+      "inputPathCount" : 95,
       "outputPathCount" : 121,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -41,7 +41,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.json",
     "assertions" : {
-      "inputPathCount" : 103,
+      "inputPathCount" : 95,
       "outputPathCount" : 121,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -52,7 +52,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-ex58-execution-advice-trade-initiation-F01-00.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-ex58-execution-advice-trade-initiation-F01-00.json",
     "assertions" : {
-      "inputPathCount" : 65,
+      "inputPathCount" : 63,
       "outputPathCount" : 102,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -74,7 +74,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-new-alpha-trade-CFTC-SEC-and-canada.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-new-alpha-trade-CFTC-SEC-and-canada.json",
     "assertions" : {
-      "inputPathCount" : 254,
+      "inputPathCount" : 250,
       "outputPathCount" : 252,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-new-beta-trade-CFTC-SEC-and-canada.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-new-beta-trade-CFTC-SEC-and-canada.json",
     "assertions" : {
-      "inputPathCount" : 232,
+      "inputPathCount" : 226,
       "outputPathCount" : 220,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-new-trade-CFTC-clearing.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-new-trade-CFTC-clearing.json",
     "assertions" : {
-      "inputPathCount" : 204,
+      "inputPathCount" : 198,
       "outputPathCount" : 199,
       "modelValidationFailures" : 22,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-new-trade-CFTC-SEC-and-canada.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-new-trade-CFTC-SEC-and-canada.json",
     "assertions" : {
-      "inputPathCount" : 284,
+      "inputPathCount" : 272,
       "outputPathCount" : 252,
       "modelValidationFailures" : 8,
       "runtimeError" : false
@@ -118,8 +118,8 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-package-price.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.json",
     "assertions" : {
-      "inputPathCount" : 125,
-      "outputPathCount" : 135,
+      "inputPathCount" : 123,
+      "outputPathCount" : 139,
       "modelValidationFailures" : 6,
       "runtimeError" : false
     }
@@ -129,8 +129,8 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-package-spread.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.json",
     "assertions" : {
-      "inputPathCount" : 124,
-      "outputPathCount" : 135,
+      "inputPathCount" : 122,
+      "outputPathCount" : 142,
       "modelValidationFailures" : 6,
       "runtimeError" : false
     }
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-partial-termination.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination.json",
     "assertions" : {
-      "inputPathCount" : 141,
+      "inputPathCount" : 139,
       "outputPathCount" : 156,
       "modelValidationFailures" : 3,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-partial-termination-xccy.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy.json",
     "assertions" : {
-      "inputPathCount" : 130,
+      "inputPathCount" : 126,
       "outputPathCount" : 98,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-10-processes/msg-partial-termination-xccy-swap.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-partial-termination-xccy-swap.json",
     "assertions" : {
-      "inputPathCount" : 163,
+      "inputPathCount" : 161,
       "outputPathCount" : 172,
       "modelValidationFailures" : 3,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-12-processes.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-12-processes.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-12-processes/custom-basket-linkId-ptrr-comp.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-12-processes/custom-basket-linkId-ptrr-comp.json",
     "assertions" : {
-      "inputPathCount" : 115,
+      "inputPathCount" : 113,
       "outputPathCount" : 143,
       "modelValidationFailures" : 9,
       "runtimeError" : false
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-12-processes/custom-basket-linkId-rtn.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-12-processes/custom-basket-linkId-rtn.json",
     "assertions" : {
-      "inputPathCount" : 116,
+      "inputPathCount" : 114,
       "outputPathCount" : 143,
       "modelValidationFailures" : 9,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-13-incomplete-processes-execution-advice.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-13-incomplete-processes-execution-advice.json
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-processes-execution-advice/msg-ex61-execution-advice-trade-change-F03-00.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex61-execution-advice-trade-change-F03-00.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 102,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-processes-execution-advice/msg-ex62-execution-advice-trade-change-correction-F03-10.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex62-execution-advice-trade-change-correction-F03-10.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 81,
       "outputPathCount" : 102,
       "modelValidationFailures" : 5,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-13-incomplete-processes-execution-advice.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-13-incomplete-processes-execution-advice.json
@@ -8,7 +8,7 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-processes-execution-advice/msg-ex100-execution-advice-trs-partial-termination.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex100-execution-advice-trs-partial-termination.json",
     "assertions" : {
-      "inputPathCount" : 72,
+      "inputPathCount" : 75,
       "outputPathCount" : 39,
       "modelValidationFailures" : 7,
       "runtimeError" : false
@@ -74,8 +74,8 @@
     "inputPath" : "ingest/input/fpml-5-13-incomplete-processes-execution-advice/msg-ex68-execution-advice-warrant.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex68-execution-advice-warrant.json",
     "assertions" : {
-      "inputPathCount" : 71,
-      "outputPathCount" : 39,
+      "inputPathCount" : 74,
+      "outputPathCount" : 42,
       "modelValidationFailures" : 5,
       "runtimeError" : false
     }

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-13-processes-execution-advice.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-13-processes-execution-advice.json
@@ -19,7 +19,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex52-execution-advice-trade-partial-novation-C02-00.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex52-execution-advice-trade-partial-novation-C02-00.json",
     "assertions" : {
-      "inputPathCount" : 103,
+      "inputPathCount" : 95,
       "outputPathCount" : 121,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -30,7 +30,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex53-execution-advice-trade-partial-novation-correction-C02-10.json",
     "assertions" : {
-      "inputPathCount" : 103,
+      "inputPathCount" : 95,
       "outputPathCount" : 121,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -85,7 +85,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex58-execution-advice-trade-initiation-F01-00.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex58-execution-advice-trade-initiation-F01-00.json",
     "assertions" : {
-      "inputPathCount" : 65,
+      "inputPathCount" : 63,
       "outputPathCount" : 102,
       "modelValidationFailures" : 5,
       "runtimeError" : false
@@ -96,7 +96,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex59-execution-advice-trade-amendment-F02-00.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex59-execution-advice-trade-amendment-F02-00.json",
     "assertions" : {
-      "inputPathCount" : 81,
+      "inputPathCount" : 79,
       "outputPathCount" : 107,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -107,7 +107,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex60-execution-advice-trade-amendment-correction-F02-10.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex60-execution-advice-trade-amendment-correction-F02-10.json",
     "assertions" : {
-      "inputPathCount" : 81,
+      "inputPathCount" : 79,
       "outputPathCount" : 107,
       "modelValidationFailures" : 6,
       "runtimeError" : false
@@ -140,7 +140,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex69-commodity-swap-coal-physical-leg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex69-commodity-swap-coal-physical-leg.json",
     "assertions" : {
-      "inputPathCount" : 83,
+      "inputPathCount" : 79,
       "outputPathCount" : 89,
       "modelValidationFailures" : 15,
       "runtimeError" : false
@@ -151,7 +151,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex69-commodity-swap-electricity-physical-leg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex69-commodity-swap-electricity-physical-leg.json",
     "assertions" : {
-      "inputPathCount" : 91,
+      "inputPathCount" : 87,
       "outputPathCount" : 93,
       "modelValidationFailures" : 15,
       "runtimeError" : false
@@ -162,7 +162,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex69-commodity-swap-environmental-physical-leg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex69-commodity-swap-environmental-physical-leg.json",
     "assertions" : {
-      "inputPathCount" : 89,
+      "inputPathCount" : 85,
       "outputPathCount" : 103,
       "modelValidationFailures" : 16,
       "runtimeError" : false
@@ -173,7 +173,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex69-commodity-swap-gas-physical-leg.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex69-commodity-swap-gas-physical-leg.json",
     "assertions" : {
-      "inputPathCount" : 85,
+      "inputPathCount" : 81,
       "outputPathCount" : 93,
       "modelValidationFailures" : 15,
       "runtimeError" : false
@@ -184,7 +184,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex69-execution-advice-commodity-swap-classification-new-trade-esma-emir-refit.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex69-execution-advice-commodity-swap-classification-new-trade-esma-emir-refit.json",
     "assertions" : {
-      "inputPathCount" : 89,
+      "inputPathCount" : 85,
       "outputPathCount" : 93,
       "modelValidationFailures" : 15,
       "runtimeError" : false
@@ -195,7 +195,7 @@
     "inputPath" : "ingest/input/fpml-5-13-processes-execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-processes-execution-advice/msg-ex70-execution-advice-commodity-swap-classification-termination-esma-emir-refit.json",
     "assertions" : {
-      "inputPathCount" : 100,
+      "inputPathCount" : 96,
       "outputPathCount" : 95,
       "modelValidationFailures" : 14,
       "runtimeError" : false

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex09-oil-put-option-american.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex09-oil-put-option-american.json
@@ -47,6 +47,41 @@
             "optionType" : "Put",
             "exerciseTerms" : {
               "style" : "American",
+              "commencementDate" : {
+                "adjustableDate" : {
+                  "unadjustedDate" : "2008-10-27",
+                  "dateAdjustments" : {
+                    "businessDayConvention" : "NotApplicable",
+                    "meta" : {
+                      "globalKey" : "3a4b88ab"
+                    }
+                  },
+                  "meta" : {
+                    "globalKey" : "25e41086"
+                  }
+                },
+                "meta" : {
+                  "globalKey" : "25e41086"
+                }
+              },
+              "expirationDate" : [ {
+                "adjustableDate" : {
+                  "unadjustedDate" : "2009-01-12",
+                  "dateAdjustments" : {
+                    "businessDayConvention" : "NotApplicable",
+                    "meta" : {
+                      "globalKey" : "3a4b88ab"
+                    }
+                  },
+                  "meta" : {
+                    "globalKey" : "25f96df7"
+                  }
+                },
+                "meta" : {
+                  "globalKey" : "25f96df7",
+                  "externalKey" : "expirationDate"
+                }
+              } ],
               "exerciseProcedure" : {
                 "automaticExercise" : {
                   "isApplicable" : true
@@ -54,7 +89,7 @@
                 "followUpConfirmation" : false
               },
               "meta" : {
-                "globalKey" : "fd49de06",
+                "globalKey" : "514df6b7",
                 "externalKey" : "exerciseDate"
               }
             },
@@ -74,12 +109,12 @@
             }
           },
           "meta" : {
-            "globalKey" : "ff71438d"
+            "globalKey" : "2fb8a57c"
           }
         } ]
       },
       "meta" : {
-        "globalKey" : "ff71438d"
+        "globalKey" : "2fb8a57c"
       }
     },
     "tradeLot" : [ {
@@ -292,7 +327,7 @@
       }
     },
     "meta" : {
-      "globalKey" : "960667d5"
+      "globalKey" : "70058444"
     }
   },
   "transferHistory" : [ {
@@ -343,6 +378,6 @@
     }
   } ],
   "meta" : {
-    "globalKey" : "d3a4d635"
+    "globalKey" : "fa0155a4"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-Vanilla-multiple-accounts.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-Vanilla-multiple-accounts.json
@@ -619,10 +619,6 @@
         "externalKey" : "p1-a1"
       }
     }, {
-      "partyReference" : {
-        "globalReference" : "b6bdbfc2",
-        "externalReference" : "p1"
-      },
       "accountNumber" : {
         "value" : "p1-account-b"
       },
@@ -631,7 +627,7 @@
         "externalReference" : "p1"
       },
       "meta" : {
-        "globalKey" : "c7b66938",
+        "globalKey" : "5e523f7",
         "externalKey" : "p1-a2"
       }
     }, {
@@ -652,10 +648,10 @@
       }
     } ],
     "meta" : {
-      "globalKey" : "42ed06e0"
+      "globalKey" : "9015a9df"
     }
   },
   "meta" : {
-    "globalKey" : "42ed06e0"
+    "globalKey" : "9015a9df"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex32-zero-coupon-swap-normal-rate.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex32-zero-coupon-swap-normal-rate.json
@@ -498,6 +498,13 @@
       },
       "assignedIdentifier" : [ {
         "identifier" : {
+          "value" : "1-2",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
+          }
+        }
+      }, {
+        "identifier" : {
           "value" : "11111111",
           "meta" : {
             "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/alpha-trade-id"
@@ -505,7 +512,7 @@
         }
       } ],
       "meta" : {
-        "globalKey" : "6e3e4581"
+        "globalKey" : "80748ff5"
       }
     }, {
       "issuerReference" : {
@@ -530,6 +537,13 @@
       },
       "assignedIdentifier" : [ {
         "identifier" : {
+          "value" : "LCH00000000001",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
+          }
+        }
+      }, {
+        "identifier" : {
           "value" : "STM",
           "meta" : {
             "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-classification"
@@ -537,7 +551,7 @@
         }
       } ],
       "meta" : {
-        "globalKey" : "67d19311"
+        "globalKey" : "5683d2c7"
       }
     }, {
       "issuer" : {
@@ -729,10 +743,10 @@
       }
     },
     "meta" : {
-      "globalKey" : "236f0d03"
+      "globalKey" : "d1813ff9"
     }
   },
   "meta" : {
-    "globalKey" : "236f0d03"
+    "globalKey" : "d1813ff9"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex9-oil-put-option-american.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex9-oil-put-option-american.json
@@ -47,6 +47,41 @@
             "optionType" : "Put",
             "exerciseTerms" : {
               "style" : "American",
+              "commencementDate" : {
+                "adjustableDate" : {
+                  "unadjustedDate" : "2008-10-27",
+                  "dateAdjustments" : {
+                    "businessDayConvention" : "NotApplicable",
+                    "meta" : {
+                      "globalKey" : "3a4b88ab"
+                    }
+                  },
+                  "meta" : {
+                    "globalKey" : "25e41086"
+                  }
+                },
+                "meta" : {
+                  "globalKey" : "25e41086"
+                }
+              },
+              "expirationDate" : [ {
+                "adjustableDate" : {
+                  "unadjustedDate" : "2009-01-12",
+                  "dateAdjustments" : {
+                    "businessDayConvention" : "NotApplicable",
+                    "meta" : {
+                      "globalKey" : "3a4b88ab"
+                    }
+                  },
+                  "meta" : {
+                    "globalKey" : "25f96df7"
+                  }
+                },
+                "meta" : {
+                  "globalKey" : "25f96df7",
+                  "externalKey" : "expirationDate"
+                }
+              } ],
               "exerciseProcedure" : {
                 "automaticExercise" : {
                   "isApplicable" : true
@@ -54,7 +89,7 @@
                 "followUpConfirmation" : false
               },
               "meta" : {
-                "globalKey" : "fd49de06",
+                "globalKey" : "514df6b7",
                 "externalKey" : "exerciseDate"
               }
             },
@@ -74,12 +109,12 @@
             }
           },
           "meta" : {
-            "globalKey" : "ff71438d"
+            "globalKey" : "2fb8a57c"
           }
         } ]
       },
       "meta" : {
-        "globalKey" : "ff71438d"
+        "globalKey" : "2fb8a57c"
       }
     },
     "tradeLot" : [ {
@@ -292,7 +327,7 @@
       }
     },
     "meta" : {
-      "globalKey" : "960667d5"
+      "globalKey" : "70058444"
     }
   },
   "transferHistory" : [ {
@@ -343,6 +378,6 @@
     }
   } ],
   "meta" : {
-    "globalKey" : "d3a4d635"
+    "globalKey" : "fa0155a4"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex06-zc.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex06-zc.json
@@ -401,6 +401,13 @@
       },
       "assignedIdentifier" : [ {
         "identifier" : {
+          "value" : "1",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
+          }
+        }
+      }, {
+        "identifier" : {
           "value" : "12345678",
           "meta" : {
             "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/alpha-trade-id"
@@ -408,7 +415,7 @@
         }
       } ],
       "meta" : {
-        "globalKey" : "a6ba5d85"
+        "globalKey" : "b629afd4"
       }
     }, {
       "issuerReference" : {
@@ -449,6 +456,34 @@
       },
       "assignedIdentifier" : [ {
         "identifier" : {
+          "value" : "LCH00000000001",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
+          }
+        }
+      }, {
+        "identifier" : {
+          "value" : "11111111",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/group-id"
+          }
+        }
+      }, {
+        "identifier" : {
+          "value" : "12",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/group-size"
+          }
+        }
+      }, {
+        "identifier" : {
+          "value" : "1111111",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/link-id"
+          }
+        }
+      }, {
+        "identifier" : {
           "value" : "STM",
           "meta" : {
             "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-classification"
@@ -456,7 +491,7 @@
         }
       } ],
       "meta" : {
-        "globalKey" : "67d19311"
+        "globalKey" : "c33bf23"
       }
     }, {
       "issuer" : {
@@ -650,10 +685,10 @@
       }
     },
     "meta" : {
-      "globalKey" : "1cfcafd0"
+      "globalKey" : "8fa73df9"
     }
   },
   "meta" : {
-    "globalKey" : "1cfcafd0"
+    "globalKey" : "8fa73df9"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex32-zero-coupon-swap-normal-rate.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex32-zero-coupon-swap-normal-rate.json
@@ -498,6 +498,13 @@
       },
       "assignedIdentifier" : [ {
         "identifier" : {
+          "value" : "1-2",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
+          }
+        }
+      }, {
+        "identifier" : {
           "value" : "11111111",
           "meta" : {
             "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/alpha-trade-id"
@@ -505,7 +512,7 @@
         }
       } ],
       "meta" : {
-        "globalKey" : "6e3e4581"
+        "globalKey" : "80748ff5"
       }
     }, {
       "issuerReference" : {
@@ -530,6 +537,13 @@
       },
       "assignedIdentifier" : [ {
         "identifier" : {
+          "value" : "LCH00000000001",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
+          }
+        }
+      }, {
+        "identifier" : {
           "value" : "STM",
           "meta" : {
             "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-classification"
@@ -537,7 +551,7 @@
         }
       } ],
       "meta" : {
-        "globalKey" : "67d19311"
+        "globalKey" : "5683d2c7"
       }
     }, {
       "issuer" : {
@@ -729,10 +743,10 @@
       }
     },
     "meta" : {
-      "globalKey" : "236f0d03"
+      "globalKey" : "d1813ff9"
     }
   },
   "meta" : {
-    "globalKey" : "236f0d03"
+    "globalKey" : "d1813ff9"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex37-zero-coupon-swap-known-amount-schedule.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex37-zero-coupon-swap-known-amount-schedule.json
@@ -478,6 +478,13 @@
       },
       "assignedIdentifier" : [ {
         "identifier" : {
+          "value" : "1-2",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
+          }
+        }
+      }, {
+        "identifier" : {
           "value" : "11111111",
           "meta" : {
             "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/alpha-trade-id"
@@ -485,7 +492,7 @@
         }
       } ],
       "meta" : {
-        "globalKey" : "6e3e4581"
+        "globalKey" : "80748ff5"
       }
     }, {
       "issuerReference" : {
@@ -526,6 +533,13 @@
       },
       "assignedIdentifier" : [ {
         "identifier" : {
+          "value" : "LCH00000000001",
+          "meta" : {
+            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
+          }
+        }
+      }, {
+        "identifier" : {
           "value" : "STM",
           "meta" : {
             "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-classification"
@@ -533,7 +547,7 @@
         }
       } ],
       "meta" : {
-        "globalKey" : "67d19311"
+        "globalKey" : "5683d2c7"
       }
     }, {
       "issuer" : {
@@ -725,10 +739,10 @@
       }
     },
     "meta" : {
-      "globalKey" : "87c6b915"
+      "globalKey" : "b9e7c479"
     }
   },
   "meta" : {
-    "globalKey" : "87c6b915"
+    "globalKey" : "b9e7c479"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.json
@@ -627,14 +627,14 @@
                       "value" : "USD"
                     }
                   },
-                  "priceType" : "AssetPrice"
+                  "priceType" : "CashPrice"
                 },
                 "meta" : {
-                  "globalKey" : "67fc4c82"
+                  "globalKey" : "1c09b6a5"
                 }
               },
               "meta" : {
-                "globalKey" : "67fc4c82"
+                "globalKey" : "1c09b6a5"
               }
             },
             "account" : [ {
@@ -659,11 +659,11 @@
               }
             } ],
             "meta" : {
-              "globalKey" : "8685ebf"
+              "globalKey" : "61dcabfc"
             }
           },
           "meta" : {
-            "globalKey" : "8685ebf"
+            "globalKey" : "61dcabfc"
           }
         }
       }
@@ -705,6 +705,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "9ee1b1f6"
+    "globalKey" : "b89ffeb3"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.json
@@ -615,12 +615,26 @@
                     "globalKey" : "df4b43f4"
                   }
                 },
+                "price" : {
+                  "value" : 123567,
+                  "unit" : {
+                    "currency" : {
+                      "value" : "USD"
+                    }
+                  },
+                  "perUnitOf" : {
+                    "currency" : {
+                      "value" : "USD"
+                    }
+                  },
+                  "priceType" : "AssetPrice"
+                },
                 "meta" : {
-                  "globalKey" : "df4b43f4"
+                  "globalKey" : "67fc4c82"
                 }
               },
               "meta" : {
-                "globalKey" : "df4b43f4"
+                "globalKey" : "67fc4c82"
               }
             },
             "account" : [ {
@@ -645,11 +659,11 @@
               }
             } ],
             "meta" : {
-              "globalKey" : "70df6425"
+              "globalKey" : "8685ebf"
             }
           },
           "meta" : {
-            "globalKey" : "70df6425"
+            "globalKey" : "8685ebf"
           }
         }
       }
@@ -691,6 +705,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "4627659e"
+    "globalKey" : "9ee1b1f6"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.json
@@ -615,12 +615,33 @@
                     "globalKey" : "df4b43f4"
                   }
                 },
+                "price" : {
+                  "value" : 0.05,
+                  "unit" : {
+                    "currency" : {
+                      "value" : "USD",
+                      "meta" : {
+                        "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
+                      }
+                    }
+                  },
+                  "perUnitOf" : {
+                    "currency" : {
+                      "value" : "USD",
+                      "meta" : {
+                        "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
+                      }
+                    }
+                  },
+                  "priceType" : "InterestRate",
+                  "arithmeticOperator" : "Add"
+                },
                 "meta" : {
-                  "globalKey" : "df4b43f4"
+                  "globalKey" : "b44a2903"
                 }
               },
               "meta" : {
-                "globalKey" : "df4b43f4"
+                "globalKey" : "b44a2903"
               }
             },
             "account" : [ {
@@ -645,11 +666,11 @@
               }
             } ],
             "meta" : {
-              "globalKey" : "70df6425"
+              "globalKey" : "8ab1e0f6"
             }
           },
           "meta" : {
-            "globalKey" : "70df6425"
+            "globalKey" : "8ab1e0f6"
           }
         }
       }
@@ -691,6 +712,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "4627659e"
+    "globalKey" : "7a8806af"
   }
 }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex68-execution-advice-warrant.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex68-execution-advice-warrant.json
@@ -13,6 +13,14 @@
               },
               "assignedIdentifier" : [ {
                 "identifier" : {
+                  "value" : "1234512345",
+                  "meta" : {
+                    "scheme" : "http://www.abcbank.com/coding-scheme/front-office/trade-id"
+                  }
+                },
+                "version" : 1
+              }, {
+                "identifier" : {
                   "value" : "4853560",
                   "meta" : {
                     "scheme" : "http://www.abcbank.com/coding-scheme/back-office/trade-id"
@@ -21,7 +29,7 @@
                 "version" : 1
               } ],
               "meta" : {
-                "globalKey" : "ec378e96"
+                "globalKey" : "5c0cc9d5"
               }
             } ],
             "tradeDate" : {
@@ -139,11 +147,11 @@
               }
             } ],
             "meta" : {
-              "globalKey" : "1d6a6921"
+              "globalKey" : "d9933960"
             }
           },
           "meta" : {
-            "globalKey" : "1d6a6921"
+            "globalKey" : "d9933960"
           }
         }
       }
@@ -182,6 +190,6 @@
   } ],
   "action" : "New",
   "meta" : {
-    "globalKey" : "86e09598"
+    "globalKey" : "9ddb9a57"
   }
 }

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-common-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-common-func.rosetta
@@ -16,7 +16,6 @@ import cdm.product.common.schedule.*
 import cdm.product.common.settlement.*
 import cdm.product.template.*
 
-import fpml.consolidated.* as fpml
 import fpml.consolidated.asset.* as fpml
 import fpml.consolidated.business.events.* as fpml
 import fpml.consolidated.com.* as fpml
@@ -28,26 +27,27 @@ import fpml.consolidated.shared.* as fpml
 
 func GetFpmlTrade:
     inputs:
-        fpmlTradingEventsBaseModel fpml.TradingEventsBaseModel (0..1)
-        fpmlPostTradeEventsBaseModel fpml.PostTradeEventsBaseModel (0..1)
-        fpmlChangeEventsBaseModel fpml.ChangeEventsBaseModel (0..1)
-        fpmlTradeAmendmentContent fpml.TradeAmendmentContent (0..1)
+        fpmlTradePackage fpml.TradePackage (0..1)
+        fpmlInputTrade fpml.Trade (0..1)
+        fpmlNovation fpml.TradeNovationContent (0..1)
+        fpmlTermination fpml.TradeNotionalChange (0..1)
+        fpmlAmendment fpml.TradeAmendmentContent (0..1)
     output:
         fpmlTrade fpml.Trade (0..1)
 
     set fpmlTrade:
-        if fpmlTradingEventsBaseModel -> tradePackage -> trade exists
-        then fpmlTradingEventsBaseModel -> tradePackage -> trade only-element
-        else if fpmlTradingEventsBaseModel -> tradingEventsBaseModelSequence -> trade exists
-        then fpmlTradingEventsBaseModel -> tradingEventsBaseModelSequence -> trade
-        else if fpmlPostTradeEventsBaseModel -> postTradeEventsBaseModelSequence -> termination -> originalTrade exists
-        then fpmlPostTradeEventsBaseModel -> postTradeEventsBaseModelSequence -> termination -> originalTrade
-        else if fpmlPostTradeEventsBaseModel -> novation -> tradeNovationContentSequence0 -> oldTradeModel -> oldTrade exists
-        then fpmlPostTradeEventsBaseModel -> novation -> tradeNovationContentSequence0 -> oldTradeModel -> oldTrade
-        else if fpmlPostTradeEventsBaseModel -> novation -> tradeNovationContentSequence1 -> feeTradeModel -> feeTrade exists
-        then fpmlPostTradeEventsBaseModel -> novation -> tradeNovationContentSequence1 -> feeTradeModel -> feeTrade
-        else if fpmlTradeAmendmentContent -> trade exists
-        then fpmlTradeAmendmentContent -> trade
+        if fpmlTradePackage -> trade exists
+        then fpmlTradePackage -> trade only-element
+        else if fpmlInputTrade exists
+        then fpmlInputTrade
+        else if fpmlTermination -> originalTrade exists
+        then fpmlTermination -> originalTrade
+        else if fpmlNovation -> oldTrade exists
+        then fpmlNovation -> oldTrade
+        else if fpmlNovation -> feeTrade exists
+        then fpmlNovation -> feeTrade
+        else if fpmlAmendment -> trade exists
+        then fpmlAmendment -> trade
 
 func MapStringWithScheme:
     inputs:
@@ -109,25 +109,27 @@ func MapResolvablePriceQuantityReference:
 
 func MapProductTaxonomyList:
     inputs:
-        fpmlProductModel fpml.ProductModel (0..1)
+        fpmlPrimaryAssetClass fpml.AssetClass (0..1)
+        fpmlSecondaryAssetClassList fpml.AssetClass (0..*)
+        fpmlProductTypeList fpml.ProductType (0..*)
     output:
         taxonomy ProductTaxonomy (0..*)
 
     add taxonomy:
         ProductTaxonomy {
             primaryAssetClass: MapAssetClassWithScheme(
-                        fpmlProductModel -> primaryAssetClass -> value,
-                        fpmlProductModel -> primaryAssetClass -> assetClassScheme
+                        fpmlPrimaryAssetClass -> value,
+                        fpmlPrimaryAssetClass -> assetClassScheme
                     ),
             secondaryAssetClass: MapAssetClassWithScheme(
-                        fpmlProductModel -> secondaryAssetClass first -> value,
-                        fpmlProductModel -> secondaryAssetClass first -> assetClassScheme
+                        fpmlSecondaryAssetClassList first -> value,
+                        fpmlSecondaryAssetClassList first -> assetClassScheme
                     ),
             ...
         }
 
     add taxonomy:
-        fpmlProductModel -> productType
+        fpmlProductTypeList
             extract
                 ProductTaxonomy {
                     source: MapTaxonomySourceEnum(productTypeScheme),
@@ -280,25 +282,25 @@ func MapFeeTypeEnumWithScheme:
 
 func MapProductIdentifierList:
     inputs:
-        fpmlProductModel fpml.ProductModel (0..1)
+        fpmlProductIdList fpml.ProductId (0..*)
     output:
         productIdentifierList ProductIdentifier (0..*)
 
-    add productIdentifierList: fpmlProductModel -> productId extract MapProductIdentifier
+    add productIdentifierList: fpmlProductIdList extract MapProductIdentifier
 
 func MapProductIdentifier:
     inputs:
-        fpmlProductId fpml.ProductId (0..1)
+        fpmlProductIdList fpml.ProductId (0..1)
     output:
         productIdentifier ProductIdentifier (0..1)
 
     set productIdentifier:
         ProductIdentifier {
             identifier: MapStringWithScheme(
-                        fpmlProductId -> value,
-                        fpmlProductId -> productIdScheme
+                        fpmlProductIdList -> value,
+                        fpmlProductIdList -> productIdScheme
                     ),
-            source: MapProductIdType(fpmlProductId -> productIdScheme)
+            source: MapProductIdType(fpmlProductIdList -> productIdScheme)
         }
 
 func MapProductIdType:
@@ -521,17 +523,18 @@ func GetFpmlFxDigitalExercise:
         fpmlDigitalExercise fpml.Exercise (1..1)
 
     set fpmlDigitalExercise:
-        if fpmlFxDigitalOption -> fxDigitalOptionSequence1 -> europeanExercise exists
-        then fpmlFxDigitalOption -> fxDigitalOptionSequence1 -> europeanExercise
-        else if fpmlFxDigitalOption -> fxDigitalOptionSequence0 -> americanExercise exists
-        then fpmlFxDigitalOption -> fxDigitalOptionSequence0 -> americanExercise
+        if fpmlFxDigitalOption -> europeanExercise exists
+        then fpmlFxDigitalOption -> europeanExercise
+        else if fpmlFxDigitalOption -> americanExercise exists
+        then fpmlFxDigitalOption -> americanExercise
 
 func MapExerciseTerms:
     inputs:
         fpmlExercise fpml.Exercise (0..1)
         fpmlExerciseProcedure fpml.ExerciseProcedure (0..1)
         fpmlAutomaticExercise boolean (0..1)
-        fpmlBuyerSellerModel fpml.BuyerSellerModel (0..1)
+        fpmlBuyerPartyReference fpml.PartyReference (0..1)
+        fpmlSellerPartyReference fpml.PartyReference (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         exerciseTerms ExerciseTerms (1..1)
@@ -540,7 +543,8 @@ func MapExerciseTerms:
         if fpmlExerciseProcedure exists or fpmlAutomaticExercise exists
         then MapExerciseProcedure(
                     fpmlExerciseProcedure,
-                    fpmlBuyerSellerModel,
+                    fpmlBuyerPartyReference,
+                    fpmlSellerPartyReference,
                     fpmlAutomaticExercise,
                     cdmCounterpartyList
                 )
@@ -601,13 +605,19 @@ func MapCommodityPhysicalEuropeanExercise:
 func MapExerciseProcedure:
     inputs:
         fpmlExerciseProcedure fpml.ExerciseProcedure (0..1)
-        fpmlBuyerSellerModel fpml.BuyerSellerModel (0..1)
+        fpmlBuyerPartyReference fpml.PartyReference (0..1)
+        fpmlSellerPartyReference fpml.PartyReference (0..1)
         fpmlAutomaticExercise boolean (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         exerciseProcedure ExerciseProcedure (1..1)
 
-    alias buyerSeller: MapBuyerSeller(fpmlBuyerSellerModel, cdmCounterpartyList)
+    alias buyerSeller:
+        MapBuyerSeller(
+                fpmlBuyerPartyReference,
+                fpmlSellerPartyReference,
+                cdmCounterpartyList
+            )
 
     set exerciseProcedure:
         ExerciseProcedure {
@@ -663,10 +673,10 @@ func MapEuropeanExerciseTerms:
             partialExercise:
                 PartialExercise {
                     notionaReference: empty with-meta {
-                            reference: fpmlEuropeanExercise -> partialExercise -> partialExerciseModel -> notionalReference -> href first
+                            reference: fpmlEuropeanExercise -> partialExercise -> notionalReference -> href first
                         },
-                    integralMultipleAmount: fpmlEuropeanExercise -> partialExercise -> partialExerciseModel -> integralMultipleAmount,
-                    minimumNotionalAmount: fpmlEuropeanExercise -> partialExercise -> partialExerciseModel -> minimumNotionalAmount,
+                    integralMultipleAmount: fpmlEuropeanExercise -> partialExercise -> integralMultipleAmount,
+                    minimumNotionalAmount: fpmlEuropeanExercise -> partialExercise -> minimumNotionalAmount,
                     ...
                 },
             ...
@@ -681,9 +691,6 @@ func MapEquityEuropeanExerciseTerms:
     output:
         exerciseTerms ExerciseTerms (1..1)
 
-    alias equityExpirationModel:
-        fpmlEquityEuropeanExercise -> equityExpirationModel -> equityExpirationModelSequence
-
     set exerciseTerms:
         ExerciseTerms {
             style: European,
@@ -691,9 +698,9 @@ func MapEquityEuropeanExerciseTerms:
                         fpmlEquityEuropeanExercise -> expirationDate
                     ),
             expirationTime: MapBusinessCenterTime(
-                        equityExpirationModel -> equityExpirationTime
+                        fpmlEquityEuropeanExercise -> equityExpirationTime
                     ),
-            expirationTimeType: equityExpirationModel -> equityExpirationTimeType to-enum ExpirationTimeTypeEnum,
+            expirationTimeType: fpmlEquityEuropeanExercise -> equityExpirationTimeType to-enum ExpirationTimeTypeEnum,
             exerciseProcedure: cdmExerciseProcedure,
             ...
         } with-meta {
@@ -707,14 +714,11 @@ func MapCommodityEuropeanExerciseTerms:
     output:
         exerciseTerms ExerciseTerms (1..1)
 
-    alias commodityExpirationModel:
-        fpmlCommodityEuropeanExercise -> commodityEuropeanExerciseSequence
-
     set exerciseTerms:
         ExerciseTerms {
             style: European,
             expirationDate: MapAdjustableOrRelativeDate(
-                        fpmlCommodityEuropeanExercise -> expirationDate
+                        fpmlCommodityEuropeanExercise -> expirationDate last
                     ),
             expirationTime: MapBusinessCenterTime(
                         fpmlCommodityEuropeanExercise -> expirationTime
@@ -787,13 +791,10 @@ func MapEquityBermudaExerciseTerms:
     output:
         exerciseTerms ExerciseTerms (1..1)
 
-    alias equityExpirationModel:
-        fpmlEquityBermudaExercise -> equityExpirationModel -> equityExpirationModelSequence
-
     set exerciseTerms:
         ExerciseTerms {
             style: Bermuda,
-            expirationTimeType: equityExpirationModel -> equityExpirationTimeType to-enum ExpirationTimeTypeEnum,
+            expirationTimeType: fpmlEquityBermudaExercise -> equityExpirationTimeType to-enum ExpirationTimeTypeEnum,
             commencementDate: MapAdjustableOrRelativeDate(
                         fpmlEquityBermudaExercise -> commencementDate
                     ),
@@ -810,7 +811,7 @@ func MapEquityBermudaExerciseTerms:
                         fpmlEquityBermudaExercise -> latestExerciseTime
                     ),
             expirationTime: MapBusinessCenterTime(
-                        equityExpirationModel -> equityExpirationTime
+                        fpmlEquityBermudaExercise -> equityExpirationTime
                     ),
             exerciseProcedure: cdmExerciseProcedure,
             ...
@@ -861,12 +862,12 @@ func MapMultipleExercise:
 
     set multipleExercise:
         MultipleExercise {
-            integralMultipleAmount: fpmlMultipleExercise -> partialExerciseModel -> integralMultipleAmount,
-            minimumNumberOfOptions: fpmlMultipleExercise -> partialExerciseModel -> minimumNumberOfOptions,
+            integralMultipleAmount: fpmlMultipleExercise -> integralMultipleAmount,
+            minimumNumberOfOptions: fpmlMultipleExercise -> minimumNumberOfOptions,
             maximumNumberOfOptions: fpmlMultipleExercise -> maximumNumberOfOptions,
-            minimumNotionalAmount: fpmlMultipleExercise -> partialExerciseModel -> minimumNotionalAmount,
+            minimumNotionalAmount: fpmlMultipleExercise -> minimumNotionalAmount,
             notionaReference: empty with-meta {
-                    reference: fpmlMultipleExercise -> partialExerciseModel -> notionalReference -> href first
+                    reference: fpmlMultipleExercise -> notionalReference -> href first
                 },
             ...
         }
@@ -877,9 +878,6 @@ func MapEquityAmericanExerciseTerms:
         cdmExerciseProcedure ExerciseProcedure (0..1)
     output:
         exerciseTerms ExerciseTerms (1..1)
-
-    alias equityExpirationModel:
-        fpmlEqutiyAmericanExercise -> equityExpirationModel -> equityExpirationModelSequence
 
     set exerciseTerms:
         ExerciseTerms {
@@ -894,9 +892,9 @@ func MapEquityAmericanExerciseTerms:
                         fpmlEqutiyAmericanExercise -> latestExerciseTime
                     ),
             expirationTime: MapBusinessCenterTime(
-                        equityExpirationModel -> equityExpirationTime
+                        fpmlEqutiyAmericanExercise -> equityExpirationTime
                     ),
-            expirationTimeType: equityExpirationModel -> equityExpirationTimeType to-enum ExpirationTimeTypeEnum,
+            expirationTimeType: fpmlEqutiyAmericanExercise -> equityExpirationTimeType to-enum ExpirationTimeTypeEnum,
             exerciseProcedure: cdmExerciseProcedure,
             multipleExercise: MapEquityMultipleExercise(
                         fpmlEqutiyAmericanExercise -> equityMultipleExercise
@@ -931,10 +929,10 @@ func MapCommodityAmericanExerciseTerms:
     set exerciseTerms:
         ExerciseTerms {
             style: American,
-            commencementDate: fpmlCommodityAmericanExercise -> commodityAmericanExerciseSequence -> exercisePeriod
+            commencementDate: fpmlCommodityAmericanExercise -> exercisePeriod
                     extract MapAdjustableOrRelativeDate(commencementDate)
                     then first,
-            expirationDate: fpmlCommodityAmericanExercise -> commodityAmericanExerciseSequence -> exercisePeriod
+            expirationDate: fpmlCommodityAmericanExercise -> exercisePeriod
                     extract MapAdjustableOrRelativeDate(expirationDate),
             latestExerciseTime: MapBusinessCenterTime(
                         fpmlCommodityAmericanExercise -> latestExerciseTime

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-datetime-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-datetime-func.rosetta
@@ -2,6 +2,7 @@ namespace cdm.ingest.fpml.confirmation.datetime
 version "${project.version}"
 
 import cdm.base.datetime.*
+import cdm.base.staticdata.codelist.*
 import cdm.event.workflow.*
 import cdm.ingest.fpml.confirmation.other.*
 import cdm.observable.asset.*
@@ -29,9 +30,9 @@ func MapAdjustableOrAdjustedDateToAdjustableOrAdjustedOrRelativeDate:
 
     set adjustableOrAdjustedOrRelativeDate:
         AdjustableOrAdjustedOrRelativeDate {
-            unadjustedDate: fpmlAdjustableOrAdjustedDate -> adjustableDateModel -> unadjustedDate -> value -> date,
+            unadjustedDate: fpmlAdjustableOrAdjustedDate -> unadjustedDate -> value -> date,
             dateAdjustments: MapBusinessDayAdjustments(
-                        fpmlAdjustableOrAdjustedDate -> adjustableDateModel -> dateAdjustments
+                        fpmlAdjustableOrAdjustedDate -> dateAdjustments
                     ),
             adjustedDate: fpmlAdjustableOrAdjustedDate -> adjustedDate -> value -> date,
             relativeDate: empty
@@ -425,11 +426,9 @@ func MapRelativeDateSequenceToAdjustedRelativeDateOffset:
             period: firstDateOffset -> period to-enum PeriodEnum,
             dayType: firstDateOffset -> dayType to-enum DayTypeEnum,
             businessDayConvention: firstDateOffset -> businessDayConvention to-enum BusinessDayConventionEnum,
-            businessCenters: MapBusinessCenters(
-                        fpmlRelativeDateSequence -> businessCentersOrReferenceModel -> businessCenters
-                    ),
+            businessCenters: MapBusinessCenters(fpmlRelativeDateSequence -> businessCenters),
             businessCentersReference: MapBusinessCenterReference(
-                        fpmlRelativeDateSequence -> businessCentersOrReferenceModel -> businessCentersReference
+                        fpmlRelativeDateSequence -> businessCentersReference
                     ),
             dateRelativeTo: MapDateReference(fpmlRelativeDateSequence -> dateRelativeTo),
             ...
@@ -447,11 +446,9 @@ func MapRelativeDateOffsetToAdjustedRelativeDateOffset:
             period: fpmlRelativeDateOffset -> period to-enum PeriodEnum,
             dayType: fpmlRelativeDateOffset -> dayType to-enum DayTypeEnum,
             businessDayConvention: fpmlRelativeDateOffset -> businessDayConvention to-enum BusinessDayConventionEnum,
-            businessCenters: MapBusinessCenters(
-                        fpmlRelativeDateOffset -> businessCentersOrReferenceModel -> businessCenters
-                    ),
+            businessCenters: MapBusinessCenters(fpmlRelativeDateOffset -> businessCenters),
             businessCentersReference: MapBusinessCenterReference(
-                        fpmlRelativeDateOffset -> businessCentersOrReferenceModel -> businessCentersReference
+                        fpmlRelativeDateOffset -> businessCentersReference
                     ),
             dateRelativeTo: MapDateReference(fpmlRelativeDateOffset -> dateRelativeTo),
             adjustedDate: fpmlRelativeDateOffset -> adjustedDate -> value -> date,
@@ -470,11 +467,9 @@ func MapRelativeDateOffset:
             period: fpmlRelativeDateOffset -> period to-enum PeriodEnum,
             dayType: fpmlRelativeDateOffset -> dayType to-enum DayTypeEnum,
             businessDayConvention: fpmlRelativeDateOffset -> businessDayConvention to-enum BusinessDayConventionEnum,
-            businessCenters: MapBusinessCenters(
-                        fpmlRelativeDateOffset -> businessCentersOrReferenceModel -> businessCenters
-                    ),
+            businessCenters: MapBusinessCenters(fpmlRelativeDateOffset -> businessCenters),
             businessCentersReference: MapBusinessCenterReference(
-                        fpmlRelativeDateOffset -> businessCentersOrReferenceModel -> businessCentersReference
+                        fpmlRelativeDateOffset -> businessCentersReference
                     ),
             dateRelativeTo: MapDateReference(fpmlRelativeDateOffset -> dateRelativeTo),
             adjustedDate: fpmlRelativeDateOffset -> adjustedDate -> value -> date
@@ -507,11 +502,9 @@ func MapRelativeDates:
             period: fpmlRelativeDates -> period to-enum PeriodEnum,
             dayType: fpmlRelativeDates -> dayType to-enum DayTypeEnum,
             businessDayConvention: fpmlRelativeDates -> businessDayConvention to-enum BusinessDayConventionEnum,
-            businessCenters: MapBusinessCenters(
-                        fpmlRelativeDates -> businessCentersOrReferenceModel -> businessCenters
-                    ),
+            businessCenters: MapBusinessCenters(fpmlRelativeDates -> businessCenters),
             businessCentersReference: MapBusinessCenterReference(
-                        fpmlRelativeDates -> businessCentersOrReferenceModel -> businessCentersReference
+                        fpmlRelativeDates -> businessCentersReference
                     ),
             dateRelativeTo: MapDateReference(fpmlRelativeDates -> dateRelativeTo),
             adjustedDate: fpmlRelativeDates -> adjustedDate -> value -> date,
@@ -532,11 +525,9 @@ func MapRelativeDateSequenceToRelativeDates:
             period: firstDateOffset -> period to-enum PeriodEnum,
             dayType: firstDateOffset -> dayType to-enum DayTypeEnum,
             businessDayConvention: firstDateOffset -> businessDayConvention to-enum BusinessDayConventionEnum,
-            businessCenters: MapBusinessCenters(
-                        fpmlRelativeDateSequence -> businessCentersOrReferenceModel -> businessCenters
-                    ),
+            businessCenters: MapBusinessCenters(fpmlRelativeDateSequence -> businessCenters),
             businessCentersReference: MapBusinessCenterReference(
-                        fpmlRelativeDateSequence -> businessCentersOrReferenceModel -> businessCentersReference
+                        fpmlRelativeDateSequence -> businessCentersReference
                     ),
             dateRelativeTo: MapDateReference(fpmlRelativeDateSequence -> dateRelativeTo),
             ...
@@ -582,7 +573,7 @@ func MapCalculationPeriodFrequency:
 func MapFxFixingDate:
     inputs:
         fpmlFxFixingDate fpml.FxFixingDate (0..1)
-        paymentDates fpml.PaymentDates (0..1)
+        fpmlPaymentDates fpml.PaymentDates (0..1)
     output:
         fxFixingDate FxFixingDate (0..1)
 
@@ -592,15 +583,13 @@ func MapFxFixingDate:
             periodMultiplier: fpmlFxFixingDate -> periodMultiplier,
             dayType: fpmlFxFixingDate -> dayType to-enum DayTypeEnum,
             businessDayConvention: fpmlFxFixingDate -> businessDayConvention to-enum BusinessDayConventionEnum,
-            businessCenters: MapBusinessCenters(
-                        fpmlFxFixingDate -> businessCentersOrReferenceModel -> businessCenters
-                    ),
+            businessCenters: MapBusinessCenters(fpmlFxFixingDate -> businessCenters),
             businessCentersReference: MapBusinessCenterReference(
-                        fpmlFxFixingDate -> businessCentersOrReferenceModel -> businessCentersReference
+                        fpmlFxFixingDate -> businessCentersReference
                     ),
             dateRelativeToPaymentDates:
                 DateRelativeToPaymentDates {
-                    paymentDatesReference: MapPaymentDatesReference(paymentDates)
+                    paymentDatesReference: MapPaymentDatesReference(fpmlPaymentDates)
                 },
             ...
         }
@@ -652,7 +641,8 @@ func MapBusinessDayAdjustments:
                         fpmlBusinessDateAdjustments -> businessDayConvention to-string
                     ),
             businessCenters: MapBusinessCenterOrBusinessCenterReference(
-                        fpmlBusinessDateAdjustments -> businessCentersOrReferenceModel
+                        fpmlBusinessDateAdjustments -> businessCenters,
+                        fpmlBusinessDateAdjustments -> businessCentersReference
             ),
         }
 
@@ -695,19 +685,19 @@ func MapBusinessCenter:
 
 func MapBusinessCenterOrBusinessCenterReference:
     inputs:
-        fpmlBusinessCentersOrReferenceModel fpml.BusinessCentersOrReferenceModel (0..1)
+        fpmlBusinessCenters fpml.BusinessCenters (0..1)
+        fpmlBusinessCentersReference fpml.BusinessCentersReference (0..1)
     output:
         businessCenters BusinessCenters (0..1)
     set businessCenters:
         BusinessCenters {
-            businessCenter: fpmlBusinessCentersOrReferenceModel -> businessCenters -> businessCenter
-                    extract MapBusinessCenter,
+            businessCenter: fpmlBusinessCenters -> businessCenter extract MapBusinessCenter,
             businessCentersReference: MapBusinessCenterReference(
-                        fpmlBusinessCentersOrReferenceModel -> businessCentersReference
+                        fpmlBusinessCentersReference
                     ),
             ...
         } with-meta {
-            key: fpmlBusinessCentersOrReferenceModel -> businessCenters -> id
+            key: fpmlBusinessCenters -> id
         }
 
 func MapBusinessCenterReference:
@@ -770,9 +760,9 @@ func MapDividendPaymentDate:
         DividendPaymentDate {
             dividendDateReference:
                 DividendDateReference {
-                    dateReference: fpmlDividendPaymentDate -> dividendPaymentDateSequence -> dividendDateReference to-enum DividendDateReferenceEnum,
+                    dateReference: fpmlDividendPaymentDate -> dividendDateReference to-enum DividendDateReferenceEnum,
                     paymentDateOffset: MapOffset(
-                                fpmlDividendPaymentDate -> dividendPaymentDateSequence -> paymentDateOffset
+                                fpmlDividendPaymentDate -> paymentDateOffset
                             )
                 },
             dividendDate: MapAdjustableDateOrAdjustedRelativeDate(
@@ -854,8 +844,7 @@ func MapCommodityDeliveryDates:
     output:
         offset Offset (0..1)
 
-    alias deliveryDates:
-        fpmlCommodity -> commodityProductModel -> commodityProductModelSequence -> commodityProductModelSequenceChoice -> deliveryDates
+    alias deliveryDates: fpmlCommodity -> deliveryDates
 
     set offset:
         Offset {
@@ -888,25 +877,23 @@ func MapDeliveryDatesToPeriodMultiplier:
 
 func MapCommodityRelativePaymentDates:
     inputs:
-        commodityPaymentDatesModel fpml.CommodityPaymentDatesModel (0..1)
+        fpmlRelativePaymentDates fpml.CommodityRelativePaymentDates (0..1)
     output:
         paymentDates PaymentDates (0..1)
-
-    alias relativePaymentDates: commodityPaymentDatesModel -> relativePaymentDates
 
     set paymentDates:
         PaymentDates {
             payRelativeTo: MapPayRelativeToEnum(
-                        relativePaymentDates -> payRelativeTo to-string
+                        fpmlRelativePaymentDates -> payRelativeTo to-string
                     ),
-            paymentDaysOffset: MapOffset(relativePaymentDates -> paymentDaysOffset),
+            paymentDaysOffset: MapOffset(fpmlRelativePaymentDates -> paymentDaysOffset),
             paymentDatesAdjustments:
                 BusinessDayAdjustments {
                     businessDayConvention: MapBusinessDayConventionEnum(
-                                relativePaymentDates -> paymentDaysOffset -> businessDayConvention to-string
+                                fpmlRelativePaymentDates -> paymentDaysOffset -> businessDayConvention to-string
                             ),
                     businessCenters: MapBusinessCenters(
-                                relativePaymentDates -> businessCentersOrReferenceModel -> businessCenters
+                                fpmlRelativePaymentDates -> businessCenters
                     ),
                 },
             ...
@@ -914,29 +901,25 @@ func MapCommodityRelativePaymentDates:
 
 func MapCommoditySwapNonPeriodicPaymentDates:
     inputs:
-        commodityPaymentDatesModel fpml.CommodityPaymentDatesModel (0..1)
+        fpmlPaymentDates fpml.AdjustableDatesOrRelativeDateOffset (0..1)
     output:
         paymentDates PaymentDates (0..1)
 
     set paymentDates:
         PaymentDates {
-            paymentDateSchedule: MapCommoditySwapPaymentDateSchedule(
-                        commodityPaymentDatesModel
-                    ),
+            paymentDateSchedule: MapCommoditySwapPaymentDateSchedule(fpmlPaymentDates),
             ...
         }
 
 func MapCommoditySwapPaymentDateSchedule:
     inputs:
-        fpmlCommodityPaymentDatesModel fpml.CommodityPaymentDatesModel (0..1)
+        fpmlPaymentDates fpml.AdjustableDatesOrRelativeDateOffset (0..1)
     output:
         paymentDateSchedule PaymentDateSchedule (0..1)
 
     set paymentDateSchedule:
         PaymentDateSchedule {
-            interimPaymentDates: MapAdjustableDatesOrRelativeDateOffset(
-                        fpmlCommodityPaymentDatesModel -> commodityNonPeriodicPaymentDatesModel -> paymentDates
-                    ),
+            interimPaymentDates: MapAdjustableDatesOrRelativeDateOffset(fpmlPaymentDates),
             ...
         }
 
@@ -972,22 +955,18 @@ func MapParametricDates:
     output:
         parametricDates ParametricDates (0..1)
 
-    alias commodityPricingDates:
-        fpmlCommodityPricingDates -> commodityPricingDatesSequence -> commodityPricingDatesSequenceSequence
-    alias daysModel: commodityPricingDates -> daysModel
-
     set parametricDates:
         ParametricDates {
-            dayType: MapDayTypeEnum(daysModel -> dayType to-string),
+            dayType: MapDayTypeEnum(fpmlCommodityPricingDates -> dayType to-string),
             dayDistribution: MapDayDistributionEnumWithScheme(
-                        daysModel -> daysModelSequence0 -> dayDistribution -> value,
-                        daysModel -> daysModelSequence0 -> dayDistribution -> commodityFrequencyTypeScheme
+                        fpmlCommodityPricingDates -> dayDistribution -> value,
+                        fpmlCommodityPricingDates -> dayDistribution -> commodityFrequencyTypeScheme
                     ),
-            dayOfWeek: daysModel -> daysModelSequence1 -> dayOfWeek
+            dayOfWeek: fpmlCommodityPricingDates -> dayOfWeek
                     extract MapDayOfWeekEnum(item to-string),
-            dayFrequency: daysModel -> daysModelSequence1 -> dayNumber,
+            dayFrequency: fpmlCommodityPricingDates -> dayNumber,
             businessCenters: MapCommodityBusinessCalendarToBusinessCenters(
-                        commodityPricingDates -> businessCalendar
+                        fpmlCommodityPricingDates -> businessCalendar
                     ),
             ...
         }
@@ -1033,38 +1012,37 @@ func MapCommodityBusinessCalendarEnumWithScheme:
 
 func MapCommodityCalculationPeriods:
     inputs:
-        fpmlCommodityCalculationPeriods fpml.CommodityCalculationPeriodsModel (0..1)
+        fpmlCommodityCalculationPeriodsSchedule fpml.CommodityCalculationPeriodsSchedule (0..1)
     output:
         calculationPeriodDates CalculationPeriodDates (0..1)
 
     set calculationPeriodDates:
         CalculationPeriodDates {
             calculationPeriodFrequency: MapCommodityCalculationPeriodFrequency(
-                        fpmlCommodityCalculationPeriods
+                        fpmlCommodityCalculationPeriodsSchedule
                     ),
             ...
         }
 
 func MapCommodityCalculationPeriodFrequency:
     inputs:
-        fpmlCommodityCalculationPeriodsModel fpml.CommodityCalculationPeriodsModel (1..1)
+        fpmlCalculationPeriodsSchedule fpml.CommodityCalculationPeriodsSchedule (0..1)
     output:
         calculationPeriodFrequency CalculationPeriodFrequency (0..1)
 
-    alias calculationPeriod:
-        fpmlCommodityCalculationPeriodsModel -> calculationPeriodsSchedule
-
     set calculationPeriodFrequency:
         CalculationPeriodFrequency {
-            period: MapPeriodExtendedEnum(calculationPeriod -> period to-string),
-            periodMultiplier: calculationPeriod -> periodMultiplier,
+            period: MapPeriodExtendedEnum(
+                        fpmlCalculationPeriodsSchedule -> period to-string
+                    ),
+            periodMultiplier: fpmlCalculationPeriodsSchedule -> periodMultiplier,
             rollConvention: empty,
-            balanceOfFirstPeriod: calculationPeriod -> balanceOfFirstPeriod
+            balanceOfFirstPeriod: fpmlCalculationPeriodsSchedule -> balanceOfFirstPeriod
         } with-meta {
-            key: calculationPeriod -> id
+            key: fpmlCalculationPeriodsSchedule -> id
         }
 
-func MapCommodityCalculationPeriodsScheduleToCalculationPeriodFrequncy:
+func MapCommodityCalculationPeriodsScheduleToCalculationPeriodFrequency:
     inputs:
         fpmlCommodityCalculationPeriodsSchedule fpml.CommodityCalculationPeriodsSchedule (0..1)
     output:
@@ -1115,7 +1093,7 @@ func MapFpmlDateTimeListToDateTimeList: <"Creates a ZonedDateTime from the provi
 
 func MapEventTimestamp:
     inputs:
-        messageHeaderModel fpml.MessageHeaderModel (0..1)
+        creationTimestamp zonedDateTime (0..1)
         fpmlTrade fpml.Trade (0..1)
     output:
         eventTimestamp EventTimestamp (0..*)
@@ -1123,9 +1101,9 @@ func MapEventTimestamp:
     alias partyTradeInformation: fpmlTrade -> tradeHeader -> partyTradeInformation
 
     add eventTimestamp:
-        if messageHeaderModel -> creationTimestamp exists
+        if creationTimestamp exists
         then EventTimestamp {
-                dateTime: messageHeaderModel -> creationTimestamp,
+                dateTime: creationTimestamp,
                 qualification: eventCreationDateTime
             }
     add eventTimestamp:

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-header-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-header-func.rosetta
@@ -13,63 +13,52 @@ import fpml.consolidated.shared.* as fpml
 func MapTradeIdentifierList:
     inputs:
         fpmlTradeHeader fpml.TradeHeader (1..1)
-        fpmlPartyTradeIdentifier fpml.PartyTradeIdentifier (0..*)
+        fpmlPartyTradeIdentifierList fpml.PartyTradeIdentifier (0..*)
     output:
         cdmTradeIdentifierList TradeIdentifier (0..*)
 
     add cdmTradeIdentifierList:
-        fpmlTradeHeader -> tradeIdentifiersModel -> partyTradeIdentifier
+        fpmlTradeHeader -> partyTradeIdentifier
             extract MapPartyTradeIdentifierToTradeIdentifierList
             then flatten
     add cdmTradeIdentifierList:
-        fpmlTradeHeader -> tradeIdentifiersModel -> tradeIdentifiersModelSequence -> partyTradeIdentifier
-            extract MapPartyTradeIdentifierToTradeIdentifierList
-            then flatten
-    add cdmTradeIdentifierList:
-        fpmlPartyTradeIdentifier
+        fpmlPartyTradeIdentifierList
             extract MapPartyTradeIdentifierToTradeIdentifierList
             then flatten
 
 func MapPartyTradeIdentifierToTradeIdentifierList:
     inputs:
-        fpmlPartyTradeIdentifier fpml.PartyTradeIdentifier (0..1)
+        fpmlPartyTradeIdentifierList fpml.PartyTradeIdentifier (0..1)
     output:
         cdmTradeIdentifier TradeIdentifier (0..*)
 
     alias issuer:
         MapStringWithScheme(
-                fpmlPartyTradeIdentifier -> issuerTradeIdModel -> issuer -> value,
-                fpmlPartyTradeIdentifier -> issuerTradeIdModel -> issuer -> issuerIdScheme
+                fpmlPartyTradeIdentifierList -> issuer -> value,
+                fpmlPartyTradeIdentifierList -> issuer -> issuerIdScheme
             )
 
     alias identifierForIssuer:
-        MapTradeIdToAssignedIdentifier(
-                fpmlPartyTradeIdentifier -> issuerTradeIdModel -> tradeId,
-                empty
-            )
+        MapTradeIdToAssignedIdentifier(fpmlPartyTradeIdentifierList -> tradeId, empty)
 
     alias identifierForTrade:
-        fpmlPartyTradeIdentifier -> tradeIdentifierSequence -> tradeIdentifierSequenceChoice
+        fpmlPartyTradeIdentifierList -> tradeIdentifierChoice
             extract
                 MapTradeIdToAssignedIdentifier(
                         tradeId default versionedTradeId -> tradeId,
-                        versionedTradeId -> versionHistoryModel -> version
+                        versionedTradeId -> version
                     )
 
     alias identifierTypeForIssuer:
-        MapTradeIdToIdentifierType(
-                fpmlPartyTradeIdentifier -> issuerTradeIdModel -> tradeId
-            )
+        MapTradeIdToIdentifierType(fpmlPartyTradeIdentifierList -> tradeId)
 
     alias identifierTypeForTrade:
-        fpmlPartyTradeIdentifier -> tradeIdentifierSequence -> tradeIdentifierSequenceChoice -> tradeId
+        fpmlPartyTradeIdentifierList -> tradeIdentifierChoice -> tradeId
             extract MapTradeIdToIdentifierType
             then first
 
     alias issuerReference:
-        MapPartyReference(
-                fpmlPartyTradeIdentifier -> tradeIdentifierSequence -> partyAndAccountReferencesModel -> partyReference -> href
-            )
+        MapPartyReference(fpmlPartyTradeIdentifierList -> partyReference -> href)
 
     set cdmTradeIdentifier:
         TradeIdentifier {
@@ -81,47 +70,43 @@ func MapPartyTradeIdentifierToTradeIdentifierList:
 
 func MapTradeIdentifierSequenceToTradeIdentifier:
     inputs:
-        fpmlTradeIdentifierSequence fpml.TradeIdentifierSequence (0..1)
+        fpmlNewTradeIdentifier fpml.PartyTradeIdentifier (0..1)
     output:
         cdmTradeIdentifier TradeIdentifier (0..1)
 
-    set cdmTradeIdentifier -> issuerReference -> reference:
-        fpmlTradeIdentifierSequence -> partyAndAccountReferencesModel -> partyReference -> href
+    alias fpmlPartyReference: fpmlNewTradeIdentifier -> partyReference
+    alias fpmlTradeIdentifierChoice: fpmlNewTradeIdentifier -> tradeIdentifierChoice
+
+    set cdmTradeIdentifier -> issuerReference -> reference: fpmlPartyReference -> href
 
     add cdmTradeIdentifier -> assignedIdentifier:
-        fpmlTradeIdentifierSequence -> tradeIdentifierSequenceChoice
-            extract MapTradeIdToAssignedIdentifier(tradeId, empty)
+        fpmlTradeIdentifierChoice extract MapTradeIdToAssignedIdentifier(tradeId, empty)
 
     add cdmTradeIdentifier -> assignedIdentifier:
-        fpmlTradeIdentifierSequence -> tradeIdentifierSequenceChoice
+        fpmlTradeIdentifierChoice
             extract
                 MapTradeIdToAssignedIdentifier(
                         versionedTradeId -> tradeId,
-                        versionedTradeId -> versionHistoryModel -> version
+                        versionedTradeId -> version
                     )
 
     set cdmTradeIdentifier -> identifierType:
-        fpmlTradeIdentifierSequence -> tradeIdentifierSequenceChoice -> tradeId
+        fpmlTradeIdentifierChoice -> tradeId
             extract MapTradeIdToIdentifierType
             then first
 
 func MapIssuerTradeIdModelToIdentifier:
     inputs:
-        fpmlIssuerTradeIdModel fpml.IssuerTradeIdModel (0..1)
+        fpmlIssuer fpml.IssuerId (1..1)
+        fpmlTradeId fpml.TradeId (1..1)
     output:
         cdmTradeIdentifier Identifier (0..1)
 
     set cdmTradeIdentifier:
         TradeIdentifier {
-            issuer: MapStringWithScheme(
-                        fpmlIssuerTradeIdModel -> issuer -> value,
-                        fpmlIssuerTradeIdModel -> issuer -> issuerIdScheme
-                    ),
-            assignedIdentifier: MapTradeIdToAssignedIdentifier(
-                        fpmlIssuerTradeIdModel -> tradeId,
-                        empty
-                    ),
-            identifierType: MapTradeIdToIdentifierType(fpmlIssuerTradeIdModel -> tradeId),
+            issuer: MapStringWithScheme(fpmlIssuer -> value, fpmlIssuer -> issuerIdScheme),
+            assignedIdentifier: MapTradeIdToAssignedIdentifier(fpmlTradeId, empty),
+            identifierType: MapTradeIdToIdentifierType(fpmlTradeId),
             ...
         }
 

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-message-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-message-func.rosetta
@@ -53,16 +53,18 @@ func MapConfirmationAgreedToTradeState:
 
     alias fpmlTrade:
         GetFpmlTrade(
-                fpmlConfirmationAgreed -> tradingEventsBaseModel,
-                fpmlConfirmationAgreed -> postTradeEventsBaseModel,
-                fpmlConfirmationAgreed -> changeEventsBaseModel,
-                empty
+                fpmlConfirmationAgreed -> tradePackage,
+                fpmlConfirmationAgreed -> trade,
+                fpmlConfirmationAgreed -> novation,
+                fpmlConfirmationAgreed -> termination,
+                fpmlConfirmationAgreed -> amendment
             )
 
     set tradeState:
         MapTradeState(
-                fpmlTrade,
-                fpmlConfirmationAgreed -> partiesAndAccountsModel,
+                fpmlConfirmationAgreed -> trade,
+                fpmlConfirmationAgreed -> party,
+                fpmlConfirmationAgreed -> account,
                 empty,
                 empty
             )
@@ -76,7 +78,8 @@ func MapDataDocumentToTradeState:
     set tradeState:
         MapTradeState(
                 fpmlDataDocument -> trade only-element,
-                fpmlDataDocument -> partiesAndAccountsModel,
+                fpmlDataDocument -> party,
+                fpmlDataDocument -> account,
                 empty,
                 empty
             )
@@ -89,7 +92,8 @@ func MapExecutionNotificationToTradeState:
 
     alias fpmlTrade:
         GetFpmlTrade(
-                fpmlExecutionNotification -> tradingEventsBaseModel,
+                fpmlExecutionNotification -> tradePackage,
+                fpmlExecutionNotification -> trade,
                 empty,
                 empty,
                 empty
@@ -98,7 +102,8 @@ func MapExecutionNotificationToTradeState:
     set tradeState:
         MapTradeState(
                 fpmlTrade,
-                fpmlExecutionNotification -> partiesAndAccountsModel,
+                fpmlExecutionNotification -> party,
+                fpmlExecutionNotification -> account,
                 empty,
                 empty
             )
@@ -111,7 +116,8 @@ func MapRequestClearingToTradeState:
 
     alias fpmlTrade:
         GetFpmlTrade(
-                fpmlRequestClearing -> tradingEventsModel -> tradingEventsBaseModel,
+                fpmlRequestClearing -> tradePackage,
+                fpmlRequestClearing -> trade,
                 empty,
                 empty,
                 empty
@@ -120,7 +126,8 @@ func MapRequestClearingToTradeState:
     set tradeState:
         MapTradeState(
                 fpmlTrade,
-                fpmlRequestClearing -> partiesAndAccountsModel,
+                fpmlRequestClearing -> party,
+                fpmlRequestClearing -> account,
                 empty,
                 empty
             )
@@ -133,16 +140,18 @@ func MapRequestConfirmationToTradeState:
 
     alias fpmlTrade:
         GetFpmlTrade(
-                fpmlRequestConfirmation -> tradingAndPostTradeEventsModel -> tradingEventsBaseModel,
-                fpmlRequestConfirmation -> tradingAndPostTradeEventsModel -> postTradeEventsBaseModel,
-                empty,
-                empty
+                fpmlRequestConfirmation -> tradePackage,
+                fpmlRequestConfirmation -> trade,
+                fpmlRequestConfirmation -> novation,
+                fpmlRequestConfirmation -> termination,
+                fpmlRequestConfirmation -> amendment
             )
 
     set tradeState:
         MapTradeState(
                 fpmlTrade,
-                fpmlRequestConfirmation -> partiesAndAccountsModel,
+                fpmlRequestConfirmation -> party,
+                fpmlRequestConfirmation -> account,
                 empty,
                 empty
             )
@@ -153,19 +162,25 @@ func MapClearingConfirmedToWorkflowStep:
     output:
         workflowStep WorkflowStep (0..1)
 
-    alias fpmlTradingEventsBaseModel:
-        fpmlClearingConfirmed -> clearingResultsModel -> tradingEventsModel -> tradingEventsBaseModel
-    alias fpmlTermination:
-        fpmlClearingConfirmed -> clearingResultsModel -> clearingResultsModelSequence -> termination
-    alias fpmlTrade: GetFpmlTrade(fpmlTradingEventsBaseModel, empty, empty, empty)
+    alias fpmlTermination: fpmlClearingConfirmed -> termination
+    alias fpmlTrade:
+        GetFpmlTrade(
+                fpmlClearingConfirmed -> tradePackage,
+                fpmlClearingConfirmed -> trade,
+                empty,
+                empty,
+                empty
+            )
     alias eventDate: GetEventDate(empty, fpmlTermination, empty, fpmlTrade)
     alias effectiveDate: GetEffectiveDate(empty, fpmlTermination, empty)
 
     alias intent:
         MapIntent(
                 fpmlTrade,
-                fpmlTradingEventsBaseModel -> tradingEventsBaseModelSequence -> originatingEvent,
-                fpmlClearingConfirmed -> clearingResultsModel -> clearingResultsModelSequence -> terminatingEvent,
+                fpmlClearingConfirmed -> originatingEvent,
+                fpmlClearingConfirmed -> terminatingEvent,
+                empty,
+                empty,
                 empty,
                 empty
             )
@@ -173,16 +188,20 @@ func MapClearingConfirmedToWorkflowStep:
     set workflowStep:
         MapWorkflowStep(
                 fpmlClearingConfirmed -> header -> messageId,
-                fpmlClearingConfirmed -> header -> messageHeaderModel,
+                fpmlClearingConfirmed -> header -> creationTimestamp,
+                fpmlClearingConfirmed -> header -> sentBy,
+                fpmlClearingConfirmed -> header -> sendTo,
                 empty,
                 fpmlTrade,
-                fpmlClearingConfirmed -> partiesAndAccountsModel,
+                empty,
+                fpmlTermination,
+                empty,
+                fpmlClearingConfirmed -> party,
+                fpmlClearingConfirmed -> account,
+                fpmlClearingConfirmed -> quote,
                 intent,
                 eventDate,
                 effectiveDate,
-                empty,
-                fpmlTradingEventsBaseModel,
-                empty,
                 empty,
                 empty
             )
@@ -195,31 +214,31 @@ func MapExecutionAdviceToWorkflowStep:
 
     alias fpmlTrade:
         GetFpmlTrade(
-                fpmlExecutionAdvice -> tradingEventsBaseModel,
-                fpmlExecutionAdvice -> postTradeEventsBaseModel,
-                fpmlExecutionAdvice -> changeEventsBaseModel,
-                fpmlExecutionAdvice -> postTradeEventsBaseModel -> amendment
+                fpmlExecutionAdvice -> tradePackage,
+                fpmlExecutionAdvice -> trade,
+                fpmlExecutionAdvice -> novation,
+                fpmlExecutionAdvice -> termination,
+                fpmlExecutionAdvice -> amendment
             )
 
-    alias fpmlTermination:
-        fpmlExecutionAdvice -> postTradeEventsBaseModel -> postTradeEventsBaseModelSequence -> termination
-    alias fpmlNovation: fpmlExecutionAdvice -> postTradeEventsBaseModel -> novation
-    alias fpmlAmendment: fpmlExecutionAdvice -> postTradeEventsBaseModel -> amendment
+    alias fpmlTermination: fpmlExecutionAdvice -> termination
+    alias fpmlNovation: fpmlExecutionAdvice -> novation
+    alias fpmlAmendment: fpmlExecutionAdvice -> amendment
     alias action:
         MapMessageAction(
                 fpmlExecutionAdvice -> isCorrection,
-                fpmlExecutionAdvice -> postTradeEventsBaseModel -> withdrawal -> reason
-                    distinct
-                    only-element -> value
+                fpmlExecutionAdvice -> withdrawal -> reason distinct only-element -> value
             )
 
     alias intent:
         MapIntent(
                 fpmlTrade,
-                fpmlExecutionAdvice -> tradingEventsBaseModel -> tradingEventsBaseModelSequence -> originatingEvent,
-                fpmlExecutionAdvice -> postTradeEventsBaseModel -> postTradeEventsBaseModelSequence -> terminatingEvent,
-                fpmlExecutionAdvice -> postTradeEventsBaseModel,
-                fpmlExecutionAdvice -> optionsEventsBaseModel
+                fpmlExecutionAdvice -> originatingEvent,
+                fpmlExecutionAdvice -> terminatingEvent,
+                fpmlExecutionAdvice -> novation,
+                fpmlExecutionAdvice -> termination,
+                fpmlExecutionAdvice -> amendment,
+                fpmlExecutionAdvice -> optionExercise
             )
 
     alias eventDate: GetEventDate(fpmlAmendment, fpmlTermination, fpmlNovation, fpmlTrade)
@@ -228,16 +247,20 @@ func MapExecutionAdviceToWorkflowStep:
     set workflowStep:
         MapWorkflowStep(
                 fpmlExecutionAdvice -> header -> messageId,
-                fpmlExecutionAdvice -> header -> messageHeaderModel,
+                fpmlExecutionAdvice -> header -> creationTimestamp,
+                fpmlExecutionAdvice -> header -> sentBy,
+                fpmlExecutionAdvice -> header -> sendTo,
                 action,
                 fpmlTrade,
-                fpmlExecutionAdvice -> partiesAndAccountsModel,
+                fpmlNovation,
+                fpmlTermination,
+                fpmlAmendment,
+                fpmlExecutionAdvice -> party,
+                fpmlExecutionAdvice -> account,
+                fpmlExecutionAdvice -> quote,
                 intent,
                 eventDate,
                 effectiveDate,
-                fpmlExecutionAdvice -> postTradeEventsBaseModel,
-                fpmlExecutionAdvice -> tradingEventsBaseModel,
-                empty,
                 empty,
                 empty
             )
@@ -250,32 +273,31 @@ func MapExecutionAdviceRetractedToWorkflowStep:
 
     alias fpmlTrade:
         GetFpmlTrade(
-                fpmlExecutionAdviceRetracted -> tradingEventsBaseModel,
-                fpmlExecutionAdviceRetracted -> postTradeEventsBaseModel,
-                fpmlExecutionAdviceRetracted -> changeEventsBaseModel,
-                empty
+                fpmlExecutionAdviceRetracted -> tradePackage,
+                fpmlExecutionAdviceRetracted -> trade,
+                fpmlExecutionAdviceRetracted -> novation,
+                fpmlExecutionAdviceRetracted -> termination,
+                fpmlExecutionAdviceRetracted -> amendment
             )
 
-    alias fpmlTermination:
-        fpmlExecutionAdviceRetracted -> postTradeEventsBaseModel -> postTradeEventsBaseModelSequence -> termination
-    alias fpmlNovation: fpmlExecutionAdviceRetracted -> postTradeEventsBaseModel -> novation
-    alias fpmlAmendment:
-        fpmlExecutionAdviceRetracted -> postTradeEventsBaseModel -> amendment
+    alias fpmlTermination: fpmlExecutionAdviceRetracted -> termination
+    alias fpmlNovation: fpmlExecutionAdviceRetracted -> novation
+    alias fpmlAmendment: fpmlExecutionAdviceRetracted -> amendment
     alias action:
         MapMessageAction(
                 empty,
-                fpmlExecutionAdviceRetracted -> postTradeEventsBaseModel -> withdrawal -> reason
-                    distinct
-                    only-element -> value
+                fpmlExecutionAdviceRetracted -> withdrawal -> reason distinct only-element -> value
             )
 
     alias intent:
         MapIntent(
                 fpmlTrade,
-                fpmlExecutionAdviceRetracted -> tradingEventsBaseModel -> tradingEventsBaseModelSequence -> originatingEvent,
-                fpmlExecutionAdviceRetracted -> postTradeEventsBaseModel -> postTradeEventsBaseModelSequence -> terminatingEvent,
-                fpmlExecutionAdviceRetracted -> postTradeEventsBaseModel,
-                fpmlExecutionAdviceRetracted -> optionsEventsBaseModel
+                fpmlExecutionAdviceRetracted -> originatingEvent,
+                fpmlExecutionAdviceRetracted -> terminatingEvent,
+                fpmlExecutionAdviceRetracted -> novation,
+                fpmlExecutionAdviceRetracted -> termination,
+                fpmlExecutionAdviceRetracted -> amendment,
+                fpmlExecutionAdviceRetracted -> optionExercise
             )
 
     alias eventDate: GetEventDate(fpmlAmendment, fpmlTermination, fpmlNovation, fpmlTrade)
@@ -284,16 +306,20 @@ func MapExecutionAdviceRetractedToWorkflowStep:
     set workflowStep:
         MapWorkflowStep(
                 fpmlExecutionAdviceRetracted -> header -> messageId,
-                fpmlExecutionAdviceRetracted -> header -> messageHeaderModel,
+                fpmlExecutionAdviceRetracted -> header -> creationTimestamp,
+                fpmlExecutionAdviceRetracted -> header -> sentBy,
+                fpmlExecutionAdviceRetracted -> header -> sendTo,
                 action,
                 fpmlTrade,
-                fpmlExecutionAdviceRetracted -> partiesAndAccountsModel,
+                fpmlNovation,
+                fpmlTermination,
+                fpmlAmendment,
+                fpmlExecutionAdviceRetracted -> party,
+                fpmlExecutionAdviceRetracted -> account,
+                empty,
                 intent,
                 eventDate,
                 effectiveDate,
-                fpmlExecutionAdviceRetracted -> postTradeEventsBaseModel,
-                fpmlExecutionAdviceRetracted -> tradingEventsBaseModel,
-                empty,
                 empty,
                 empty
             )
@@ -306,7 +332,8 @@ func MapExecutionNotificationToWorkflowStep:
 
     alias fpmlTrade:
         GetFpmlTrade(
-                fpmlExecutionNotification -> tradingEventsBaseModel,
+                fpmlExecutionNotification -> tradePackage,
+                fpmlExecutionNotification -> trade,
                 empty,
                 empty,
                 empty
@@ -317,10 +344,12 @@ func MapExecutionNotificationToWorkflowStep:
     alias intent:
         MapIntent(
                 fpmlTrade,
-                fpmlExecutionNotification -> tradingEventsBaseModel -> tradingEventsBaseModelSequence -> originatingEvent,
+                fpmlExecutionNotification -> originatingEvent,
                 empty,
                 empty,
-                fpmlExecutionNotification -> optionsEventsBaseModel
+                empty,
+                empty,
+                fpmlExecutionNotification -> optionExercise
             )
 
     alias eventDate: GetEventDate(empty, empty, empty, fpmlTrade)
@@ -329,16 +358,20 @@ func MapExecutionNotificationToWorkflowStep:
     set workflowStep:
         MapWorkflowStep(
                 fpmlExecutionNotification -> header -> messageId,
-                fpmlExecutionNotification -> header -> messageHeaderModel,
+                fpmlExecutionNotification -> header -> creationTimestamp,
+                fpmlExecutionNotification -> header -> sentBy,
+                fpmlExecutionNotification -> header -> sendTo,
                 action,
                 fpmlTrade,
-                fpmlExecutionNotification -> partiesAndAccountsModel,
+                empty,
+                empty,
+                empty,
+                fpmlExecutionNotification -> party,
+                fpmlExecutionNotification -> account,
+                fpmlExecutionNotification -> quote,
                 intent,
                 eventDate,
                 effectiveDate,
-                empty,
-                fpmlExecutionNotification -> tradingEventsBaseModel,
-                empty,
                 empty,
                 empty
             )
@@ -351,7 +384,8 @@ func MapRequestClearingToWorkflowStep:
 
     alias fpmlTrade:
         GetFpmlTrade(
-                fpmlRequestClearing -> tradingEventsModel -> tradingEventsBaseModel,
+                fpmlRequestClearing -> tradePackage,
+                fpmlRequestClearing -> trade,
                 empty,
                 empty,
                 empty
@@ -359,7 +393,9 @@ func MapRequestClearingToWorkflowStep:
     alias intent:
         MapIntent(
                 fpmlTrade,
-                fpmlRequestClearing -> tradingEventsModel -> tradingEventsBaseModel -> tradingEventsBaseModelSequence -> originatingEvent,
+                fpmlRequestClearing -> originatingEvent,
+                empty,
+                empty,
                 empty,
                 empty,
                 empty
@@ -372,16 +408,20 @@ func MapRequestClearingToWorkflowStep:
     set workflowStep:
         MapWorkflowStep(
                 fpmlRequestClearing -> header -> messageId,
-                fpmlRequestClearing -> header -> messageHeaderModel,
+                fpmlRequestClearing -> header -> creationTimestamp,
+                fpmlRequestClearing -> header -> sentBy,
+                fpmlRequestClearing -> header -> sendTo,
                 action,
                 fpmlTrade,
-                fpmlRequestClearing -> partiesAndAccountsModel,
+                empty,
+                empty,
+                empty,
+                fpmlRequestClearing -> party,
+                fpmlRequestClearing -> account,
+                fpmlRequestClearing -> quote,
                 intent,
                 eventDate,
                 effectiveDate,
-                empty,
-                fpmlRequestClearing -> tradingEventsModel -> tradingEventsBaseModel,
-                empty,
                 empty,
                 empty
             )
@@ -394,7 +434,7 @@ func MapTradeChangeAdviceToWorkflowStep:
 
     alias fpmlTrade: fpmlTradeChangeAdvice -> change -> trade
 
-    alias intent: MapIntent(fpmlTrade, empty, empty, empty, empty)
+    alias intent: MapIntent(fpmlTrade, empty, empty, empty, empty, empty, empty)
 
     alias eventDate: GetEventDate(empty, empty, empty, fpmlTrade)
     alias effectiveDate: GetEffectiveDate(empty, empty, empty)
@@ -403,16 +443,20 @@ func MapTradeChangeAdviceToWorkflowStep:
     set workflowStep:
         MapWorkflowStep(
                 fpmlTradeChangeAdvice -> header -> messageId,
-                fpmlTradeChangeAdvice -> header -> messageHeaderModel,
+                fpmlTradeChangeAdvice -> header -> creationTimestamp,
+                fpmlTradeChangeAdvice -> header -> sentBy,
+                fpmlTradeChangeAdvice -> header -> sendTo,
                 action,
                 fpmlTrade,
-                fpmlTradeChangeAdvice -> partiesAndAccountsModel,
+                empty,
+                empty,
+                empty,
+                fpmlTradeChangeAdvice -> party,
+                fpmlTradeChangeAdvice -> account,
+                fpmlTradeChangeAdvice -> quote,
                 intent,
                 eventDate,
                 effectiveDate,
-                empty,
-                empty,
-                empty,
                 empty,
                 empty
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-other-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-other-func.rosetta
@@ -7,6 +7,7 @@ import cdm.base.math.*
 import cdm.base.staticdata.asset.common.*
 import cdm.base.staticdata.asset.credit.*
 import cdm.base.staticdata.asset.rates.*
+import cdm.base.staticdata.codelist.*
 import cdm.base.staticdata.party.*
 import cdm.event.common.*
 import cdm.event.workflow.*
@@ -2742,22 +2743,6 @@ func MapRoundingDirectionEnum:
             "Up" then Up,
             "Down" then Down,
             "Nearest" then Nearest,
-            default empty
-
-func MapScheduledTransferEnum:
-    inputs:
-        value string (0..1)
-    output:
-        result ScheduledTransferEnum (0..1)
-    set result:
-        value switch
-            "Coupon" then Coupon,
-            "CreditEvent" then CreditEvent,
-            "DividendReturn" then DividendReturn,
-            "ExerciseFee" then Exercise,
-            "InterestReturn" then InterestReturn,
-            "PriceReturn" then Performance,
-            "PrincipleExchange" then PrincipalPayment,
             default empty
 
 func MapSettledEntityMatrixSourceEnum:

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-party-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-party-func.rosetta
@@ -101,39 +101,29 @@ func MapCounterpartyList:
 
 func MapPayerReceiverModelToCounterpartyList:
     inputs:
-        fpmlPayerReceiverModel fpml.PayerReceiverModel (0..1)
+        fpmlPayerPartyReference fpml.PartyReference (0..1)
+        fpmlReceiverPartyReference fpml.PartyReference (0..1)
     output:
         counterpartyList Counterparty (0..2)
 
     add counterpartyList:
-        MapCounterparty(
-                CounterpartyRoleEnum -> Party1,
-                fpmlPayerReceiverModel -> payerModel -> payerPartyReference
-            )
+        MapCounterparty(CounterpartyRoleEnum -> Party1, fpmlPayerPartyReference)
 
     add counterpartyList:
-        MapCounterparty(
-                CounterpartyRoleEnum -> Party2,
-                fpmlPayerReceiverModel -> receiverModel -> receiverPartyReference
-            )
+        MapCounterparty(CounterpartyRoleEnum -> Party2, fpmlReceiverPartyReference)
 
 func MapBuyerSellerModelToCounterpartyList:
     inputs:
-        fpmlBuyerSellerModel fpml.BuyerSellerModel (0..1)
+        fpmlBuyerPartyReference fpml.PartyReference (1..1)
+        fpmlSellerPartyReference fpml.PartyReference (1..1)
     output:
         counterpartyList Counterparty (0..2)
 
     add counterpartyList:
-        MapCounterparty(
-                CounterpartyRoleEnum -> Party1,
-                fpmlBuyerSellerModel -> buyerPartyReference
-            )
+        MapCounterparty(CounterpartyRoleEnum -> Party1, fpmlBuyerPartyReference)
 
     add counterpartyList:
-        MapCounterparty(
-                CounterpartyRoleEnum -> Party2,
-                fpmlBuyerSellerModel -> sellerPartyReference
-            )
+        MapCounterparty(CounterpartyRoleEnum -> Party2, fpmlSellerPartyReference)
 
 func MapCounterparty:
     inputs:
@@ -190,9 +180,7 @@ func MapAncillaryPartyList:
         ancillaryPartyList AncillaryParty (0..*)
 
     add ancillaryPartyList:
-        MapCalculationAgentIndependentToAncillaryParty(
-                fpmlTrade -> calculationAgentModel -> calculationAgent
-            )
+        MapCalculationAgentIndependentToAncillaryParty(fpmlTrade -> calculationAgent)
 
     add ancillaryPartyList:
         fpmlTrade -> product switch
@@ -262,21 +250,16 @@ func MapEarlyTerminationProvisionToAncillaryParty:
     output:
         ancillaryParty AncillaryParty (0..*)
 
-    alias optionalEarlyTermination:
-        fpmlEarlyTerminationProvision -> optionalEarlyTerminationModel -> optionalEarlyTermination default fpmlEarlyTerminationProvision -> earlyTerminationProvisionSequence -> optionalEarlyTerminationModel -> optionalEarlyTermination
-    alias mandatoryEarlyTermination:
-        fpmlEarlyTerminationProvision -> earlyTerminationProvisionSequence -> mandatoryEarlyTerminationModel -> mandatoryEarlyTermination default fpmlEarlyTerminationProvision -> earlyTerminationProvisionSequence -> mandatoryEarlyTerminationModel -> mandatoryEarlyTerminationModelSequence -> mandatoryEarlyTermination
-
     add ancillaryParty:
         MapOptionalEarlyTerminationToAncillaryParty(
-                optionalEarlyTermination,
+                fpmlEarlyTerminationProvision -> optionalEarlyTermination,
                 cdmCounterpartyList
             )
     add ancillaryParty:
-        if mandatoryEarlyTermination -> calculationAgent exists
+        if fpmlEarlyTerminationProvision -> mandatoryEarlyTermination -> calculationAgent exists
         then MapAncillaryParty(
                     CalculationAgentMandatoryEarlyTermination,
-                    mandatoryEarlyTermination -> calculationAgent -> calculationAgentPartyReference -> href,
+                    fpmlEarlyTerminationProvision -> mandatoryEarlyTermination -> calculationAgent -> calculationAgentPartyReference -> href,
                     empty,
                     empty
                 )
@@ -389,34 +372,35 @@ func MapPartyReference:
 
 func MapPartyList:
     inputs:
-        fpmlParties fpml.Party (0..*)
-        fpmlPartyTradeInformation fpml.PartyTradeInformation (0..*)
+        fpmlPartyList fpml.Party (0..*)
+        fpmlPartyTradeInformationList fpml.PartyTradeInformation (0..*)
     output:
         partyList Party (0..*)
 
-    add partyList: fpmlParties extract MapParty(item, fpmlPartyTradeInformation)
+    add partyList: fpmlPartyList extract MapParty(item, fpmlPartyTradeInformationList)
 
 func MapParty:
     inputs:
         fpmlParty fpml.Party (0..1)
-        fpmlPartyTradeInformation fpml.PartyTradeInformation (0..*)
+        fpmlPartyTradeInformationList fpml.PartyTradeInformation (0..*)
     output:
         party Party (0..1)
 
-    alias partyModel: fpmlParty -> partyModel
-    alias partyName: partyModel -> partyName
-
     set party:
         Party {
-            partyId: partyModel -> partyId extract MapPartyIdentifier,
-            name: MapStringWithScheme(partyName -> value, partyName -> partyNameScheme),
-            businessUnit: partyModel -> businessUnit extract MapBusinessUnit,
-            person: partyModel -> person extract MapNaturalPerson,
-            personRole: MapNaturalPersonRoleList(fpmlParty, fpmlPartyTradeInformation),
+            partyId: fpmlParty -> partyId
+                    extract MapPartyIdentifier(item -> value, item -> partyIdScheme),
+            name: MapStringWithScheme(
+                        fpmlParty -> partyName -> value,
+                        fpmlParty -> partyName -> partyNameScheme
+                    ),
+            businessUnit: fpmlParty -> businessUnit extract MapBusinessUnit,
+            person: fpmlParty -> person extract MapNaturalPerson,
+            personRole: MapNaturalPersonRoleList(fpmlParty, fpmlPartyTradeInformationList),
             account: empty, // MapAccount(empty),
             contactInformation: MapContactInformation(
-                        partyModel -> partyInformationModel -> country,
-                        partyModel -> contactInfo
+                        fpmlParty -> country,
+                        fpmlParty -> contactInfo
                     )
         } with-meta {
             key: fpmlParty -> id
@@ -424,17 +408,31 @@ func MapParty:
 
 func MapPartyIdentifier:
     inputs:
-        fpmlPartyIdentifier fpml.PartyId (0..1)
+        identifierValue string (0..1)
+        identifierScheme string (0..1)
     output:
         partyIdentifier PartyIdentifier (0..1)
 
     set partyIdentifier:
         PartyIdentifier {
-            identifier: MapStringWithScheme(
-                        fpmlPartyIdentifier -> value,
-                        fpmlPartyIdentifier -> partyIdScheme
+            identifier: MapStringWithScheme(identifierValue, identifierScheme),
+            identifierType: MapPartyIdentifierTypeEnum(identifierScheme)
+        }
+
+func MapExchangeIdToAssetParty:
+    inputs:
+        fpmlExchangeId fpml.ExchangeId (0..1)
+    output:
+        party Party (0..1)
+
+    set party:
+        Party {
+            partyId: fpmlExchangeId extract MapPartyIdentifier(value, exchangeIdScheme),
+            name: MapStringWithScheme(
+                        fpmlExchangeId -> value,
+                        fpmlExchangeId -> exchangeIdScheme
                     ),
-            identifierType: MapPartyIdentifierTypeEnum(fpmlPartyIdentifier -> partyIdScheme)
+            ...
         }
 
 func MapBusinessUnit:
@@ -539,8 +537,6 @@ func MapNaturalPerson:
     output:
         cdmNaturalPerson NaturalPerson (0..1)
 
-    alias personSequence: fpmlPerson -> personSequence
-
     set cdmNaturalPerson:
         NaturalPerson {
             personId: fpmlPerson -> personId
@@ -549,12 +545,12 @@ func MapNaturalPerson:
                                 item,
                                 fpmlPerson -> contactInfo -> address -> country
                             ),
-            honorific: personSequence -> honorific,
-            firstName: personSequence -> firstName,
-            middleName: personSequence -> middleName,
-            initial: personSequence -> initial,
-            surname: personSequence -> surname,
-            suffix: personSequence -> suffix,
+            honorific: fpmlPerson -> honorific,
+            firstName: fpmlPerson -> firstName,
+            middleName: fpmlPerson -> middleName,
+            initial: fpmlPerson -> initial,
+            surname: fpmlPerson -> surname,
+            suffix: fpmlPerson -> suffix,
             dateOfBirth: fpmlPerson -> dateOfBirth -> date,
             contactInformation: MapContactInformation(
                         fpmlPerson -> country,
@@ -588,11 +584,11 @@ func MapPersonIdentifier:
 func MapNaturalPersonRoleList:
     inputs:
         fpmlParty fpml.Party (0..1)
-        fpmlPartyTradeInformation fpml.PartyTradeInformation (0..*)
+        fpmlPartyTradeInformationList fpml.PartyTradeInformation (0..*)
     output:
         naturalPersonRoleList NaturalPersonRole (0..*)
 
-    alias relatedPerson: fpmlPartyTradeInformation -> relatedPerson
+    alias relatedPerson: fpmlPartyTradeInformationList -> relatedPerson
 
     add naturalPersonRoleList:
         relatedPerson
@@ -608,7 +604,7 @@ func GetPartyPersonForRelatedPerson:
         fpmlPerson fpml.Person (0..1)
 
     set fpmlPerson:
-        fpmlParty -> partyModel -> person
+        fpmlParty -> person
             filter id = fpmlRelatedPerson -> personReference -> href
             then first
 
@@ -688,38 +684,35 @@ func MapPartyRoleList:
 
 func MapRelatedPartyToPartyRole:
     inputs:
-        fpmlPartyTradeInformation fpml.PartyTradeInformation (0..1)
+        fpmlPartyTradeInformationList fpml.PartyTradeInformation (0..1)
     output:
         partyRole PartyRole (0..*)
 
-    alias relatedParties: fpmlPartyTradeInformation -> relatedParty
+    alias relatedParties: fpmlPartyTradeInformationList -> relatedParty
 
     add partyRole:
         relatedParties
             extract
                 PartyRole {
-                    partyReference: MapPartyReference(
-                                partyAndAccountReferencesModel -> partyReference -> href
-                            ),
+                    partyReference: MapPartyReference(partyReference -> href),
                     role: role -> value to-enum PartyRoleEnum,
                     ownershipPartyReference: MapPartyReference(
-                                fpmlPartyTradeInformation -> partyAndAccountReferencesModel -> partyReference -> href
+                                fpmlPartyTradeInformationList -> partyReference -> href
                             )
                 }
 
 func MapAccountList:
     inputs:
         fpmlTrade fpml.Trade (0..1)
-        fpmlPartiesAndAccountsModel fpml.PartiesAndAccountsModel (0..1)
+        fpmlAccountList fpml.Account (0..*)
     output:
         accountList Account (0..*)
 
-    add accountList:
-        fpmlPartiesAndAccountsModel -> account extract MapAccount(item, fpmlTrade)
+    add accountList: fpmlAccountList extract MapAccount(item, fpmlTrade)
 
 func MapAccount:
     inputs:
-        fpmlAccount fpml.Account (0..1)
+        fpmlAccountList fpml.Account (0..1)
         fpmlTrade fpml.Trade (0..1)
     output:
         account Account (0..1)
@@ -727,75 +720,87 @@ func MapAccount:
     alias partyReference:
         fpmlTrade -> product switch
             fpml.BondOption then
-                MapBondOptionAccountPartyReference(item, fpmlAccount),
+                MapBondOptionAccountPartyReference(item, fpmlAccountList),
             fpml.BrokerEquityOption then
-                MapBrokerEquityOptionAccountPartyReference(item, fpmlAccount),
+                MapBrokerEquityOptionAccountPartyReference(item, fpmlAccountList),
             fpml.CapFloor then
-                MapCapFloorAccountPartyReference(item, fpmlAccount),
+                MapCapFloorAccountPartyReference(item, fpmlAccountList),
             fpml.CommodityForward then
-                MapCommodityForwardAccountPartyReference(item, fpmlAccount),
+                MapCommodityForwardAccountPartyReference(item, fpmlAccountList),
             fpml.CommodityOption then
-                MapCommodityOptionAccountPartyReference(item, fpmlAccount),
+                MapCommodityOptionAccountPartyReference(item, fpmlAccountList),
             fpml.CommoditySwap then
-                MapCommoditySwapAccountPartyReference(item, fpmlAccount),
+                MapCommoditySwapAccountPartyReference(item, fpmlAccountList),
             fpml.CommoditySwaption then
-                MapCommoditySwaptionAccountPartyReference(item, fpmlAccount),
+                MapCommoditySwaptionAccountPartyReference(item, fpmlAccountList),
             fpml.CorrelationSwap then
-                MapCorrelationSwapAccountPartyReference(item, fpmlAccount),
+                MapCorrelationSwapAccountPartyReference(item, fpmlAccountList),
             fpml.CreditDefaultSwap then
-                MapCreditDefaultSwapAccountPartyReference(item, fpmlAccount),
+                MapCreditDefaultSwapAccountPartyReference(item, fpmlAccountList),
             fpml.CreditDefaultSwapOption then
-                MapCreditDefaultSwapOptionAccountPartyReference(item, fpmlAccount),
+                MapCreditDefaultSwapOptionAccountPartyReference(item, fpmlAccountList),
             fpml.DividendSwapOptionTransactionSupplement then
                 MapDividendSwapOptionTransactionSupplementAccountPartyReference(
                         item,
-                        fpmlAccount
+                        fpmlAccountList
                     ),
             fpml.DividendSwapTransactionSupplement then
-                MapDividendSwapTransactionSupplementAccountPartyReference(item, fpmlAccount),
+                MapDividendSwapTransactionSupplementAccountPartyReference(
+                        item,
+                        fpmlAccountList
+                    ),
             fpml.EquityForward then
-                MapEquityForwardAccountPartyReference(item, fpmlAccount),
+                MapEquityForwardAccountPartyReference(item, fpmlAccountList),
             fpml.EquityOption then
-                MapEquityOptionAccountPartyReference(item, fpmlAccount),
+                MapEquityOptionAccountPartyReference(item, fpmlAccountList),
             fpml.EquityOptionTransactionSupplement then
-                MapEquityOptionTransactionSupplementAccountPartyReference(item, fpmlAccount),
+                MapEquityOptionTransactionSupplementAccountPartyReference(
+                        item,
+                        fpmlAccountList
+                    ),
             fpml.EquitySwapTransactionSupplement then
-                MapEquitySwapTransactionSupplementAccountPartyReference(item, fpmlAccount),
+                MapEquitySwapTransactionSupplementAccountPartyReference(
+                        item,
+                        fpmlAccountList
+                    ),
             fpml.Fra then
-                MapFraAccountPartyReference(item, fpmlAccount),
+                MapFraAccountPartyReference(item, fpmlAccountList),
             fpml.FxOption then
-                MapFxOptionAccountPartyReference(item, fpmlAccount),
+                MapFxOptionAccountPartyReference(item, fpmlAccountList),
             fpml.FxSingleLeg then
-                MapFxSingleLegAccountPartyReference(item, fpmlAccount),
+                MapFxSingleLegAccountPartyReference(item, fpmlAccountList),
             fpml.FxSwap then
-                MapFxSwapAccountPartyReference(item, fpmlAccount),
+                MapFxSwapAccountPartyReference(item, fpmlAccountList),
             fpml.FxVarianceSwap then
-                MapFxVarianceSwapAccountPartyReference(item, fpmlAccount),
+                MapFxVarianceSwapAccountPartyReference(item, fpmlAccountList),
             fpml.FxVolatilitySwap then
-                MapFxVolatilitySwapAccountPartyReference(item, fpmlAccount),
+                MapFxVolatilitySwapAccountPartyReference(item, fpmlAccountList),
             fpml.GenericProduct then
-                MapGenericProductAccountPartyReference(item, fpmlAccount),
+                MapGenericProductAccountPartyReference(item, fpmlAccountList),
             fpml.ReturnSwap then
-                MapReturnSwapAccountPartyReference(item, fpmlAccount),
+                MapReturnSwapAccountPartyReference(item, fpmlAccountList),
             fpml.Swap then
-                MapSwapAccountPartyReference(item, fpmlAccount),
+                MapSwapAccountPartyReference(item, fpmlAccountList),
             fpml.Swaption then
-                MapSwaptionAccountPartyReference(item, fpmlAccount),
+                MapSwaptionAccountPartyReference(item, fpmlAccountList),
             fpml.VarianceOptionTransactionSupplement then
                 MapVarianceOptionTransactionSupplementAccountPartyReference(
                         item,
-                        fpmlAccount
+                        fpmlAccountList
                     ),
             fpml.VarianceSwap then
-                MapVarianceSwapAccountPartyReference(item, fpmlAccount),
+                MapVarianceSwapAccountPartyReference(item, fpmlAccountList),
             fpml.VarianceSwapTransactionSupplement then
-                MapVarianceSwapTransactionSupplementAccountPartyReference(item, fpmlAccount),
+                MapVarianceSwapTransactionSupplementAccountPartyReference(
+                        item,
+                        fpmlAccountList
+                    ),
             fpml.VolatilitySwap then
-                MapVolatilitySwapAccountPartyReference(item, fpmlAccount),
+                MapVolatilitySwapAccountPartyReference(item, fpmlAccountList),
             fpml.VolatilitySwapTransactionSupplement then
                 MapVolatilitySwapTransactionSupplementAccountPartyReference(
                         item,
-                        fpmlAccount
+                        fpmlAccountList
                     ),
             default empty
 
@@ -803,43 +808,42 @@ func MapAccount:
         Account {
             partyReference: partyReference,
             accountNumber: MapStringWithScheme(
-                        fpmlAccount -> accountId only-element -> value,
-                        fpmlAccount -> accountId only-element -> accountIdScheme
+                        fpmlAccountList -> accountId only-element -> value,
+                        fpmlAccountList -> accountId only-element -> accountIdScheme
                     ),
             accountName: MapStringWithScheme(
-                        fpmlAccount -> accountName -> value,
-                        fpmlAccount -> accountName -> accountNameScheme
+                        fpmlAccountList -> accountName -> value,
+                        fpmlAccountList -> accountName -> accountNameScheme
                     ),
-            accountType: MapAccountTypeEnum(fpmlAccount -> accountType -> value),
+            accountType: MapAccountTypeEnum(fpmlAccountList -> accountType -> value),
             accountBeneficiary: MapPartyReference(
-                        fpmlAccount -> accountSequence -> accountBeneficiary -> href
+                        fpmlAccountList -> accountBeneficiary -> href
                     ),
-            servicingParty: MapPartyReference(fpmlAccount -> servicingParty -> href)
+            servicingParty: MapPartyReference(fpmlAccountList -> servicingParty -> href)
         } with-meta {
-            key: fpmlAccount -> id
+            key: fpmlAccountList -> id
         }
 
 func MapPayerReceiverToAccountPartyReference:
     inputs:
         fpmlAccount fpml.Account (0..1)
-        fpmlPayerReceiverModelList fpml.PayerReceiverModel (0..*)
+        fpmlPayerAccountReference fpml.AccountReference (0..1)
+        fpmlReceiverAccountReference fpml.AccountReference (0..1)
+        fpmlPayerPartyReference fpml.PartyReference (0..1)
+        fpmlReceiverPartyReference fpml.PartyReference (0..1)
     output:
         partyReference Party (0..1)
             [metadata reference]
 
     alias payerPartyReference:
-        fpmlPayerReceiverModelList -> payerModel
-            filter payerAccountReference -> href = fpmlAccount -> id
-            then extract payerPartyReference -> href
-            then distinct only-element
+        if fpmlPayerAccountReference -> href = fpmlAccount -> id
+        then fpmlPayerPartyReference -> href
 
     alias receiverPartyReference:
-        fpmlPayerReceiverModelList -> receiverModel
-            filter receiverAccountReference -> href = fpmlAccount -> id
-            then extract receiverPartyReference -> href
-            then distinct only-element
+        if fpmlReceiverAccountReference -> href = fpmlAccount -> id
+        then fpmlReceiverPartyReference -> href
 
-    alias href:
+    alias selectedPartyHref:
         if payerPartyReference exists
         then payerPartyReference
         else if receiverPartyReference exists
@@ -847,27 +851,28 @@ func MapPayerReceiverToAccountPartyReference:
 
     set partyReference:
         empty with-meta {
-            reference: href
+            reference: selectedPartyHref
         }
 
 func MapBuyerSellerToAccountPartyReference:
     inputs:
-        fpmlAccount fpml.Account (0..1)
-        fpmlBuyerSellerModelModelList fpml.BuyerSellerModel (0..*)
+        fpmlAccountList fpml.Account (0..1)
+        fpmlBuyerAccountReferenceList fpml.AccountReference (0..*)
+        fpmlSellerAccountReferenceList fpml.AccountReference (0..*)
     output:
         partyReference Party (0..1)
             [metadata reference]
 
     alias buyerPartyReference:
-        fpmlBuyerSellerModelModelList
-            filter buyerAccountReference -> href = fpmlAccount -> id
-            then extract buyerAccountReference -> href
+        fpmlBuyerAccountReferenceList
+            filter href = fpmlAccountList -> id
+            then extract href
             then distinct only-element
 
     alias sellerPartyReference:
-        fpmlBuyerSellerModelModelList
-            filter sellerAccountReference -> href = fpmlAccount -> id
-            then extract sellerAccountReference -> href
+        fpmlSellerAccountReferenceList
+            filter href = fpmlAccountList -> id
+            then extract href
             then distinct only-element
 
     set partyReference:
@@ -881,17 +886,13 @@ func MapLegalEntity:
     output:
         legalEntity LegalEntity (0..1)
 
-    alias entityIdFromLegalEntitySequence:
-        fpmlLegalEntity -> legalEntitySequence -> entityId
-            extract MapStringWithScheme(value, entityIdScheme)
-
     alias entityIdFromLegalEntity:
         fpmlLegalEntity -> entityId extract MapStringWithScheme(value, entityIdScheme)
 
     set legalEntity:
         LegalEntity {
-            entityId: [entityIdFromLegalEntitySequence, entityIdFromLegalEntity],
-            name: fpmlLegalEntity -> legalEntitySequence -> entityName
+            entityId: entityIdFromLegalEntity,
+            name: fpmlLegalEntity -> entityName
                     extract MapStringWithScheme(value, entityNameScheme),
             entityIdentifier: MapEntityIdentifier(fpmlLegalEntity)
         }
@@ -954,7 +955,8 @@ func MapExchangeIdToLegalEntity:
 
 func MapPayerReceiver:
     inputs:
-        fpmlPayerReceiverModel fpml.PayerReceiverModel (0..1)
+        fpmlPayerPartyReference fpml.PartyReference (0..1)
+        fpmlReceiverPartyReference fpml.PartyReference (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         payerReceiver PayerReceiver (0..1)
@@ -962,18 +964,19 @@ func MapPayerReceiver:
     set payerReceiver:
         PayerReceiver {
             payer: MapCounterpartyRoleEnum(
-                        fpmlPayerReceiverModel -> payerModel -> payerPartyReference -> href,
+                        fpmlPayerPartyReference -> href,
                         cdmCounterpartyList
                     ),
             receiver: MapCounterpartyRoleEnum(
-                        fpmlPayerReceiverModel -> receiverModel -> receiverPartyReference -> href,
+                        fpmlReceiverPartyReference -> href,
                         cdmCounterpartyList
             ),
         }
 
 func MapBuyerSeller:
     inputs:
-        fpmlBuyerSellerModel fpml.BuyerSellerModel (0..1)
+        fpmlBuyerPartyReference fpml.PartyReference (1..1)
+        fpmlSellerPartyReference fpml.PartyReference (1..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         buyerSeller BuyerSeller (0..1)
@@ -981,18 +984,19 @@ func MapBuyerSeller:
     set buyerSeller:
         BuyerSeller {
             buyer: MapCounterpartyRoleEnum(
-                        fpmlBuyerSellerModel -> buyerPartyReference -> href,
+                        fpmlBuyerPartyReference -> href,
                         cdmCounterpartyList
                     ),
             seller: MapCounterpartyRoleEnum(
-                        fpmlBuyerSellerModel -> sellerPartyReference -> href,
+                        fpmlSellerPartyReference -> href,
                         cdmCounterpartyList
             ),
         }
 
 func MapSellerAsPayerAndBuyerAsReceiver:
     inputs:
-        fpmlBuyerSellerModel fpml.BuyerSellerModel (0..1)
+        fpmlSellerPartyReference fpml.PartyReference (1..1)
+        fpmlBuyerPartyReference fpml.PartyReference (1..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         payerReceiver PayerReceiver (0..1)
@@ -1000,18 +1004,19 @@ func MapSellerAsPayerAndBuyerAsReceiver:
     set payerReceiver:
         PayerReceiver {
             payer: MapCounterpartyRoleEnum(
-                        fpmlBuyerSellerModel -> sellerPartyReference -> href,
+                        fpmlSellerPartyReference -> href,
                         cdmCounterpartyList
                     ),
             receiver: MapCounterpartyRoleEnum(
-                        fpmlBuyerSellerModel -> buyerPartyReference -> href,
+                        fpmlBuyerPartyReference -> href,
                         cdmCounterpartyList
             ),
         }
 
 func MapPayerAsSellerAndReceiverAsBuyer:
     inputs:
-        fpmlPayerReceiverModel fpml.PayerReceiverModel (0..1)
+        fpmlPayerPartyReference fpml.PartyReference (0..1)
+        fpmlReceiverPartyReference fpml.PartyReference (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         buyerSeller BuyerSeller (0..1)
@@ -1019,32 +1024,15 @@ func MapPayerAsSellerAndReceiverAsBuyer:
     set buyerSeller:
         BuyerSeller {
             buyer: MapCounterpartyRoleEnum(
-                        fpmlPayerReceiverModel -> payerModel -> payerPartyReference -> href,
+                        fpmlPayerPartyReference -> href,
                         cdmCounterpartyList
                     ),
             seller: MapCounterpartyRoleEnum(
-                        fpmlPayerReceiverModel -> receiverModel -> receiverPartyReference -> href,
+                        fpmlReceiverPartyReference -> href,
                         cdmCounterpartyList
             ),
         }
 
-// func MapSellerBuyerModelAsPayerReceiverModel:
-//     inputs:
-//         fpmlBuyerSellerModel fpml.BuyerSellerModel (0..1)
-//         cdmCounterpartyList Counterparty (0..2)
-//     output:
-//         payerReceiver fpml.PayerReceiverModel (0..1)
-//     set payerReceiver:
-//         PayerReceiverModel {
-//             payerModel: MapCounterpartyRoleEnum(
-//                     fpmlBuyerSellerModel -> sellerPartyReference -> href,
-//                     cdmCounterpartyList
-//                 ),
-//             receiverModel: MapCounterpartyRoleEnum(
-//                     fpmlBuyerSellerModel -> buyerPartyReference -> href,
-//                     cdmCounterpartyList
-//             ),
-//         }
 func FlipPayerAndReceiver:
     inputs:
         payerReceiver PayerReceiver (0..1)

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-payment-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-payment-func.rosetta
@@ -76,14 +76,11 @@ func MapTransferStateList:
     add transfer:
         fpmlProduct switch
             fpml.CreditDefaultSwap then
-                if feeLeg -> feeLegSequence -> initialPayment exists
-                then MapInitialPaymentToTransferState(
-                            feeLeg -> feeLegSequence -> initialPayment,
-                            Upfront
-                        )
-                else if feeLeg -> feeLegSequence -> singlePayment exists
+                if feeLeg -> initialPayment exists
+                then MapInitialPaymentToTransferState(feeLeg -> initialPayment, Upfront)
+                else if feeLeg -> singlePayment exists
                 then MapSinglePaymentListToTransferStateList(
-                            feeLeg -> feeLegSequence -> singlePayment,
+                            feeLeg -> singlePayment,
                             Upfront
                         ),
             default empty
@@ -161,7 +158,8 @@ func MapPaymentToTransferState:
                     quantity: MapTransferQuantity(fpmlPayment -> paymentAmount),
                     asset: MapTransferCashAsset(fpmlPayment -> paymentAmount),
                     payerReceiver: MapPaymentToPartyReferencePayerReceiver(
-                                fpmlPayment -> payerReceiverModel
+                                fpmlPayment -> payerPartyReference,
+                                fpmlPayment -> receiverPartyReference
                             ),
                     settlementDate: MapAdjustableOrAdjustedDateToAdjustableOrAdjustedOrRelativeDate(
                                 fpmlPayment -> paymentDate
@@ -204,7 +202,8 @@ func MapNonNegativePaymentToTransferState:
                     quantity: MapTransferQuantity(fpmlNonNegativePayment -> paymentAmount),
                     asset: MapTransferCashAsset(fpmlNonNegativePayment -> paymentAmount),
                     payerReceiver: MapPaymentToPartyReferencePayerReceiver(
-                                fpmlNonNegativePayment -> payerReceiverModel
+                                fpmlNonNegativePayment -> payerPartyReference,
+                                fpmlNonNegativePayment -> receiverPartyReference
                             ),
                     settlementDate: MapAdjustableOrAdjustedOrRelativeDate(
                                 fpmlNonNegativePayment -> paymentDate -> adjustableDate -> unadjustedDate -> value -> date,
@@ -238,7 +237,8 @@ func MapSimplePaymentToTransferState:
                     quantity: MapTransferQuantity(fpmlSimplePayment -> paymentAmount),
                     asset: MapTransferCashAsset(fpmlSimplePayment -> paymentAmount),
                     payerReceiver: MapPaymentToPartyReferencePayerReceiver(
-                                fpmlSimplePayment -> payerReceiverModel
+                                fpmlSimplePayment -> payerPartyReference,
+                                fpmlSimplePayment -> receiverPartyReference
                             ),
                     settlementDate: MapAdjustableOrAdjustedOrRelativeDate(
                                 fpmlSimplePayment -> paymentDate -> adjustableDate -> unadjustedDate -> value -> date,
@@ -287,7 +287,8 @@ func MapReturnSwapAdditionalPaymentToTransferState:
                                 fpmlReturnSwapAdditionalPayment -> additionalPaymentAmount -> paymentAmount
                             ),
                     payerReceiver: MapPaymentToPartyReferencePayerReceiver(
-                                fpmlReturnSwapAdditionalPayment -> payerReceiverModel
+                                fpmlReturnSwapAdditionalPayment -> payerPartyReference,
+                                fpmlReturnSwapAdditionalPayment -> receiverPartyReference
                             ),
                     settlementDate: MapAdjustableOrAdjustedOrRelativeDate(
                                 empty,
@@ -323,7 +324,8 @@ func MapInitialPaymentToTransferState:
                             ),
                     asset: MapMoneyToTransferCashAsset(fpmlInitialPayment -> paymentAmount),
                     payerReceiver: MapPaymentToPartyReferencePayerReceiver(
-                                fpmlInitialPayment -> payerReceiverModel
+                                fpmlInitialPayment -> payerPartyReference,
+                                fpmlInitialPayment -> receiverPartyReference
                             ),
                     settlementDate:
                         AdjustableOrAdjustedOrRelativeDate {
@@ -442,7 +444,8 @@ func MapEquityPremiumToTransferState:
                     quantity: MapTransferQuantity(fpmlEquityPremium -> paymentAmount),
                     asset: MapTransferCashAsset(fpmlEquityPremium -> paymentAmount),
                     payerReceiver: MapPaymentToPartyReferencePayerReceiver(
-                                fpmlEquityPremium -> payerReceiverModel
+                                fpmlEquityPremium -> payerPartyReference,
+                                fpmlEquityPremium -> receiverPartyReference
                             ),
                     settlementDate: MapAdjustableOrAdjustedOrRelativeDate(
                                 MapZoneDateTimeToDate(
@@ -507,14 +510,15 @@ func MapMoneyToTransferCashAsset:
 
 func MapPaymentToPartyReferencePayerReceiver:
     inputs:
-        fpmlPayerReceiverModel fpml.PayerReceiverModel (1..1)
+        fpmlPayerPartyReference fpml.PartyReference (0..1)
+        fpmlReceiverPartyReference fpml.PartyReference (0..1)
     output:
         partyReferencePayerReceiver PartyReferencePayerReceiver (0..1)
 
     set partyReferencePayerReceiver -> payerPartyReference -> reference:
-        fpmlPayerReceiverModel -> payerModel -> payerPartyReference -> href
+        fpmlPayerPartyReference -> href
     set partyReferencePayerReceiver -> receiverPartyReference -> reference:
-        fpmlPayerReceiverModel -> receiverModel -> receiverPartyReference -> href
+        fpmlReceiverPartyReference -> href
 
 func MapTransferQuantity:
     inputs:
@@ -561,7 +565,8 @@ func MapPrincipalPayments:
         fpmlPrincipalExchanges fpml.PrincipalExchanges (0..1)
         fpmlPrincipalExchangeList fpml.PrincipalExchange (0..*)
         fpmlCurrency fpml.Currency (0..1)
-        fpmlPayerReceiverModel fpml.PayerReceiverModel (0..1)
+        fpmlPayerPartyReference fpml.PartyReference (0..1)
+        fpmlReceiverPartyReference fpml.PartyReference (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         principalPayments PrincipalPayments (0..1)
@@ -575,7 +580,8 @@ func MapPrincipalPayments:
                         fpmlPrincipalExchanges,
                         fpmlPrincipalExchangeList,
                         fpmlCurrency,
-                        fpmlPayerReceiverModel,
+                        fpmlPayerPartyReference,
+                        fpmlReceiverPartyReference,
                         cdmCounterpartyList
                     ),
             ...
@@ -588,7 +594,8 @@ func MapPrincipalPaymentSchedule:
         fpmlPrincipalExchanges fpml.PrincipalExchanges (0..1)
         fpmlPrincipalExchangeList fpml.PrincipalExchange (0..*)
         fpmlCurrency fpml.Currency (0..1)
-        fpmlPayerReceiverModel fpml.PayerReceiverModel (0..1)
+        fpmlPayerPartyReference fpml.PartyReference (0..1)
+        fpmlReceiverPartyReference fpml.PartyReference (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         principalPaymentSchedule PrincipalPaymentSchedule (0..1)
@@ -609,14 +616,16 @@ func MapPrincipalPaymentSchedule:
                     then MapPrincipalPayment(
                             initialPrincipalExchange,
                             fpmlCurrency,
-                            fpmlPayerReceiverModel,
+                            fpmlPayerPartyReference,
+                            fpmlReceiverPartyReference,
                             cdmCounterpartyList
                         ),
             finalPrincipalPayment: if finalPrincipalExchange exists
                     then MapPrincipalPayment(
                             finalPrincipalExchange,
                             fpmlCurrency,
-                            fpmlPayerReceiverModel,
+                            fpmlPayerPartyReference,
+                            fpmlReceiverPartyReference,
                             cdmCounterpartyList
                         ),
             ...
@@ -626,7 +635,8 @@ func MapPrincipalPayment:
     inputs:
         fpmlPrincipalExchange fpml.PrincipalExchange (0..1)
         fpmlCurrency fpml.Currency (0..1)
-        fpmlPayerReceiverModel fpml.PayerReceiverModel (0..1)
+        fpmlPayerPartyReference fpml.PartyReference (0..1)
+        fpmlReceiverPartyReference fpml.PartyReference (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         principalPayment PrincipalPayment (0..1)
@@ -638,7 +648,8 @@ func MapPrincipalPayment:
             principalPaymentDate: MapPrincipalPaymentDate(fpmlPrincipalExchange),
             payerReceiver: MapPrincipalPayerReceiver(
                         fpmlPrincipalExchange,
-                        fpmlPayerReceiverModel,
+                        fpmlPayerPartyReference,
+                        fpmlReceiverPartyReference,
                         cdmCounterpartyList
                     ),
             principalAmount:
@@ -657,21 +668,16 @@ func MapPrincipalPayment:
 func MapPrincipalPayerReceiver:
     inputs:
         fpmlPrincipalExchange fpml.PrincipalExchange (0..1)
-        fpmlPayerReceiverModel fpml.PayerReceiverModel (0..1)
+        fpmlPayerPartyReference fpml.PartyReference (0..1)
+        fpmlReceiverPartyReference fpml.PartyReference (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         payerReceiver PayerReceiver (0..1)
 
     alias payer:
-        MapCounterpartyRoleEnum(
-                fpmlPayerReceiverModel -> payerModel -> payerPartyReference -> href,
-                cdmCounterpartyList
-            )
+        MapCounterpartyRoleEnum(fpmlPayerPartyReference -> href, cdmCounterpartyList)
     alias receiver:
-        MapCounterpartyRoleEnum(
-                fpmlPayerReceiverModel -> receiverModel -> receiverPartyReference -> href,
-                cdmCounterpartyList
-            )
+        MapCounterpartyRoleEnum(fpmlReceiverPartyReference -> href, cdmCounterpartyList)
 
     set payerReceiver:
         if fpmlPrincipalExchange -> principalExchangeAmount >= 0

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-pricequantity-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-pricequantity-func.rosetta
@@ -5,6 +5,7 @@ import cdm.base.datetime.*
 import cdm.base.math.*
 import cdm.base.staticdata.asset.common.*
 import cdm.base.staticdata.asset.rates.*
+import cdm.base.staticdata.party.*
 import cdm.ingest.fpml.confirmation.common.*
 import cdm.ingest.fpml.confirmation.datetime.*
 import cdm.ingest.fpml.confirmation.other.*
@@ -465,8 +466,6 @@ func MapOptionBaseExtendedQuantityListWithLocation:
         quantityList NonNegativeQuantitySchedule (0..*)
             [metadata location]
 
-    alias optionDenominationModel: fpmlOptionBaseExtended -> optionDenominationModel
-
     add quantityList:
         if fpmlOptionBaseExtended -> notionalAmount exists
         then CreateQuantityWithLocation(
@@ -475,13 +474,13 @@ func MapOptionBaseExtendedQuantityListWithLocation:
                 )
 
     add quantityList:
-        if optionDenominationModel -> numberOfOptions exists
+        if fpmlOptionBaseExtended -> numberOfOptions exists
         then CreateQuantityWithLocation(
                     MapNumberOfOptionsAndOptionEntitlementToQuantity(
-                            optionDenominationModel -> numberOfOptions,
+                            fpmlOptionBaseExtended -> numberOfOptions,
                             Contract,
-                            optionDenominationModel -> optionEntitlement,
-                            optionDenominationModel -> entitlementCurrency
+                            fpmlOptionBaseExtended -> optionEntitlement,
+                            fpmlOptionBaseExtended -> entitlementCurrency
                         ),
                     CreateQuantityKey("numberOfOptions", empty)
                 )
@@ -496,7 +495,7 @@ func MapOptionBaseExtendedQuantityListWithAddress:
     set quantityList:
         if fpmlOptionBaseExtended -> notionalAmount exists
         then CreateQuantityWithAddress(CreateQuantityKey("notionalAmount", empty))
-        else if fpmlOptionBaseExtended -> optionDenominationModel -> numberOfOptions exists
+        else if fpmlOptionBaseExtended -> numberOfOptions exists
         then CreateQuantityWithAddress(CreateQuantityKey("numberOfOptions", empty))
 
 func MapEquityDerivativeBaseQuantityListWithLocation:
@@ -562,14 +561,15 @@ func MapEquityDerivativeBaseQuantityListWithAddress:
 
 func MapFxCoreDetailsModelQuantityListWithLocation:
     inputs:
-        fpmlFxCoreDetailsModel fpml.FxCoreDetailsModel (1..1)
+        fpmlExchangedCurrency1 fpml.Payment (1..1)
+        fpmlExchangedCurrency2 fpml.Payment (1..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         quantityList NonNegativeQuantitySchedule (0..*)
             [metadata location]
 
-    alias quantity1: fpmlFxCoreDetailsModel -> exchangedCurrency1 -> paymentAmount
-    alias quantity2: fpmlFxCoreDetailsModel -> exchangedCurrency2 -> paymentAmount
+    alias quantity1: fpmlExchangedCurrency1 -> paymentAmount
+    alias quantity2: fpmlExchangedCurrency2 -> paymentAmount
 
     add quantityList:
         if quantity1 exists
@@ -597,13 +597,13 @@ func MapFxCoreDetailsModelQuantityListWithLocation:
 
 func MapFxCoreDetailsModelQuantityWithAddress:
     inputs:
-        fpmlFxCoreDetailsModel fpml.FxCoreDetailsModel (1..1)
+        fpmlExchangeRate fpml.ExchangeRate (0..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         quantity NonNegativeQuantitySchedule (0..1)
             [metadata address]
 
-    alias quotedCurrencyPair: fpmlFxCoreDetailsModel -> exchangeRate -> quotedCurrencyPair
+    alias quotedCurrencyPair: fpmlExchangeRate -> quotedCurrencyPair
 
     set quantity:
         if quotedCurrencyPair -> quoteBasis = Currency2PerCurrency1
@@ -616,11 +616,13 @@ func MapFxCoreDetailsModelQuantityWithAddress:
 
 func GetFpmlExchangedCurrency:
     inputs:
-        fpmlFxCoreDetailsModel fpml.FxCoreDetailsModel (0..1)
+        fpmlExchangeRate fpml.ExchangeRate (0..1)
+        fpmlExchangedCurrency1 fpml.Payment (0..1)
+        fpmlExchangedCurrency2 fpml.Payment (0..1)
     output:
         fpmlExchangedCurrency fpml.Payment (0..1)
 
-    alias quotedCurrencyPair: fpmlFxCoreDetailsModel -> exchangeRate -> quotedCurrencyPair
+    alias quotedCurrencyPair: fpmlExchangeRate -> quotedCurrencyPair
 
     alias currency:
         if quotedCurrencyPair -> quoteBasis = Currency2PerCurrency1
@@ -628,10 +630,10 @@ func GetFpmlExchangedCurrency:
         else quotedCurrencyPair -> currency2
 
     set fpmlExchangedCurrency:
-        if fpmlFxCoreDetailsModel -> exchangedCurrency1 -> paymentAmount -> currency = currency
-        then fpmlFxCoreDetailsModel -> exchangedCurrency1
-        else if fpmlFxCoreDetailsModel -> exchangedCurrency2 -> paymentAmount -> currency = currency
-        then fpmlFxCoreDetailsModel -> exchangedCurrency2
+        if fpmlExchangedCurrency1 -> paymentAmount -> currency = currency
+        then fpmlExchangedCurrency1
+        else if fpmlExchangedCurrency2 -> paymentAmount -> currency = currency
+        then fpmlExchangedCurrency2
 
 func MapFxOptionToQuantityListWithLocation:
     inputs:
@@ -676,34 +678,33 @@ func MapFxOptionQuantityWithAddress:
 
 func MapCommodityNotionalQuantityToQuantityListWithLocation:
     inputs:
-        fpmlCommodityNotionalQuantityModel fpml.CommodityNotionalQuantityModel (0..1)
+        fpmlNotionalQuantity fpml.CommodityNotionalQuantity (0..1)
+        totalNotionalQuantity number (0..1)
+        fpmlNotionalQuantitySchedule fpml.CommodityNotionalQuantitySchedule (0..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         nonNegativeQuantitySchedule NonNegativeQuantitySchedule (0..*)
             [metadata location]
 
-    alias fpmlQuantityModel:
-        fpmlCommodityNotionalQuantityModel -> commodityNotionalQuantityModelSequence
-
     add nonNegativeQuantitySchedule:
         MapCommodityNotionalQuantityToQuantityWithLocation(
-                fpmlQuantityModel -> notionalQuantity -> quantity,
+                fpmlNotionalQuantity -> quantity,
                 empty,
-                fpmlQuantityModel -> notionalQuantity -> quantityUnit,
-                fpmlQuantityModel -> notionalQuantity -> quantityFrequency,
+                fpmlNotionalQuantity -> quantityUnit,
+                fpmlNotionalQuantity -> quantityFrequency,
                 fpmlLeg
             )
 
     add nonNegativeQuantitySchedule:
         MapCommodityTotalNotionalQuantityToQuantityWithLocation(
-                fpmlQuantityModel -> totalNotionalQuantity,
-                fpmlQuantityModel -> notionalQuantity -> quantityUnit default fpmlQuantityModel -> notionalQuantitySchedule -> notionalStep first -> quantityUnit,
+                totalNotionalQuantity,
+                fpmlNotionalQuantity -> quantityUnit default fpmlNotionalQuantitySchedule -> notionalStep first -> quantityUnit,
                 fpmlLeg
             )
 
 func MapCommodityNotionalQuantityToQuantityWithAddress:
     inputs:
-        fpmlCommodityNotionalQuantityModel fpml.CommodityNotionalQuantityModel (0..1)
+        totalNotionalQuantity number (0..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         nonNegativeQuantitySchedule NonNegativeQuantitySchedule (0..1)
@@ -711,22 +712,19 @@ func MapCommodityNotionalQuantityToQuantityWithAddress:
 
     set nonNegativeQuantitySchedule:
         MapCommodityTotalNotionalQuantityToQuantityWithAddress(
-                fpmlCommodityNotionalQuantityModel -> commodityNotionalQuantityModelSequence -> totalNotionalQuantity,
+                totalNotionalQuantity,
                 fpmlLeg
             )
 
 func MapCommodityFixedPhysicalQuantityToQuantityListWithLocation:
     inputs:
-        fpmlCommodityFixedPhysicalQuantityModel fpml.CommodityFixedPhysicalQuantityModel (0..1)
+        fpmlPhysicalQuantity fpml.CommodityNotionalQuantity (0..1)
+        fpmlPhysicalQuantitySchedule fpml.CommodityPhysicalQuantitySchedule (0..1)
+        fpmlTotalPhysicalQuantity fpml.UnitQuantity (0..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         nonNegativeQuantitySchedule NonNegativeQuantitySchedule (0..*)
             [metadata location]
-
-    alias fpmlPhysicalQuantity: fpmlCommodityFixedPhysicalQuantityModel -> physicalQuantity
-
-    alias fpmlPhysicalQuantitySchedule:
-        fpmlCommodityFixedPhysicalQuantityModel -> physicalQuantitySchedule
 
     add nonNegativeQuantitySchedule:
         MapCommodityNotionalQuantityToQuantityWithLocation(
@@ -739,14 +737,14 @@ func MapCommodityFixedPhysicalQuantityToQuantityListWithLocation:
 
     add nonNegativeQuantitySchedule:
         MapCommodityTotalNotionalQuantityToQuantityWithLocation(
-                fpmlCommodityFixedPhysicalQuantityModel -> totalPhysicalQuantity -> quantity,
-                fpmlCommodityFixedPhysicalQuantityModel -> totalPhysicalQuantity -> quantityUnit,
+                fpmlTotalPhysicalQuantity -> quantity,
+                fpmlTotalPhysicalQuantity -> quantityUnit,
                 fpmlLeg
             )
 
 func MapCommodityFixedPhysicalQuantityToQuantityWithAddress:
     inputs:
-        fpmlCommodityFixedPhysicalQuantityModel fpml.CommodityFixedPhysicalQuantityModel (0..1)
+        fpmlTotalPhysicalQuantity fpml.UnitQuantity (0..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         nonNegativeQuantitySchedule NonNegativeQuantitySchedule (0..1)
@@ -754,7 +752,7 @@ func MapCommodityFixedPhysicalQuantityToQuantityWithAddress:
 
     set nonNegativeQuantitySchedule:
         MapCommodityTotalNotionalQuantityToQuantityWithAddress(
-                fpmlCommodityFixedPhysicalQuantityModel -> totalPhysicalQuantity -> quantity,
+                fpmlTotalPhysicalQuantity -> quantity,
                 fpmlLeg
             )
 
@@ -937,7 +935,7 @@ func MapFloatingRateMultiplerScheduleToPriceWithLocation:
 
     alias floatingRateMultiplierSchedule:
         fpmlRate switch
-            fpml.FloatingRateCalculation then floatingRateModel -> floatingRateMultiplierSchedule,
+            fpml.FloatingRateCalculation then floatingRateMultiplierSchedule,
             default empty
 
     add priceSchedule:
@@ -959,8 +957,8 @@ func MapSpreadScheduleToPriceWithLocation:
 
     alias spreadSchedule:
         fpmlRate switch
-            fpml.FloatingRateCalculation then floatingRateModel -> spreadSchedule,
-            fpml.InflationRateCalculation then floatingRateModel -> spreadSchedule,
+            fpml.FloatingRateCalculation then spreadSchedule,
+            fpml.InflationRateCalculation then spreadSchedule,
             default empty
 
     add priceSchedule:
@@ -973,13 +971,13 @@ func MapSpreadScheduleToPriceWithLocation:
 
 func MapSpreadScheduleWithAddress:
     inputs:
-        fpmlFloatingRateModel fpml.FloatingRateModel (0..1)
+        fpmlSpreadScheduleList fpml.SpreadSchedule (0..*)
         fpmlLeg fpml.Leg (0..1)
     output:
         spreadSchedule SpreadSchedule (0..1)
 
     set spreadSchedule:
-        if fpmlFloatingRateModel -> spreadSchedule exists
+        if fpmlSpreadScheduleList exists
         then SpreadSchedule {
                 price: CreatePriceWithAddress(CreatePriceKey("spreadSchedule", fpmlLeg)),
                 ...
@@ -997,7 +995,7 @@ func MapCapRateScheduleToPriceWithLocation:
     add priceSchedule:
         fpmlRate switch
             fpml.FloatingRateCalculation then
-                floatingRateModel -> capRateSchedule
+                capRateSchedule
                     extract
                         CreatePriceWithLocation(
                                 MapScheduleToInterestRatePriceSchedule(
@@ -1011,13 +1009,13 @@ func MapCapRateScheduleToPriceWithLocation:
 
 func MapCapRateScheduleWithAddress:
     inputs:
-        fpmlFloatingRateModel fpml.FloatingRateModel (0..1)
+        fpmlCapRateScheduleList fpml.StrikeSchedule (0..*)
         fpmlLeg fpml.Leg (0..1)
     output:
         strikeSchedule StrikeSchedule (0..1)
 
     set strikeSchedule:
-        if fpmlFloatingRateModel -> capRateSchedule exists
+        if fpmlCapRateScheduleList exists
         then StrikeSchedule {
                 price: CreatePriceWithAddress(CreatePriceKey("capRateSchedule", fpmlLeg)),
                 ...
@@ -1035,7 +1033,7 @@ func MapFloorRateScheduleToPriceWithLocation:
     add priceSchedule:
         fpmlRate switch
             fpml.FloatingRateCalculation then
-                floatingRateModel -> floorRateSchedule
+                floorRateSchedule
                     extract
                         CreatePriceWithLocation(
                                 MapScheduleToInterestRatePriceSchedule(
@@ -1049,13 +1047,13 @@ func MapFloorRateScheduleToPriceWithLocation:
 
 func MapFloorRateScheduleWithAddress:
     inputs:
-        fpmlFloatingRateModel fpml.FloatingRateModel (0..1)
+        fpmlFloorRateScheduleList fpml.StrikeSchedule (0..*)
         fpmlLeg fpml.Leg (0..1)
     output:
         strikeSchedule StrikeSchedule (0..1)
 
     set strikeSchedule:
-        if fpmlFloatingRateModel -> floorRateSchedule exists
+        if fpmlFloorRateScheduleList exists
         then StrikeSchedule {
                 price: CreatePriceWithAddress(CreatePriceKey("floorRateSchedule", fpmlLeg)),
                 ...
@@ -1166,7 +1164,7 @@ func MapSwapOptionStrikePrice:
         fpmlCreditDefaultSwapOption fpml.CreditDefaultSwapOption (0..1)
         fpmlStrikePrice number (0..1)
         fpmlStrikePercentage number (0..1)
-        currency fpml.Currency (0..1)
+        fpmlCurrency fpml.Currency (0..1)
     output:
         optionStrike OptionStrike (0..1)
 
@@ -1178,12 +1176,12 @@ func MapSwapOptionStrikePrice:
                         value: fpmlStrikePrice default fpmlStrikePercentage,
                         unit:
                             UnitType {
-                                currency: MapCurrency(currency),
+                                currency: MapCurrency(fpmlCurrency),
                                 ...
                             },
                         perUnitOf:
                             UnitType {
-                                currency: MapCurrency(currency),
+                                currency: MapCurrency(fpmlCurrency),
                                 ...
                             },
                         priceType: InterestRate,
@@ -1207,20 +1205,16 @@ func MapOptionStrikeReferenceSwapCurve:
                     swapUnwindValue: fpmlReferenceSwapCurve -> swapUnwindValue
                             then extract
                                 SwapCurveValuation {
-                                    floatingRateIndex: floatingRateIndexModel -> floatingRateIndex -> value to-enum FloatingRateIndexEnum,
-                                    indexTenor: MapPeriod(
-                                                floatingRateIndexModel -> indexTenor
-                                            ),
+                                    floatingRateIndex: floatingRateIndex -> value to-enum FloatingRateIndexEnum,
+                                    indexTenor: MapPeriod(indexTenor),
                                     spread: spread,
                                     side: side to-enum QuotationSideEnum
                                 },
                     makeWholeAmount: fpmlReferenceSwapCurve -> makeWholeAmount
                             then extract
                                 MakeWholeAmount {
-                                    floatingRateIndex: floatingRateIndexModel -> floatingRateIndex -> value to-enum FloatingRateIndexEnum,
-                                    indexTenor: MapPeriod(
-                                                floatingRateIndexModel -> indexTenor
-                                            ),
+                                    floatingRateIndex: floatingRateIndex -> value to-enum FloatingRateIndexEnum,
+                                    indexTenor: MapPeriod(indexTenor),
                                     spread: spread,
                                     side: side to-enum QuotationSideEnum,
                                     interpolationMethod: interpolationMethod -> value to-enum InterpolationMethodEnum,
@@ -1237,7 +1231,7 @@ func MapNetPriceToPriceListWithLocation:
         priceSchedules PriceSchedule (0..*)
             [metadata location]
 
-    alias fpmlNetPrice: fpmlPrice -> equityPriceModel -> netPrice
+    alias fpmlNetPrice: fpmlPrice -> netPrice
 
     add priceSchedules:
         if fpmlNetPrice exists
@@ -1263,21 +1257,26 @@ func MapNetPriceToPriceListWithLocation:
 
 func MapFxCoreDetailsModelPriceQuantityList:
     inputs:
-        fpmlFxCoreDetailsModel fpml.FxCoreDetailsModel (0..1)
+        fpmlExchangeRate fpml.ExchangeRate (0..1)
+        fpmlExchangedCurrency1 fpml.Payment (0..1)
+        fpmlExchangedCurrency2 fpml.Payment (0..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         priceQuantityList PriceQuantity (0..*)
 
-    alias exchangedCurrency: GetFpmlExchangedCurrency(fpmlFxCoreDetailsModel)
+    alias exchangedCurrency:
+        GetFpmlExchangedCurrency(
+                fpmlExchangeRate,
+                fpmlExchangedCurrency1,
+                fpmlExchangedCurrency2
+            )
 
     add priceQuantityList:
         PriceQuantity {
-            price: MapFxCoreDetailsModelPriceListWithLocation(
-                        fpmlFxCoreDetailsModel,
-                        fpmlLeg
-                    ),
+            price: MapFxCoreDetailsModelPriceListWithLocation(fpmlExchangeRate, fpmlLeg),
             quantity: MapFxCoreDetailsModelQuantityListWithLocation(
-                        fpmlFxCoreDetailsModel,
+                        fpmlExchangedCurrency1,
+                        fpmlExchangedCurrency2,
                         fpmlLeg
                     ),
             observable: MapCurrencyToObservableCashWithLocation(
@@ -1289,29 +1288,29 @@ func MapFxCoreDetailsModelPriceQuantityList:
 
 func MapFxCoreDetailsModelPriceListWithLocation:
     inputs:
-        fpmlFxCoreDetailsModel fpml.FxCoreDetailsModel (0..1)
+        fpmlExchangeRate fpml.ExchangeRate (0..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         priceList PriceSchedule (0..*)
             [metadata location]
 
     add priceList:
-        if fpmlFxCoreDetailsModel -> exchangeRate exists
+        if fpmlExchangeRate exists
         then CreatePriceWithLocation(
-                    MapExchangeRateToPrice(fpmlFxCoreDetailsModel -> exchangeRate),
+                    MapExchangeRateToPrice(fpmlExchangeRate),
                     CreatePriceKey("exchangeRate", fpmlLeg)
                 )
 
 func MapFxCoreDetailsModelPriceWithAddress:
     inputs:
-        fpmlFxCoreDetailsModel fpml.FxCoreDetailsModel (0..1)
+        fpmlExchangeRate fpml.ExchangeRate (0..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         price PriceSchedule (0..1)
             [metadata address]
 
     set price:
-        if fpmlFxCoreDetailsModel -> exchangeRate exists
+        if fpmlExchangeRate exists
         then CreatePriceWithAddress(CreatePriceKey("exchangeRate", fpmlLeg))
 
 func MapExchangeRateToPrice:
@@ -1321,9 +1320,8 @@ func MapExchangeRateToPrice:
         price PriceSchedule (0..1)
 
     alias rate: fpmlExchangeRate -> rate
-    alias spotRate: fpmlExchangeRate -> exchangeRateSequence -> spotRate
-    alias forwardPoints:
-        fpmlExchangeRate -> exchangeRateSequence -> exchangeRateSequenceSequence -> forwardPoints
+    alias spotRate: fpmlExchangeRate -> spotRate
+    alias forwardPoints: fpmlExchangeRate -> forwardPoints
     alias quotedCurrencyPair: fpmlExchangeRate -> quotedCurrencyPair
 
     alias fpmlCurrency:
@@ -1406,21 +1404,18 @@ func MapCommoditySpreadToPriceWithAddress:
 
 func MapCommodityFixedLegToPriceWithLocation:
     inputs:
-        fpmlCommodityFixedPriceModel fpml.CommodityFixedPriceModel (1..1)
+        fpmlFixedPrice fpml.CommodityFixedPrice (0..1)
+        fpmlFixedPriceSchedule fpml.CommodityFixedPriceSchedule (0..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         priceSchedule PriceSchedule (0..1)
             [metadata location]
 
     alias fixedPrice:
-        if fpmlCommodityFixedPriceModel -> commodityFixedPriceModelChoice -> fixedPrice exists
-        then MapCommmodityFixedPriceToPriceSchedule(
-                    fpmlCommodityFixedPriceModel -> commodityFixedPriceModelChoice -> fixedPrice
-                )
-        else if fpmlCommodityFixedPriceModel -> fixedPriceSchedule exists
-        then MapCommmodityFixedPriceScheduleToPriceSchedule(
-                    fpmlCommodityFixedPriceModel -> fixedPriceSchedule
-                )
+        if fpmlFixedPrice exists
+        then MapCommmodityFixedPriceToPriceSchedule(fpmlFixedPrice)
+        else if fpmlFixedPriceSchedule exists
+        then MapCommmodityFixedPriceScheduleToPriceSchedule(fpmlFixedPriceSchedule)
 
     set priceSchedule:
         if fixedPrice exists
@@ -1428,21 +1423,18 @@ func MapCommodityFixedLegToPriceWithLocation:
 
 func MapCommodityFixedLegToPriceWithAddress:
     inputs:
-        fpmlCommodityFixedPriceModel fpml.CommodityFixedPriceModel (1..1)
+        fpmlFixedPrice fpml.CommodityFixedPrice (0..1)
+        fpmlFixedPriceSchedule fpml.CommodityFixedPriceSchedule (0..1)
         fpmlLeg fpml.Leg (0..1)
     output:
         priceSchedule PriceSchedule (0..1)
             [metadata address]
 
     alias fixedPrice:
-        if fpmlCommodityFixedPriceModel -> commodityFixedPriceModelChoice -> fixedPrice exists
-        then MapCommmodityFixedPriceToPriceSchedule(
-                    fpmlCommodityFixedPriceModel -> commodityFixedPriceModelChoice -> fixedPrice
-                )
-        else if fpmlCommodityFixedPriceModel -> fixedPriceSchedule exists
-        then MapCommmodityFixedPriceScheduleToPriceSchedule(
-                    fpmlCommodityFixedPriceModel -> fixedPriceSchedule
-                )
+        if fpmlFixedPrice exists
+        then MapCommmodityFixedPriceToPriceSchedule(fpmlFixedPrice)
+        else if fpmlFixedPriceSchedule exists
+        then MapCommmodityFixedPriceScheduleToPriceSchedule(fpmlFixedPriceSchedule)
 
     set priceSchedule:
         if fixedPrice exists
@@ -1454,21 +1446,19 @@ func MapCommmodityFixedPriceToPriceSchedule:
     output:
         priceSchedule PriceSchedule (0..1)
 
-    alias commodityPriceModel: fpmlCommodityFixedPrice -> commodityPriceModel
-
     alias unit:
         UnitType {
             currency: MapStringWithScheme(
-                        commodityPriceModel -> priceCurrency -> value,
-                        commodityPriceModel -> priceCurrency -> currencyScheme
+                        fpmlCommodityFixedPrice -> priceCurrency -> value,
+                        fpmlCommodityFixedPrice -> priceCurrency -> currencyScheme
                     ),
             ...
         }
 
     alias perUnitOf:
         MapUnitTypeWithScheme(
-                commodityPriceModel -> priceUnit -> value,
-                commodityPriceModel -> priceUnit -> quantityUnitScheme
+                fpmlCommodityFixedPrice -> priceUnit -> value,
+                fpmlCommodityFixedPrice -> priceUnit -> quantityUnitScheme
             )
 
     set priceSchedule:
@@ -1491,22 +1481,21 @@ func MapCommmodityFixedPriceScheduleToPriceSchedule:
     output:
         priceSchedule PriceSchedule (0..1)
 
-    alias commodityPriceModel:
-        fpmlCommodityFixedPriceSchedule -> fixedPriceStep first -> commodityPriceModel
+    alias fixedPriceStep: fpmlCommodityFixedPriceSchedule -> fixedPriceStep first
 
     alias unit:
         UnitType {
             currency: MapStringWithScheme(
-                        commodityPriceModel -> priceCurrency -> value,
-                        commodityPriceModel -> priceCurrency -> currencyScheme
+                        fixedPriceStep -> priceCurrency -> value,
+                        fixedPriceStep -> priceCurrency -> currencyScheme
                     ),
             ...
         }
 
     alias perUnitOf:
         MapUnitTypeWithScheme(
-                commodityPriceModel -> priceUnit -> value,
-                commodityPriceModel -> priceUnit -> quantityUnitScheme
+                fixedPriceStep -> priceUnit -> value,
+                fixedPriceStep -> priceUnit -> quantityUnitScheme
             )
 
     set priceSchedule:
@@ -1682,18 +1671,18 @@ func MapFloatingRateIndex:
     output:
         floatingRateIndex FloatingRateIndex (0..1)
 
-    alias model: fpmlFloatingRateCalculation -> floatingRateIndexModel
-
     set floatingRateIndex:
         FloatingRateIndex {
             identifier:
                 AssetIdentifier {
-                    identifier: model -> floatingRateIndex -> value,
+                    identifier: fpmlFloatingRateCalculation -> floatingRateIndex -> value,
                     identifierType: Other // This will require contains syntax to derive correctly
                 },
             assetClass: InterestRate,
-            floatingRateIndex: MapFloatingRateIndexEnum(model -> floatingRateIndex -> value),
-            indexTenor: MapPeriod(model -> indexTenor),
+            floatingRateIndex: MapFloatingRateIndexEnum(
+                        fpmlFloatingRateCalculation -> floatingRateIndex -> value
+                    ),
+            indexTenor: MapPeriod(fpmlFloatingRateCalculation -> indexTenor),
             ...
         }
 
@@ -1703,16 +1692,14 @@ func MapInflationIndex:
     output:
         inflationIndex InflationIndex (0..1)
 
-    alias model: fpmlInflationRateCalculation -> floatingRateIndexModel
-
     set inflationIndex:
         InflationIndex {
             identifier: empty,
             assetClass: InterestRate,
             inflationRateIndex: MapInflationRateIndexEnum(
-                        model -> floatingRateIndex -> value
+                        fpmlInflationRateCalculation -> floatingRateIndex -> value
                     ),
-            indexTenor: MapPeriod(model -> indexTenor),
+            indexTenor: MapPeriod(fpmlInflationRateCalculation -> indexTenor),
             ...
         }
 
@@ -1892,14 +1879,14 @@ func MapAsset:
                 MapIdentifiedAssetToAssetListedDerivative(
                         item,
                         exchangeId,
-                        exchangeIdentifierModel -> relatedExchangeId,
+                        relatedExchangeId,
                         Fund
                     ),
             fpml.ExchangeTradedContract then
                 MapIdentifiedAssetToAssetListedDerivative(
                         item,
                         exchangeId,
-                        exchangeIdentifierModel -> relatedExchangeId,
+                        relatedExchangeId,
                         ListedDerivative
                     ),
             fpml.Loan then
@@ -1912,7 +1899,7 @@ func MapAsset:
                 MapIdentifiedAssetToAssetSecurity(
                         item,
                         exchangeId,
-                        exchangeIdentifierModel -> relatedExchangeId,
+                        relatedExchangeId,
                         Equity
                     ),
             fpml.Commodity then MapAssetCommodity,
@@ -2043,7 +2030,7 @@ func MapAssetCommodity:
                 Commodity {
                     identifier: MapAssetIdentifierList(fpmlCommodity),
                     priceQuoteType: MapQuotationSideEnum(
-                                fpmlCommodity -> commodityProductModel -> specifiedPrice to-string
+                                fpmlCommodity -> specifiedPrice to-string
                             ),
                     deliveryDateReference:
                         DeliveryDateParameters {
@@ -2069,7 +2056,7 @@ func MapEquityIndex:
                     isExchangeListed: if fpmlIndex -> exchangeId exists
                             then True,
                     exchange: fpmlIndex -> exchangeId extract MapExchangeIdToLegalEntity,
-                    relatedExchange: fpmlIndex -> exchangeIdentifierModel -> relatedExchangeId
+                    relatedExchange: fpmlIndex -> relatedExchangeId
                             extract MapExchangeIdToLegalEntity,
                     name: fpmlIndex -> description,
                     assetClass: Equity,

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-bondoption-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-bondoption-func.rosetta
@@ -22,7 +22,10 @@ func MapBondOptionCounterpartyList:
         counterpartyList Counterparty (0..2)
 
     add counterpartyList:
-        MapBuyerSellerModelToCounterpartyList(fpmlBondOption -> buyerSellerModel)
+        MapBuyerSellerModelToCounterpartyList(
+                fpmlBondOption -> buyerPartyReference,
+                fpmlBondOption -> sellerPartyReference
+            )
 
 func MapBondOptionAncillaryPartyList:
     inputs:
@@ -46,8 +49,12 @@ func MapBondOptionNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlBondOption -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlBondOption -> productModel),
+            identifier: MapProductIdentifierList(fpmlBondOption -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlBondOption -> primaryAssetClass,
+                        fpmlBondOption -> secondaryAssetClass,
+                        fpmlBondOption -> productType
+                    ),
             economicTerms: MapBondOptionEconomicTerms(fpmlBondOption, cdmCounterpartyList)
         }
 
@@ -72,14 +79,15 @@ func MapBondOptionPayout:
         payout Payout (0..1)
 
     alias fpmlUnderlyingAsset:
-        fpmlBondOption -> bondChoiceModel -> bond default fpmlBondOption -> bondChoiceModel -> convertibleBond
+        fpmlBondOption -> bond default fpmlBondOption -> convertibleBond
 
     set payout:
         Payout {
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlBondOption -> buyerSellerModel,
+                                fpmlBondOption -> sellerPartyReference,
+                                fpmlBondOption -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
@@ -90,10 +98,13 @@ func MapBondOptionPayout:
                             ...
                         },
                     settlementTerms: MapOptionSettlementModelToSettlementTerms(
-                                fpmlBondOption -> optionSettlementModel
+                                fpmlBondOption -> settlementType,
+                                fpmlBondOption -> settlementCurrency,
+                                fpmlBondOption -> settlementDate
                             ),
                     buyerSeller: MapBuyerSeller(
-                                fpmlBondOption -> buyerSellerModel,
+                                fpmlBondOption -> buyerPartyReference,
+                                fpmlBondOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -106,7 +117,8 @@ func MapBondOptionPayout:
                                 fpmlBondOption -> exercise,
                                 fpmlBondOption -> exerciseProcedure,
                                 empty,
-                                fpmlBondOption -> buyerSellerModel,
+                                fpmlBondOption -> buyerPartyReference,
+                                fpmlBondOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     strike: MapBondOptionStrikeToOptionStrike(fpmlBondOption -> strike),
@@ -150,7 +162,7 @@ func MapBondOptionPriceQuantityList:
         priceQuantityList PriceQuantity (0..*)
 
     alias fpmlUnderlyingAsset:
-        fpmlBondOption -> bondChoiceModel -> bond default fpmlBondOption -> bondChoiceModel -> convertibleBond
+        fpmlBondOption -> bond default fpmlBondOption -> convertibleBond
 
     add priceQuantityList:
         PriceQuantity {
@@ -170,5 +182,6 @@ func MapBondOptionAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlBondOption -> buyerSellerModel
+                fpmlBondOption -> buyerAccountReference,
+                fpmlBondOption -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-brokerequityoption-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-brokerequityoption-func.rosetta
@@ -22,7 +22,10 @@ func MapBrokerEquityOptionCounterpartyList:
         counterpartyList Counterparty (0..2)
 
     add counterpartyList:
-        MapBuyerSellerModelToCounterpartyList(fpmlBrokerEquityOption -> buyerSellerModel)
+        MapBuyerSellerModelToCounterpartyList(
+                fpmlBrokerEquityOption -> buyerPartyReference,
+                fpmlBrokerEquityOption -> sellerPartyReference
+            )
 
 func MapBrokerEquityOptionNonTransferableProduct:
     inputs:
@@ -33,8 +36,12 @@ func MapBrokerEquityOptionNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlBrokerEquityOption -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlBrokerEquityOption -> productModel),
+            identifier: MapProductIdentifierList(fpmlBrokerEquityOption -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlBrokerEquityOption -> primaryAssetClass,
+                        fpmlBrokerEquityOption -> secondaryAssetClass,
+                        fpmlBrokerEquityOption -> productType
+                    ),
             economicTerms: MapBrokerEquityOptionEconomicTerms(
                         fpmlBrokerEquityOption,
                         cdmCounterpartyList
@@ -79,7 +86,8 @@ func MapBrokerEquityOptionPayout:
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlBrokerEquityOption -> buyerSellerModel,
+                                fpmlBrokerEquityOption -> sellerPartyReference,
+                                fpmlBrokerEquityOption -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
@@ -95,7 +103,8 @@ func MapBrokerEquityOptionPayout:
                                 empty
                             ),
                     buyerSeller: MapBuyerSeller(
-                                fpmlBrokerEquityOption -> buyerSellerModel,
+                                fpmlBrokerEquityOption -> buyerPartyReference,
+                                fpmlBrokerEquityOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -111,13 +120,14 @@ func MapBrokerEquityOptionPayout:
                                         fpmlBrokerEquityOption -> equityExercise
                                     ),
                                 empty,
-                                fpmlBrokerEquityOption -> equityExercise -> equityExerciseValuationSettlementSequence -> automaticExercise,
-                                fpmlBrokerEquityOption -> buyerSellerModel,
+                                fpmlBrokerEquityOption -> equityExercise -> automaticExercise,
+                                fpmlBrokerEquityOption -> buyerPartyReference,
+                                fpmlBrokerEquityOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     strike: MapOptionStrikePrice(
                                 fpmlBrokerEquityOption -> strike -> strikePrice,
-                                fpmlBrokerEquityOption -> strike -> equityStrikeSequence -> strikePercentage,
+                                fpmlBrokerEquityOption -> strike -> strikePercentage,
                                 unit,
                                 perUnitOf
                             ),
@@ -157,5 +167,6 @@ func MapBrokerEquityOptionAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlBrokerEquityOption -> buyerSellerModel
+                fpmlBrokerEquityOption -> buyerAccountReference,
+                fpmlBrokerEquityOption -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-capfloor-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-capfloor-func.rosetta
@@ -21,7 +21,8 @@ func MapCapFloorCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlCapFloor -> capFloorStream -> payerReceiverModel
+                fpmlCapFloor -> capFloorStream -> payerPartyReference,
+                fpmlCapFloor -> capFloorStream -> receiverPartyReference
             )
 
 func MapCapFloorAncillaryPartyList:
@@ -46,8 +47,12 @@ func MapCapFloorNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlCapFloor -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlCapFloor -> productModel),
+            identifier: MapProductIdentifierList(fpmlCapFloor -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlCapFloor -> primaryAssetClass,
+                        fpmlCapFloor -> secondaryAssetClass,
+                        fpmlCapFloor -> productType
+                    ),
             economicTerms: MapCapFloorEconomicTerms(fpmlCapFloor, cdmCounterpartyList)
         }
 
@@ -79,25 +84,25 @@ func MapCapFloorPriceQuantityList:
 
 func MapCapfloorPriceQuantity:
     inputs:
-        capFloorStream fpml.InterestRateStream (0..1)
+        fpmlCapFloorStream fpml.InterestRateStream (0..1)
     output:
         priceQuantity PriceQuantity (0..1)
 
-    alias calculationPeriodAmount: capFloorStream -> calculationPeriodAmount
+    alias calculationPeriodAmount: fpmlCapFloorStream -> calculationPeriodAmount
 
     set priceQuantity:
         PriceQuantity {
             price: MapCapfloorCalculationPeriodAmountToPriceList(
                         calculationPeriodAmount,
-                        capFloorStream
+                        fpmlCapFloorStream
                     ),
             quantity: swap.MapCalculationPeriodAmountToQuantityList(
                         calculationPeriodAmount,
-                        capFloorStream
+                        fpmlCapFloorStream
                     ),
             observable: MapRateOptionToObservableWithLocation(
                         calculationPeriodAmount -> calculation -> rateCalculation,
-                        capFloorStream
+                        fpmlCapFloorStream
                     ),
             ...
         }
@@ -115,7 +120,7 @@ func MapCapfloorCalculationPeriodAmountToPriceList:
     alias fpmlCurrency: swap.GetInterestRatePriceCurrency(fpmlCalculationPeriodAmount)
 
     alias fixedRateSchedule:
-        fpmlCalculationPeriodAmount -> calculation -> calculationSequence -> fixedRateSchedule default fpmlCalculationPeriodAmount -> calculation -> calculationSequence1 -> fixedRateSchedule
+        fpmlCalculationPeriodAmount -> calculation -> fixedRateSchedule default fpmlCalculationPeriodAmount -> calculation -> fixedRateSchedule
 
     add priceSchedules:
         MapFixedRateScheduleToPriceWithLocation(fixedRateSchedule, fpmlCurrency, fpmlLeg)
@@ -137,7 +142,12 @@ func MapCapFloorAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                fpmlCapFloor -> capFloorStream -> payerReceiverModel
-            )
+        fpmlCapFloor -> capFloorStream
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-commodityforward-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-commodityforward-func.rosetta
@@ -25,8 +25,12 @@ func MapCommodityForwardNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlCommodityForward -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlCommodityForward -> productModel),
+            identifier: MapProductIdentifierList(fpmlCommodityForward -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlCommodityForward -> primaryAssetClass,
+                        fpmlCommodityForward -> secondaryAssetClass,
+                        fpmlCommodityForward -> productType
+                    ),
             economicTerms: MapCommodityForwardEconomicTerms(
                         fpmlCommodityForward,
                         cdmCounterpartyList

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-commodityoption-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-commodityoption-func.rosetta
@@ -26,7 +26,10 @@ func MapCommodityOptionCounterpartyList:
         counterpartyList Counterparty (0..2)
 
     add counterpartyList:
-        MapBuyerSellerModelToCounterpartyList(fpmlCommodityOption -> buyerSellerModel)
+        MapBuyerSellerModelToCounterpartyList(
+                fpmlCommodityOption -> buyerPartyReference,
+                fpmlCommodityOption -> sellerPartyReference
+            )
 
 func MapCommodityOptionNonTransferableProduct:
     inputs:
@@ -37,8 +40,12 @@ func MapCommodityOptionNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlCommodityOption -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlCommodityOption -> productModel),
+            identifier: MapProductIdentifierList(fpmlCommodityOption -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlCommodityOption -> primaryAssetClass,
+                        fpmlCommodityOption -> secondaryAssetClass,
+                        fpmlCommodityOption -> productType
+                    ),
             economicTerms: MapCommodityOptionEconomicTerms(
                         fpmlCommodityOption,
                         cdmCounterpartyList
@@ -54,12 +61,10 @@ func MapCommodityOptionEconomicTerms:
 
     set economicTerms:
         EconomicTerms {
-            effectiveDate: MapAdjustableOrRelativeDate(
-                        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityOptionFeaturesModel -> effectiveDate
-                    ),
+            effectiveDate: MapAdjustableOrRelativeDate(fpmlCommodityOption -> effectiveDate),
             payout: MapCommodityOptionPayout(fpmlCommodityOption, cdmCounterpartyList),
             terminationDate: MapAdjustableOrRelativeDate(
-                        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityOptionFeaturesModel -> terminationDate
+                        fpmlCommodityOption -> terminationDate
                     ),
             ...
         }
@@ -73,16 +78,14 @@ func MapCommodityOptionPayout:
 
     alias strikeUnit:
         UnitType {
-            currency: MapCurrency(
-                        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityStrikePriceModel -> strikePricePerUnit -> currency
-                    ),
+            currency: MapCurrency(fpmlCommodityOption -> strikePricePerUnit -> currency),
             ...
         }
 
     alias strikePerUnitOf:
         UnitType {
             capacityUnit: MapCapacityUnitEnum(
-                        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityNotionalQuantityModel -> commodityNotionalQuantityModelSequence -> notionalQuantity -> quantityUnit -> value
+                        fpmlCommodityOption -> notionalQuantity -> quantityUnit -> value
                     ),
             ...
         }
@@ -92,22 +95,24 @@ func MapCommodityOptionPayout:
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlCommodityOption -> buyerSellerModel,
+                                fpmlCommodityOption -> sellerPartyReference,
+                                fpmlCommodityOption -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
                         ResolvablePriceQuantity {
                             quantitySchedule: MapCommodityNotionalQuantityToQuantityWithAddress(
-                                        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityNotionalQuantityModel,
+                                        fpmlCommodityOption -> totalNotionalQuantity,
                                         empty
                                     ),
                             ...
                         },
                     settlementTerms: MapCommodityExerciseToSettlementTerms(
-                                fpmlCommodityOption -> commodityFinancialOptionModel -> exercise
+                                fpmlCommodityOption -> exercise
                             ),
                     buyerSeller: MapBuyerSeller(
-                                fpmlCommodityOption -> buyerSellerModel,
+                                fpmlCommodityOption -> buyerPartyReference,
+                                fpmlCommodityOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     observationTerms: MapCommodityOptionToObservationTerms(
@@ -116,31 +121,30 @@ func MapCommodityOptionPayout:
                     underlier:
                         Underlier {
                             Observable: MapAssetToObservableWithAddress(
-                                        fpmlCommodityOption -> commodityFinancialOptionModel -> commodity
+                                        fpmlCommodityOption -> commodity
                                     ),
                             ...
                         },
                     optionType: fpmlCommodityOption -> optionType to-enum OptionTypeEnum,
                     exerciseTerms: MapExerciseTerms(
-                                GetFpmlCommodityExercise(
-                                        fpmlCommodityOption -> commodityFinancialOptionModel -> exercise
-                                    ),
+                                GetFpmlCommodityExercise(fpmlCommodityOption -> exercise),
                                 fpml.ExerciseProcedure {
-                                    followUpConfirmation: fpmlCommodityOption -> commodityFinancialOptionModel -> exercise -> writtenConfirmation,
+                                    followUpConfirmation: fpmlCommodityOption -> exercise -> writtenConfirmation,
                                     ...
                                 },
-                                fpmlCommodityOption -> commodityFinancialOptionModel -> exercise -> automaticExercise,
-                                fpmlCommodityOption -> buyerSellerModel,
+                                fpmlCommodityOption -> exercise -> automaticExercise,
+                                fpmlCommodityOption -> buyerPartyReference,
+                                fpmlCommodityOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
-                    strike: if fpmlCommodityOption -> commodityFinancialOptionModel -> commodityStrikePriceModel -> strikePricePerUnit -> amount exists
+                    strike: if fpmlCommodityOption -> strikePricePerUnit -> amount exists
                             then MapOptionStrikePrice(
-                                    fpmlCommodityOption -> commodityFinancialOptionModel -> commodityStrikePriceModel -> strikePricePerUnit -> amount,
+                                    fpmlCommodityOption -> strikePricePerUnit -> amount,
                                     empty,
                                     strikeUnit,
                                     strikePerUnitOf
                                 )
-                        else if fpmlCommodityOption -> commodityFinancialOptionModel -> commodityStrikePriceModel -> strikePricePerUnitSchedule -> strikePricePerUnitStep -> amount exists
+                        else if fpmlCommodityOption -> strikePricePerUnitSchedule -> strikePricePerUnitStep -> amount exists
                         then OptionStrike {
                                 strikePrice:
                                     Price {
@@ -163,25 +167,22 @@ func MapCommodityOptionToStrikePriceDatedValues:
     output:
         strikePriceSchedule DatedValue (0..*)
 
-    alias fpmlStrikePriceSchedule:
-        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityStrikePriceModel -> strikePricePerUnitSchedule
+    alias fpmlStrikePriceSchedule: fpmlCommodityOption -> strikePricePerUnitSchedule
     alias fpmlCalculationPeriodsSchedule:
         ExtractCommodityCalculationPeriodsScheduleFromHref(
                 CollectAllCalculationPeriodsSchedules(fpmlCommodityOption),
-                fpmlStrikePriceSchedule -> commodityCalculationPeriodsPointerModel -> calculationPeriodsScheduleReference -> href
+                fpmlCommodityOption -> strikePricePerUnitSchedule -> calculationPeriodsScheduleReference -> href
             )
     alias fpmlCalculationPeriods:
         ExtractCommodityCalculationPeriodsFromHref(
                 CollectAllCalculationPeriods(fpmlCommodityOption),
-                fpmlStrikePriceSchedule -> commodityCalculationPeriodsPointerModel -> calculationPeriodsReference -> href
+                fpmlCommodityOption -> strikePricePerUnitSchedule -> calculationPeriodsReference -> href
             )
 
-    alias fpmlCommodityOptionFeatures:
-        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityOptionFeaturesModel
     alias effectiveDate:
-        MapAdjustableOrRelativeDate(fpmlCommodityOptionFeatures -> effectiveDate) -> adjustableDate -> unadjustedDate
+        MapAdjustableOrRelativeDate(fpmlCommodityOption -> effectiveDate) -> adjustableDate -> unadjustedDate
     alias terminationDate:
-        MapAdjustableOrRelativeDate(fpmlCommodityOptionFeatures -> terminationDate) -> adjustableDate -> unadjustedDate
+        MapAdjustableOrRelativeDate(fpmlCommodityOption -> terminationDate) -> adjustableDate -> unadjustedDate
 
     alias fpmlCommodityStrikePriceDates:
         if fpmlCalculationPeriods exists
@@ -195,7 +196,7 @@ func MapCommodityOptionToStrikePriceDatedValues:
 
     add strikePriceSchedule:
         MapCommodityOptionStrikePriceSchedule(
-                fpmlStrikePriceSchedule -> strikePricePerUnitStep,
+                fpmlCommodityOption -> strikePricePerUnitSchedule -> strikePricePerUnitStep,
                 fpmlCommodityStrikePriceDates
             )
 
@@ -203,24 +204,24 @@ func CollectAllCalculationPeriodsSchedules:
     inputs:
         fpmlCommodityOption fpml.CommodityOption (0..1)
     output:
-        fpmlCommodityCalculationPeriodsSchedules fpml.CommodityCalculationPeriodsSchedule (0..*)
+        fpmlCommodityCalculationPeriodsScheduleList fpml.CommodityCalculationPeriodsSchedule (0..*)
 
-    add fpmlCommodityCalculationPeriodsSchedules:
-        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityOptionFeaturesModel -> commodityOptionFeaturesModelSequence -> commodityAsianModel -> calculationPeriodsSchedule
-    add fpmlCommodityCalculationPeriodsSchedules:
-        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityOptionFeaturesModel -> commodityAsianModel -> calculationPeriodsSchedule
-    add fpmlCommodityCalculationPeriodsSchedules:
-        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityFloatingStrikePriceModel -> floatingStrikePricePerUnitSchedule
+    add fpmlCommodityCalculationPeriodsScheduleList:
+        fpmlCommodityOption -> calculationPeriodsSchedule
+    add fpmlCommodityCalculationPeriodsScheduleList:
+        fpmlCommodityOption -> calculationPeriodsSchedule
+    add fpmlCommodityCalculationPeriodsScheduleList:
+        fpmlCommodityOption -> floatingStrikePricePerUnitSchedule
 
 func ExtractCommodityCalculationPeriodsScheduleFromHref:
     inputs:
-        fpmlCommodityCalculationPeriodsSchedules fpml.CommodityCalculationPeriodsSchedule (0..*)
+        fpmlCommodityCalculationPeriodsScheduleList fpml.CommodityCalculationPeriodsSchedule (0..*)
         href string (1..1)
     output:
         fpmlCommodityCalculationPeriodsSchedule fpml.CommodityCalculationPeriodsSchedule (0..1)
 
     set fpmlCommodityCalculationPeriodsSchedule:
-        fpmlCommodityCalculationPeriodsSchedules
+        fpmlCommodityCalculationPeriodsScheduleList
             filter id = href
             then first
 
@@ -239,20 +240,18 @@ func CollectAllCalculationPeriods:
     output:
         fpmlCommodityCalculationPeriods fpml.AdjustableDates (0..*)
 
-    add fpmlCommodityCalculationPeriods:
-        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityOptionFeaturesModel -> commodityOptionFeaturesModelSequence -> commodityAsianModel -> calculationPeriods
-    add fpmlCommodityCalculationPeriods:
-        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityOptionFeaturesModel -> commodityAsianModel -> calculationPeriods
+    add fpmlCommodityCalculationPeriods: fpmlCommodityOption -> calculationPeriods
+    add fpmlCommodityCalculationPeriods: fpmlCommodityOption -> calculationPeriods
 
 func ExtractCommodityCalculationPeriodsFromHref:
     inputs:
-        fpmlCommodityCalculationPeriodsList fpml.AdjustableDates (0..*)
+        fpmlCommodityCalculationPeriodList fpml.AdjustableDates (0..*)
         href string (1..1)
     output:
         fpmlCommodityCalculationPeriods fpml.AdjustableDates (0..1)
 
     set fpmlCommodityCalculationPeriods:
-        fpmlCommodityCalculationPeriodsList
+        fpmlCommodityCalculationPeriodList
             filter id = href
             then first
 
@@ -271,21 +270,15 @@ func MapCommodityOptionToObservationTerms:
     output:
         observationTerms ObservationTerms (0..1)
 
-    alias fpmlCalculationPeriodsSchedule:
-        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityOptionFeaturesModel
-            extract
-                commodityOptionFeaturesModelSequence -> commodityAsianModel -> calculationPeriodsSchedule default commodityAsianModel -> calculationPeriodsSchedule
+    alias fpmlCalculationPeriodsSchedule: fpmlCommodityOption -> calculationPeriodsSchedule
 
-    alias fpmlPricingDates:
-        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityOptionFeaturesModel
-            extract
-                commodityOptionFeaturesModelSequence -> commodityAsianModel -> pricingDates default commodityAsianModel -> pricingDates
+    alias fpmlPricingDates: fpmlCommodityOption -> pricingDates
 
     set observationTerms:
         ObservationTerms {
             calculationPeriodDates:
                 CalculationPeriodDates {
-                    calculationPeriodFrequency: MapCommodityCalculationPeriodsScheduleToCalculationPeriodFrequncy(
+                    calculationPeriodFrequency: MapCommodityCalculationPeriodsScheduleToCalculationPeriodFrequency(
                                 fpmlCalculationPeriodsSchedule
                             ),
                     ...
@@ -300,19 +293,14 @@ func MapCommodityPricingDatesToObservationDates:
     output:
         observationDates ObservationDates (0..1)
 
-    alias fpmlDateSequence:
-        fpmlCommodityPricingDates -> commodityPricingDatesSequence -> commodityPricingDatesSequenceSequence
-
     set observationDates:
         ObservationDates {
             parametricDates:
                 ParametricDates {
-                    dayType: MapDayTypeEnum(
-                                fpmlDateSequence -> daysModel -> dayType to-string
-                            ),
-                    dayDistribution: fpmlDateSequence -> daysModel -> daysModelSequence0 -> dayDistribution -> value to-enum DayDistributionEnum,
+                    dayType: MapDayTypeEnum(fpmlCommodityPricingDates -> dayType to-string),
+                    dayDistribution: fpmlCommodityPricingDates -> dayDistribution -> value to-enum DayDistributionEnum,
                     businessCenters: MapCommodityBusinessCalendarToBusinessCenters(
-                                fpmlDateSequence -> businessCalendar
+                                fpmlCommodityPricingDates -> businessCalendar
                             ),
                     ...
                 },
@@ -328,12 +316,12 @@ func MapCommodityOptionPriceQuantityList:
     add priceQuantityList:
         PriceQuantity {
             quantity: MapCommodityNotionalQuantityToQuantityListWithLocation(
-                        fpmlCommodityOption -> commodityFinancialOptionModel -> commodityNotionalQuantityModel,
+                        fpmlCommodityOption -> notionalQuantity,
+                        fpmlCommodityOption -> totalNotionalQuantity,
+                        fpmlCommodityOption -> notionalQuantitySchedule,
                         empty
                     ),
-            observable: MapAssetToObservableWithLocation(
-                        fpmlCommodityOption -> commodityFinancialOptionModel -> commodity
-                    ),
+            observable: MapAssetToObservableWithLocation(fpmlCommodityOption -> commodity),
             ...
         }
 
@@ -348,5 +336,6 @@ func MapCommodityOptionAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlCommodityOption -> buyerSellerModel
+                fpmlCommodityOption -> buyerAccountReference,
+                fpmlCommodityOption -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-commodityswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-commodityswap-func.rosetta
@@ -25,27 +25,48 @@ func MapCommoditySwapCounterpartyList:
     output:
         counterpartyList Counterparty (0..2)
 
-    alias payerReceiver:
-        fpmlCommoditySwap -> commoditySwapDetailsModel -> commoditySwapLeg
-            extract GetFpmlPayerReceiver
+    alias payer:
+        fpmlCommoditySwap -> commoditySwapLeg
+            extract GetFpmlPayer
             then first
 
-    add counterpartyList: MapPayerReceiverModelToCounterpartyList(payerReceiver)
+    alias receiver:
+        fpmlCommoditySwap -> commoditySwapLeg
+            extract GetFpmlReceiver
+            then first
 
-func GetFpmlPayerReceiver:
+    add counterpartyList: MapPayerReceiverModelToCounterpartyList(payer, receiver)
+
+func GetFpmlPayer:
     inputs:
         fpmlCommodityLeg fpml.CommodityLeg (0..1)
     output:
-        fpmlPayerReceiverModel fpml.PayerReceiverModel (0..1)
+        fpmlPayerPartyReference fpml.PartyReference (0..1)
 
-    set fpmlPayerReceiverModel:
+    set fpmlPayerPartyReference:
         fpmlCommodityLeg switch
-            fpml.FloatingLeg then payerReceiverModel,
-            fpml.GasPhysicalLeg then payerReceiverModel,
-            fpml.OilPhysicalLeg then payerReceiverModel,
-            fpml.ElectricityPhysicalLeg then payerReceiverModel,
-            fpml.EnvironmentalPhysicalLeg then payerReceiverModel,
-            fpml.CoalPhysicalLeg then payerReceiverModel,
+            fpml.FloatingLeg then payerPartyReference,
+            fpml.GasPhysicalLeg then payerPartyReference,
+            fpml.OilPhysicalLeg then payerPartyReference,
+            fpml.ElectricityPhysicalLeg then payerPartyReference,
+            fpml.EnvironmentalPhysicalLeg then payerPartyReference,
+            fpml.CoalPhysicalLeg then payerPartyReference,
+            default empty
+
+func GetFpmlReceiver:
+    inputs:
+        fpmlCommodityLeg fpml.CommodityLeg (0..1)
+    output:
+        fpmlReceiverPartyReference fpml.PartyReference (0..1)
+
+    set fpmlReceiverPartyReference:
+        fpmlCommodityLeg switch
+            fpml.FloatingLeg then receiverPartyReference,
+            fpml.GasPhysicalLeg then receiverPartyReference,
+            fpml.OilPhysicalLeg then receiverPartyReference,
+            fpml.ElectricityPhysicalLeg then receiverPartyReference,
+            fpml.EnvironmentalPhysicalLeg then receiverPartyReference,
+            fpml.CoalPhysicalLeg then receiverPartyReference,
             default empty
 
 func MapCommoditySwapNonTransferableProduct:
@@ -57,31 +78,38 @@ func MapCommoditySwapNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlCommoditySwap -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlCommoditySwap -> productModel),
+            identifier: MapProductIdentifierList(fpmlCommoditySwap -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlCommoditySwap -> primaryAssetClass,
+                        fpmlCommoditySwap -> secondaryAssetClass,
+                        fpmlCommoditySwap -> productType
+                    ),
             economicTerms: MapCommoditySwapEconomicTerms(
-                        fpmlCommoditySwap -> commoditySwapDetailsModel,
+                        fpmlCommoditySwap -> commoditySwapLeg,
+                        fpmlCommoditySwap -> settlementCurrency,
+                        fpmlCommoditySwap -> effectiveDate,
+                        fpmlCommoditySwap -> terminationDate,
                         cdmCounterpartyList
                     )
         }
 
 func MapCommoditySwapEconomicTerms:
     inputs:
-        fpmlCommoditySwapDetailsModel fpml.CommoditySwapDetailsModel (1..1)
+        fpmlCommoditySwapLegList fpml.CommodityLeg (0..*)
+        fpmlSettlementCurrency fpml.IdentifiedCurrency (0..1)
+        fpmlEffectiveDate fpml.AdjustableOrRelativeDate (0..1)
+        fpmlTerminationDate fpml.AdjustableOrRelativeDate (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         economicTerms EconomicTerms (0..1)
 
     set economicTerms:
         EconomicTerms {
-            effectiveDate: MapAdjustableOrRelativeDate(
-                        fpmlCommoditySwapDetailsModel -> effectiveDate
-                    ),
-            terminationDate: MapAdjustableOrRelativeDate(
-                        fpmlCommoditySwapDetailsModel -> terminationDate
-                    ),
+            effectiveDate: MapAdjustableOrRelativeDate(fpmlEffectiveDate),
+            terminationDate: MapAdjustableOrRelativeDate(fpmlTerminationDate),
             payout: MapCommoditySwapLegListToPayoutList(
-                        fpmlCommoditySwapDetailsModel,
+                        fpmlCommoditySwapLegList,
+                        fpmlSettlementCurrency,
                         cdmCounterpartyList
                     ),
             ...
@@ -89,12 +117,11 @@ func MapCommoditySwapEconomicTerms:
 
 func MapCommoditySwapLegListToPayoutList:
     inputs:
-        fpmlCommoditySwapDetailsModel fpml.CommoditySwapDetailsModel (1..1)
+        fpmlCommoditySwapLegList fpml.CommodityLeg (0..*)
+        fpmlSettlementCurrency fpml.IdentifiedCurrency (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         payoutList Payout (0..*)
-
-    alias fpmlCommoditySwapLegList: fpmlCommoditySwapDetailsModel -> commoditySwapLeg
 
     add payoutList:
         fpmlCommoditySwapLegList
@@ -102,7 +129,7 @@ func MapCommoditySwapLegListToPayoutList:
                 item switch
                     fpml.FloatingLeg then
                         MapFloatingLegToCommodityPayout(
-                                fpmlCommoditySwapDetailsModel,
+                                fpmlSettlementCurrency,
                                 item,
                                 cdmCounterpartyList
                             ),
@@ -164,7 +191,7 @@ func MapCommoditySwapLegListToPayoutList:
 
 func MapFloatingLegToCommodityPayout:
     inputs:
-        fpmlCommoditySwapDetailsModel fpml.CommoditySwapDetailsModel (1..1)
+        fpmlSettlementCurrency fpml.IdentifiedCurrency (0..1)
         fpmlFloatingLeg fpml.FloatingLeg (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
@@ -175,19 +202,20 @@ func MapFloatingLegToCommodityPayout:
             CommodityPayout:
                 CommodityPayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlFloatingLeg -> payerReceiverModel,
+                                fpmlFloatingLeg -> payerPartyReference,
+                                fpmlFloatingLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
                         ResolvablePriceQuantity {
                             quantitySchedule: MapCommodityNotionalQuantityToQuantityWithAddress(
-                                        fpmlFloatingLeg -> commodityNotionalQuantityModel,
+                                        fpmlFloatingLeg -> totalNotionalQuantity,
                                         fpmlFloatingLeg
                                     ),
                             ...
                         },
                     settlementTerms: MapCommoditySettlementModelToSettlementTerms(
-                                fpmlCommoditySwapDetailsModel
+                                fpmlSettlementCurrency
                             ),
                     averagingFeature: MapAveragingCalculation(
                                 fpmlFloatingLeg -> calculation -> averagingMethod
@@ -196,15 +224,15 @@ func MapFloatingLegToCommodityPayout:
                                 fpmlFloatingLeg -> calculation -> pricingDates
                             ),
                     calculationPeriodDates: MapCommodityCalculationPeriods(
-                                fpmlFloatingLeg -> commodityCalculationPeriodsModel
+                                fpmlFloatingLeg -> calculationPeriodsSchedule
                             ),
-                    paymentDates: if fpmlFloatingLeg -> commodityPaymentDatesModel -> relativePaymentDates exists
+                    paymentDates: if fpmlFloatingLeg -> relativePaymentDates exists
                             then MapCommodityRelativePaymentDates(
-                                    fpmlFloatingLeg -> commodityPaymentDatesModel
+                                    fpmlFloatingLeg -> relativePaymentDates
                                 )
-                        else if fpmlFloatingLeg -> commodityPaymentDatesModel -> commodityNonPeriodicPaymentDatesModel exists
+                        else if fpmlFloatingLeg -> paymentDates exists
                         then MapCommoditySwapNonPeriodicPaymentDates(
-                                    fpmlFloatingLeg -> commodityPaymentDatesModel
+                                    fpmlFloatingLeg -> paymentDates
                                 ),
                     underlier:
                         Underlier {
@@ -266,7 +294,8 @@ func MapGasPhysicalLegToSettlementPayout:
             SettlementPayout:
                 SettlementPayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlGasPhysicalLeg -> payerReceiverModel,
+                                fpmlGasPhysicalLeg -> payerPartyReference,
+                                fpmlGasPhysicalLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -294,7 +323,8 @@ func MapOilPhysicalLegToSettlementPayout:
             SettlementPayout:
                 SettlementPayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlOilPhysicalLeg -> payerReceiverModel,
+                                fpmlOilPhysicalLeg -> payerPartyReference,
+                                fpmlOilPhysicalLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -322,7 +352,8 @@ func MapElectricityPhysicalLegToSettlementPayout:
             SettlementPayout:
                 SettlementPayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlElectricityPhysicalLeg -> payerReceiverModel,
+                                fpmlElectricityPhysicalLeg -> payerPartyReference,
+                                fpmlElectricityPhysicalLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -350,7 +381,8 @@ func MapEnvironmentalPhysicalLegToSettlementPayout:
             SettlementPayout:
                 SettlementPayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlEnvironmentalPhysicalLeg -> payerReceiverModel,
+                                fpmlEnvironmentalPhysicalLeg -> payerPartyReference,
+                                fpmlEnvironmentalPhysicalLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -378,7 +410,8 @@ func MapCoalPhysicalLegToSettlementPayout:
             SettlementPayout:
                 SettlementPayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlCoalPhysicalLeg -> payerReceiverModel,
+                                fpmlCoalPhysicalLeg -> payerPartyReference,
+                                fpmlCoalPhysicalLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -406,24 +439,26 @@ func MapFixedLegToFixedPricePayout:
             FixedPricePayout:
                 FixedPricePayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlFixedLeg -> payerReceiverModel,
+                                fpmlFixedLeg -> payerPartyReference,
+                                fpmlFixedLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
                         ResolvablePriceQuantity {
                             quantitySchedule: MapCommodityNotionalQuantityToQuantityWithAddress(
-                                        fpmlFixedLeg -> commodityNotionalQuantityModel,
+                                        fpmlFixedLeg -> totalNotionalQuantity,
                                         fpmlFixedLeg
                                     ),
                             ...
                         },
                     paymentDates: MapCommodityRelativePaymentDates(
-                                fpmlFixedLeg -> commodityPaymentDatesModel
+                                fpmlFixedLeg -> relativePaymentDates
                             ),
                     fixedPrice:
                         FixedPrice {
                             price: MapCommodityFixedLegToPriceWithAddress(
-                                        fpmlFixedLeg -> commodityFixedPriceModel,
+                                        fpmlFixedLeg -> fixedPrice,
+                                        fpmlFixedLeg -> fixedPriceSchedule,
                                         fpmlFixedLeg
                                     )
                         },
@@ -438,8 +473,7 @@ func MapCommoditySwapPriceQuantityList:
     output:
         priceQuantityList PriceQuantity (0..*)
 
-    alias fpmlCommoditySwapLegList:
-        fpmlCommoditySwap -> commoditySwapDetailsModel -> commoditySwapLeg
+    alias fpmlCommoditySwapLegList: fpmlCommoditySwap -> commoditySwapLeg
 
     add priceQuantityList:
         fpmlCommoditySwapLegList
@@ -499,11 +533,14 @@ func MapFixedLegToPriceQuantity:
     set priceQuantity:
         PriceQuantity {
             quantity: MapCommodityNotionalQuantityToQuantityListWithLocation(
-                        fpmlFixedLeg -> commodityNotionalQuantityModel,
+                        fpmlFixedLeg -> notionalQuantity,
+                        fpmlFixedLeg -> totalNotionalQuantity,
+                        fpmlFixedLeg -> notionalQuantitySchedule,
                         fpmlFixedLeg
                     ),
             price: MapCommodityFixedLegToPriceWithLocation(
-                        fpmlFixedLeg -> commodityFixedPriceModel,
+                        fpmlFixedLeg -> fixedPrice,
+                        fpmlFixedLeg -> fixedPriceSchedule,
                         fpmlFixedLeg
                     ),
             ...
@@ -517,14 +554,14 @@ func MapFloatingLegToPriceQuantity:
 
     alias priceCapacityUnit:
         // if fpmlFloatingLeg exists then
-        MapCapacityUnitEnum(
-                fpmlFloatingLeg -> commodityNotionalQuantityModel -> commodityNotionalQuantityModelSequence -> notionalQuantity -> quantityUnit -> value
-            )
+        MapCapacityUnitEnum(fpmlFloatingLeg -> notionalQuantity -> quantityUnit -> value)
 
     set priceQuantity:
         PriceQuantity {
             quantity: MapCommodityNotionalQuantityToQuantityListWithLocation(
-                        fpmlFloatingLeg -> commodityNotionalQuantityModel,
+                        fpmlFloatingLeg -> notionalQuantity,
+                        fpmlFloatingLeg -> totalNotionalQuantity,
+                        fpmlFloatingLeg -> notionalQuantitySchedule,
                         fpmlFloatingLeg
                     ),
             observable: MapAssetToObservableWithLocation(fpmlFloatingLeg -> commodity),

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-commodityswaption-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-commodityswaption-func.rosetta
@@ -20,7 +20,10 @@ func MapCommoditySwaptionCounterpartyList:
         counterpartyList Counterparty (0..2)
 
     add counterpartyList:
-        MapBuyerSellerModelToCounterpartyList(fpmlCommoditySwaption -> buyerSellerModel)
+        MapBuyerSellerModelToCounterpartyList(
+                fpmlCommoditySwaption -> buyerPartyReference,
+                fpmlCommoditySwaption -> sellerPartyReference
+            )
 
 func MapCommoditySwaptionAncillaryPartyList:
     inputs:
@@ -43,8 +46,12 @@ func MapCommoditySwaptionNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlCommoditySwaption -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlCommoditySwaption -> productModel),
+            identifier: MapProductIdentifierList(fpmlCommoditySwaption -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlCommoditySwaption -> primaryAssetClass,
+                        fpmlCommoditySwaption -> secondaryAssetClass,
+                        fpmlCommoditySwaption -> productType
+                    ),
             economicTerms: MapCommoditySwaptionEconomicTerms(
                         fpmlCommoditySwaption,
                         cdmCounterpartyList
@@ -76,14 +83,16 @@ func MapCommoditySwaptionPayout:
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlCommoditySwaption -> buyerSellerModel,
+                                fpmlCommoditySwaption -> sellerPartyReference,
+                                fpmlCommoditySwaption -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     settlementTerms: MapCommoditySwaptionSettlementTerms(
                                 fpmlCommoditySwaption
                             ),
                     buyerSeller: MapBuyerSeller(
-                                fpmlCommoditySwaption -> buyerSellerModel,
+                                fpmlCommoditySwaption -> buyerPartyReference,
+                                fpmlCommoditySwaption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -91,7 +100,10 @@ func MapCommoditySwaptionPayout:
                             Product:
                                 Product {
                                     NonTransferableProduct: MapUnderlierNonTransferableProduct(
-                                                fpmlCommoditySwaption -> commoditySwap -> commoditySwapDetailsModel,
+                                                fpmlCommoditySwaption -> commoditySwap -> commoditySwapLeg,
+                                                fpmlCommoditySwaption -> commoditySwap -> settlementCurrency,
+                                                fpmlCommoditySwaption -> commoditySwap -> effectiveDate,
+                                                fpmlCommoditySwaption -> commoditySwap -> terminationDate,
                                                 cdmCounterpartyList
                                             ),
                                     ...
@@ -105,7 +117,8 @@ func MapCommoditySwaptionPayout:
                                     ),
                                 empty,
                                 empty,
-                                fpmlCommoditySwaption -> buyerSellerModel,
+                                fpmlCommoditySwaption -> buyerPartyReference,
+                                fpmlCommoditySwaption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     strike: empty,
@@ -116,7 +129,10 @@ func MapCommoditySwaptionPayout:
 
 func MapUnderlierNonTransferableProduct:
     inputs:
-        fpmlCommoditySwapDetailsModel fpml.CommoditySwapDetailsModel (1..1)
+        fpmlCommoditySwapLegList fpml.CommodityLeg (0..*)
+        fpmlSettlementCurrency fpml.IdentifiedCurrency (0..1)
+        fpmlEffectiveDate fpml.AdjustableOrRelativeDate (0..1)
+        fpmlTerminationDate fpml.AdjustableOrRelativeDate (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         nonTransferableProduct NonTransferableProduct (0..1)
@@ -124,7 +140,10 @@ func MapUnderlierNonTransferableProduct:
     set nonTransferableProduct:
         NonTransferableProduct {
             economicTerms: commodityswap.MapCommoditySwapEconomicTerms(
-                        fpmlCommoditySwapDetailsModel,
+                        fpmlCommoditySwapLegList,
+                        fpmlSettlementCurrency,
+                        fpmlEffectiveDate,
+                        fpmlTerminationDate,
                         cdmCounterpartyList
                     ),
             ...
@@ -137,7 +156,7 @@ func MapCommoditySwaptionPriceQuantityList:
         priceQuantityList PriceQuantity (0..*)
 
     alias fpmlCommoditySwaptionLegList:
-        fpmlCommoditySwaption -> commoditySwap -> commoditySwapDetailsModel -> commoditySwapLeg
+        fpmlCommoditySwaption -> commoditySwap -> commoditySwapLeg
 
     add priceQuantityList:
         fpmlCommoditySwaptionLegList
@@ -164,5 +183,6 @@ func MapCommoditySwaptionAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlCommoditySwaption -> buyerSellerModel
+                fpmlCommoditySwaption -> buyerAccountReference,
+                fpmlCommoditySwaption -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-correlationswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-correlationswap-func.rosetta
@@ -25,7 +25,8 @@ func MapCorrelationSwapCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlCorrelationSwap -> correlationLeg -> payerReceiverModel
+                fpmlCorrelationSwap -> correlationLeg -> payerPartyReference,
+                fpmlCorrelationSwap -> correlationLeg -> receiverPartyReference
             )
 
 func MapCorrelationSwapNonTransferableProduct:
@@ -37,8 +38,12 @@ func MapCorrelationSwapNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlCorrelationSwap -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlCorrelationSwap -> productModel),
+            identifier: MapProductIdentifierList(fpmlCorrelationSwap -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlCorrelationSwap -> primaryAssetClass,
+                        fpmlCorrelationSwap -> secondaryAssetClass,
+                        fpmlCorrelationSwap -> productType
+                    ),
             economicTerms: MapCorrelationSwapEconomicTerms(
                         fpmlCorrelationSwap,
                         cdmCounterpartyList
@@ -74,18 +79,18 @@ func MapCorrelationSwapPayout:
                     payerReceiver:
                         PayerReceiver {
                             payer: MapCounterpartyRoleEnum(
-                                        correlationLeg -> payerReceiverModel -> payerModel -> payerPartyReference -> href,
+                                        fpmlCorrelationSwap -> correlationLeg -> payerPartyReference -> href,
                                         cdmCounterpartyList
                                     ),
                             receiver: MapCounterpartyRoleEnum(
-                                        correlationLeg -> payerReceiverModel -> receiverModel -> receiverPartyReference -> href,
+                                        fpmlCorrelationSwap -> correlationLeg -> receiverPartyReference -> href,
                                         cdmCounterpartyList
                                     )
                         },
                     priceQuantity:
                         ResolvablePriceQuantity {
                             quantitySchedule: MapNonNegativeMoneyToQuantityWithAddress(
-                                        correlationLeg -> amount -> correlation -> notionalAmount,
+                                        fpmlCorrelationSwap -> correlationLeg -> amount -> correlation -> notionalAmount,
                                         empty,
                                         correlationLeg
                                     ),
@@ -93,20 +98,20 @@ func MapCorrelationSwapPayout:
                         },
                     settlementTerms: MapCorrelationLegToSettlementTerms(correlationLeg),
                     observationTerms: MapAdjustableOrRelativeDateToObservationTerms(
-                                correlationLeg -> amount -> observationStartDate
+                                fpmlCorrelationSwap -> correlationLeg -> amount -> observationStartDate
                             ),
                     valuationDates:
                         ValuationDates {
                             finalValuationDate: MapPerformanceValuationDates(
                                         empty,
-                                        correlationLeg -> valuation
+                                        fpmlCorrelationSwap -> correlationLeg -> valuation
                                     ),
                             ...
                         },
                     underlier:
                         Underlier {
                             Observable: MapUnderlyerToObservableWithAddress(
-                                        correlationLeg -> underlyer
+                                        fpmlCorrelationSwap -> correlationLeg -> underlyer
                                     ),
                             ...
                         },
@@ -135,14 +140,14 @@ func MapCorrelationLegToCorrelationReturnTerms:
         CorrelationReturnTerms {
             dividendApplicability:
                 DividendApplicability {
-                    allDividends: fpmlAmount -> dividendsModel -> allDividends,
+                    allDividends: fpmlCorrelationLeg -> amount -> allDividends,
                     ...
                 },
-            expectedN: fpmlAmount -> correlation -> expectedN,
+            expectedN: fpmlCorrelationLeg -> amount -> correlation -> expectedN,
             valuationTerms: empty,
             correlationStrikePrice:
                 Price {
-                    value: fpmlAmount -> correlation -> correlationStrikePrice,
+                    value: fpmlCorrelationLeg -> amount -> correlation -> correlationStrikePrice,
                     priceType: Correlation,
                     ...
                 },
@@ -150,15 +155,15 @@ func MapCorrelationLegToCorrelationReturnTerms:
                 NumberRange {
                     lowerBound:
                         NumberBound {
-                            number: fpmlAmount -> correlation -> boundedCorrelation -> minimumBoundaryPercent,
+                            number: fpmlCorrelationLeg -> amount -> correlation -> boundedCorrelation -> minimumBoundaryPercent,
                             inclusive: empty
                         },
                     upperBound:
                         NumberBound {
-                            number: fpmlAmount -> correlation -> boundedCorrelation -> maximumBoundaryPercent,
+                            number: fpmlCorrelationLeg -> amount -> correlation -> boundedCorrelation -> maximumBoundaryPercent,
                             inclusive: empty
             },},
-            numberOfDataSeries: fpmlAmount -> correlation -> numberOfDataSeries,
+            numberOfDataSeries: fpmlCorrelationLeg -> amount -> correlation -> numberOfDataSeries,
             ...
         }
 
@@ -173,11 +178,13 @@ func MapCorrelationSwapPriceQuantityList:
     add priceQuantityList:
         PriceQuantity {
             quantity: MapNonNegativeMoneyToQuantityWithLocation(
-                        correlationLeg -> amount -> correlation -> notionalAmount,
+                        fpmlCorrelationSwap -> correlationLeg -> amount -> correlation -> notionalAmount,
                         empty,
                         correlationLeg
                     ),
-            observable: MapUnderlyerToObservableWithLocation(correlationLeg -> underlyer),
+            observable: MapUnderlyerToObservableWithLocation(
+                        fpmlCorrelationSwap -> correlationLeg -> underlyer
+                    ),
             ...
         }
 
@@ -190,7 +197,12 @@ func MapCorrelationSwapAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                fpmlCorrelationSwap -> correlationLeg -> payerReceiverModel
-            )
+        fpmlCorrelationSwap -> correlationLeg
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-creditdefaultswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-creditdefaultswap-func.rosetta
@@ -31,18 +31,16 @@ func MapCreditDefaultSwapCounterpartyList:
     output:
         counterpartyList Counterparty (0..2)
 
-    alias buyerSellerModel: fpmlCreditDefaultSwap -> generalTerms -> buyerSellerModel
-
     add counterpartyList:
         MapCounterparty(
                 CounterpartyRoleEnum -> Party1,
-                buyerSellerModel -> sellerPartyReference
+                fpmlCreditDefaultSwap -> generalTerms -> sellerPartyReference
             )
 
     add counterpartyList:
         MapCounterparty(
                 CounterpartyRoleEnum -> Party2,
-                buyerSellerModel -> buyerPartyReference
+                fpmlCreditDefaultSwap -> generalTerms -> buyerPartyReference
             )
 
 func MapCreditDefaultSwapNonTransferableProduct:
@@ -55,8 +53,12 @@ func MapCreditDefaultSwapNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlCreditDefaultSwap -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlCreditDefaultSwap -> productModel),
+            identifier: MapProductIdentifierList(fpmlCreditDefaultSwap -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlCreditDefaultSwap -> primaryAssetClass,
+                        fpmlCreditDefaultSwap -> secondaryAssetClass,
+                        fpmlCreditDefaultSwap -> productType
+                    ),
             economicTerms: MapCreditDefaultSwapEconomicTerms(
                         fpmlCreditDefaultSwap,
                         fpmlTradeHeader,
@@ -99,7 +101,8 @@ func MapCreditDefaultSwapPayoutList:
 
     alias generalTermsPayerReceiver:
         MapSellerAsPayerAndBuyerAsReceiver(
-                fpmlCreditDefaultSwap -> generalTerms -> buyerSellerModel,
+                fpmlCreditDefaultSwap -> generalTerms -> sellerPartyReference,
+                fpmlCreditDefaultSwap -> generalTerms -> buyerPartyReference,
                 cdmCounterpartyList
             )
     add payouts:
@@ -211,7 +214,7 @@ func MapReferenceObligation:
 
     alias seniority:
         if fpmlReferenceObligation -> bond exists
-        then fpmlReferenceObligation -> bond -> fixedIncomeSecurityContentModel -> seniority -> value
+        then fpmlReferenceObligation -> bond -> seniority -> value
 
     set referenceObligation:
         ReferenceObligation {
@@ -235,11 +238,10 @@ func MapCreditIndex:
     output:
         creditIndex CreditIndex (0..1)
 
-    alias indexName:
-        fpmlIndexReferenceInformation -> indexReferenceInformationSequence0 -> indexName
+    alias indexName: fpmlIndexReferenceInformation -> indexName
 
     alias indexId:
-        fpmlIndexReferenceInformation -> indexReferenceInformationSequence0 -> indexId default fpmlIndexReferenceInformation -> indexReferenceInformationSequence1 -> indexId
+        fpmlIndexReferenceInformation -> indexId default fpmlIndexReferenceInformation -> indexId
 
     set creditIndex:
         if fpmlIndexReferenceInformation exists
@@ -248,7 +250,10 @@ func MapCreditIndex:
                         indexName extract MapIndexNameToAssetIdentifier,
                         indexId extract MapIndexIdToAssetIdentifier
                     ],
-                name: MapStringWithScheme(indexName -> value, indexName -> indexNameScheme),
+                name: MapStringWithScheme(
+                            fpmlIndexReferenceInformation -> indexName -> value,
+                            fpmlIndexReferenceInformation -> indexName -> indexNameScheme
+                        ),
                 provider: empty,
                 assetClass: Credit,
                 indexSeries: fpmlIndexReferenceInformation -> indexSeries,
@@ -265,8 +270,8 @@ func MapCreditIndex:
                 settledEntityMatrix: MapSettledEntityMatrix(
                             fpmlIndexReferenceInformation -> settledEntityMatrix
                         ),
-                indexFactor: fpmlIndexReferenceInformation -> indexReferenceInformationSequence2 -> indexFactor,
-                seniority: fpmlIndexReferenceInformation -> indexReferenceInformationSequence2 -> seniority -> value to-enum CreditSeniorityEnum,
+                indexFactor: fpmlIndexReferenceInformation -> indexFactor,
+                seniority: fpmlIndexReferenceInformation -> seniority -> value to-enum CreditSeniorityEnum,
                 ...
             }
 
@@ -292,12 +297,9 @@ func MapBasketReferenceInformation:
     output:
         basketReferenceInformation BasketReferenceInformation (0..1)
 
-    alias basketName:
-        fpmlBasketReferenceInformation -> basketIdentifierModel -> basketIdentifierModelSequence -> basketName
+    alias basketName: fpmlBasketReferenceInformation -> basketName
 
-    alias basketIdList:
-        fpmlBasketReferenceInformation -> basketIdentifierModel
-            extract basketIdentifierModelSequence -> basketId default basketId
+    alias basketIdList: fpmlBasketReferenceInformation -> basketId
 
     set basketReferenceInformation:
         if fpmlBasketReferenceInformation exists
@@ -312,8 +314,8 @@ func MapBasketReferenceInformation:
                         referencePoolItem: fpmlBasketReferenceInformation -> referencePool -> referencePoolItem
                                 extract MapReferencePoolItem
                     },
-                nthToDefault: fpmlBasketReferenceInformation -> basketReferenceInformationSequence -> nthToDefault,
-                mthToDefault: fpmlBasketReferenceInformation -> basketReferenceInformationSequence -> mthToDefault,
+                nthToDefault: fpmlBasketReferenceInformation -> nthToDefault,
+                mthToDefault: fpmlBasketReferenceInformation -> mthToDefault,
                 tranche: MapTranche(fpmlBasketReferenceInformation -> tranche),
             }
 
@@ -692,5 +694,6 @@ func MapCreditDefaultSwapAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlCreditDefaultSwap -> generalTerms -> buyerSellerModel
+                fpmlCreditDefaultSwap -> generalTerms -> buyerAccountReference,
+                fpmlCreditDefaultSwap -> generalTerms -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-creditdefaultswapoption-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-creditdefaultswapoption-func.rosetta
@@ -28,7 +28,8 @@ func MapCreditDefaultSwapOptionCounterpartyList:
 
     add counterpartyList:
         MapBuyerSellerModelToCounterpartyList(
-                fpmlCreditDefaultSwapOption -> buyerSellerModel
+                fpmlCreditDefaultSwapOption -> buyerPartyReference,
+                fpmlCreditDefaultSwapOption -> sellerPartyReference
             )
 
 func MapCreditDefaultSwapOptionAncillaryPartyList:
@@ -58,10 +59,12 @@ func MapCreditDefaultSwapOptionNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(
-                        fpmlCreditDefaultSwapOption -> productModel
+            identifier: MapProductIdentifierList(fpmlCreditDefaultSwapOption -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlCreditDefaultSwapOption -> primaryAssetClass,
+                        fpmlCreditDefaultSwapOption -> secondaryAssetClass,
+                        fpmlCreditDefaultSwapOption -> productType
                     ),
-            taxonomy: MapProductTaxonomyList(fpmlCreditDefaultSwapOption -> productModel),
             economicTerms: MapCreditDefaultSwapOptionEconomicTerms(
                         fpmlCreditDefaultSwapOption,
                         cdmCounterpartyList,
@@ -102,7 +105,8 @@ func MapCreditDefaultSwapOptionPayout:
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlCreditDefaultSwapOption -> buyerSellerModel,
+                                fpmlCreditDefaultSwapOption -> sellerPartyReference,
+                                fpmlCreditDefaultSwapOption -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
@@ -115,9 +119,9 @@ func MapCreditDefaultSwapOptionPayout:
                     principalPayment: empty, // MapPrincipalPayments(fpmlTrade, fpmlPartiesAndAccountsModel),
                     settlementTerms:
                         SettlementTerms {
-                            settlementType: fpmlCreditDefaultSwapOption -> optionSettlementModel -> settlementType to-enum SettlementTypeEnum,
+                            settlementType: fpmlCreditDefaultSwapOption -> settlementType to-enum SettlementTypeEnum,
                             settlementCurrency: MapCurrency(
-                                        fpmlCreditDefaultSwapOption -> optionSettlementModel -> settlementAmountOrCurrencyModel -> settlementCurrency
+                                        fpmlCreditDefaultSwapOption -> settlementCurrency
                                     ),
                             physicalSettlementTerms: MapPhysicalSettlementTermsWithReference(
                                         fpmlCreditDefaultSwapOption
@@ -125,7 +129,8 @@ func MapCreditDefaultSwapOptionPayout:
                             ...
                         },
                     buyerSeller: MapBuyerSeller(
-                                fpmlCreditDefaultSwapOption -> buyerSellerModel,
+                                fpmlCreditDefaultSwapOption -> buyerPartyReference,
+                                fpmlCreditDefaultSwapOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     feature: MapSwapOptionFeature(
@@ -155,7 +160,8 @@ func MapCreditDefaultSwapOptionPayout:
                                 fpmlCreditDefaultSwapOption -> exercise,
                                 fpmlCreditDefaultSwapOption -> exerciseProcedure,
                                 empty,
-                                fpmlCreditDefaultSwapOption -> buyerSellerModel,
+                                fpmlCreditDefaultSwapOption -> buyerPartyReference,
+                                fpmlCreditDefaultSwapOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     strike: MapSwapOptionStrikePrice(
@@ -178,7 +184,7 @@ func MapSwapOptionFeature:
     set feature:
         OptionFeature {
             knock: MapKnock(
-                        fpmlCreditDefaultSwapOption -> feature -> optionFeatureModel -> knock,
+                        fpmlCreditDefaultSwapOption -> feature -> knock,
                         fpmlCreditDefaultSwapOption,
                         cdmCounterpartyList
                     ),
@@ -194,14 +200,13 @@ func MapKnock:
         knock Knock (0..1)
     set knock:
         Knock {
-            knockIn: if fpmlKnock -> knockSequence -> knockIn exists
+            knockIn: if fpmlKnock -> knockIn exists
                     then MapTriggerEvent(
-                            fpmlKnock -> knockSequence -> knockIn,
+                            fpmlKnock -> knockIn,
                             fpmlCreditDefaultSwapOption,
                             cdmCounterpartyList
                         ),
             knockOut: if fpmlKnock -> knockOut exists
-                        or fpmlKnock -> knockSequence -> knockOut exists
                     then MapTriggerEvent(
                             fpmlKnock -> knockOut,
                             fpmlCreditDefaultSwapOption,
@@ -238,7 +243,7 @@ func MapTrigger:
     set trigger:
         Trigger {
             creditEventsReference: MapCreditEventsReferenceWithReference(
-                        fpmlTrigger -> triggerChoice -> creditEventsReference,
+                        fpmlTrigger -> creditEventsReference,
                         fpmlCreditDefaultSwapOption,
                         cdmCounterpartyList
                     ),
@@ -313,7 +318,7 @@ func MapCreditEventsReferenceWithReference:
         } with-meta {
             key: fpmlCreditDefaultSwapOption -> creditDefaultSwap -> protectionTerms -> creditEvents -> id first
         } with-meta {
-            reference: fpmlCreditDefaultSwapOption -> feature -> optionFeatureModel -> knock -> knockOut -> trigger -> triggerChoice -> creditEventsReference -> href
+            reference: fpmlCreditDefaultSwapOption -> feature -> knock -> knockOut -> trigger -> creditEventsReference -> href
         }
 
 func MapPhysicalSettlementTermsWithReference:
@@ -376,5 +381,6 @@ func MapCreditDefaultSwapOptionAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlCreditDefaultSwapOption -> buyerSellerModel
+                fpmlCreditDefaultSwapOption -> buyerAccountReference,
+                fpmlCreditDefaultSwapOption -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-dividendswapoptiontransactionsupplement-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-dividendswapoptiontransactionsupplement-func.rosetta
@@ -21,7 +21,8 @@ func MapDividendSwapOptionTransactionSupplementCounterpartyList:
 
     add counterpartyList:
         MapBuyerSellerModelToCounterpartyList(
-                fpmlDividendSwapOptionTransactionSupplement -> buyerSellerModel
+                fpmlDividendSwapOptionTransactionSupplement -> buyerPartyReference,
+                fpmlDividendSwapOptionTransactionSupplement -> sellerPartyReference
             )
 
 func MapDividendSwapOptionTransactionSupplementAncillaryPartyList:
@@ -46,10 +47,12 @@ func MapDividendSwapOptionTransactionSupplementNonTransferableProduct:
     set nonTransferableProduct:
         NonTransferableProduct {
             identifier: MapProductIdentifierList(
-                        fpmlDividendSwapOptionTransactionSupplement -> productModel
+                        fpmlDividendSwapOptionTransactionSupplement -> productId
                     ),
             taxonomy: MapProductTaxonomyList(
-                        fpmlDividendSwapOptionTransactionSupplement -> productModel
+                        fpmlDividendSwapOptionTransactionSupplement -> primaryAssetClass,
+                        fpmlDividendSwapOptionTransactionSupplement -> secondaryAssetClass,
+                        fpmlDividendSwapOptionTransactionSupplement -> productType
                     ),
             economicTerms: MapDividendSwapOptionTransactionSupplementEconomicTerms(
                         fpmlDividendSwapOptionTransactionSupplement,
@@ -85,7 +88,8 @@ func MapDividendSwapOptionTransactionSupplementPayout:
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlDividendSwapOptionTransactionSupplement -> buyerSellerModel,
+                                fpmlDividendSwapOptionTransactionSupplement -> sellerPartyReference,
+                                fpmlDividendSwapOptionTransactionSupplement -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     settlementTerms: MapEquityExerciseValuationSettlementToSettlementTerms(
@@ -93,7 +97,8 @@ func MapDividendSwapOptionTransactionSupplementPayout:
                                 empty
                             ),
                     buyerSeller: MapBuyerSeller(
-                                fpmlDividendSwapOptionTransactionSupplement -> buyerSellerModel,
+                                fpmlDividendSwapOptionTransactionSupplement -> buyerPartyReference,
+                                fpmlDividendSwapOptionTransactionSupplement -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -114,7 +119,8 @@ func MapDividendSwapOptionTransactionSupplementPayout:
                                     ),
                                 empty,
                                 empty,
-                                fpmlDividendSwapOptionTransactionSupplement -> buyerSellerModel,
+                                fpmlDividendSwapOptionTransactionSupplement -> buyerPartyReference,
+                                fpmlDividendSwapOptionTransactionSupplement -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     ...
@@ -144,5 +150,6 @@ func MapDividendSwapOptionTransactionSupplementAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlDividendSwapOptionTransactionSupplement -> buyerSellerModel
+                fpmlDividendSwapOptionTransactionSupplement -> buyerAccountReference,
+                fpmlDividendSwapOptionTransactionSupplement -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-dividendswaptransactionsupplement-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-dividendswaptransactionsupplement-func.rosetta
@@ -16,6 +16,7 @@ import cdm.product.template.*
 import fpml.consolidated.* as fpml
 import fpml.consolidated.asset.* as fpml
 import fpml.consolidated.dividend.swaps.* as fpml
+import fpml.consolidated.fpmlenum.* as fpml
 import fpml.consolidated.option.shared.* as fpml
 import fpml.consolidated.shared.* as fpml
 
@@ -27,7 +28,8 @@ func MapDividendSwapTransactionSupplementCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlDividendSwapTransactionSupplement -> dividendLeg -> payerReceiverModel
+                fpmlDividendSwapTransactionSupplement -> dividendLeg -> payerPartyReference,
+                fpmlDividendSwapTransactionSupplement -> dividendLeg -> receiverPartyReference
             )
 
 func MapDividendSwapTransactionSupplementNonTransferableProduct:
@@ -40,10 +42,12 @@ func MapDividendSwapTransactionSupplementNonTransferableProduct:
     set nonTransferableProduct:
         NonTransferableProduct {
             identifier: MapProductIdentifierList(
-                        fpmlDividendSwapTransactionSupplement -> productModel
+                        fpmlDividendSwapTransactionSupplement -> productId
                     ),
             taxonomy: MapProductTaxonomyList(
-                        fpmlDividendSwapTransactionSupplement -> productModel
+                        fpmlDividendSwapTransactionSupplement -> primaryAssetClass,
+                        fpmlDividendSwapTransactionSupplement -> secondaryAssetClass,
+                        fpmlDividendSwapTransactionSupplement -> productType
                     ),
             economicTerms: MapDividendSwapTransactionSupplementEconomicTerms(
                         fpmlDividendSwapTransactionSupplement,
@@ -66,8 +70,12 @@ func MapDividendSwapTransactionSupplementEconomicTerms:
                         fpmlDividendSwapTransactionSupplement,
                         cdmCounterpartyList
                     ),
-            effectiveDate: MapAdjustableOrRelativeDate(dividendLeg -> effectiveDate),
-            terminationDate: MapAdjustableOrRelativeDate(dividendLeg -> terminationDate),
+            effectiveDate: MapAdjustableOrRelativeDate(
+                        fpmlDividendSwapTransactionSupplement -> dividendLeg -> effectiveDate
+                    ),
+            terminationDate: MapAdjustableOrRelativeDate(
+                        fpmlDividendSwapTransactionSupplement -> dividendLeg -> terminationDate
+                    ),
             ...
         }
 
@@ -103,14 +111,17 @@ func MapDividendLegToPerformancePayout:
             PerformancePayout:
                 PerformancePayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlDividendLeg -> payerReceiverModel,
+                                fpmlDividendLeg -> payerPartyReference,
+                                fpmlDividendLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     // REMEMBER - Java needed to have priceQuantity populate with multiple dividendPeriods and FixedPayments as no ID's to correctly match
                     paymentDates: empty,
                     valuationDates: empty,
                     settlementTerms: MapOptionSettlementModelToSettlementTerms(
-                                fpmlDividendLeg -> optionSettlementModel
+                                fpmlDividendLeg -> settlementType,
+                                fpmlDividendLeg -> settlementCurrency,
+                                fpmlDividendLeg -> settlementDate
                             ),
                     underlier:
                         Underlier {
@@ -140,25 +151,23 @@ func MapSwapTransactionSupplementDividendReturnTerms:
 
     alias fpmlUnderlyer: fpmlDividendLeg -> underlyer
     alias fpmlDividendPeriodPaymentList: fpmlDividendLeg -> dividendPeriod
-    alias fpmlDividendPercentageModel:
-        fpmlDividendLeg -> declaredCashAndCashEquivalentDividendPercentageModel
 
     set dividendReturnTerms:
         DividendReturnTerms {
-            dividendPayoutRatio: if fpmlUnderlyer -> basket exists
-                    then fpmlUnderlyer -> basket -> basketConstituent
+            dividendPayoutRatio: if fpmlDividendLeg -> underlyer -> basket exists
+                    then fpmlDividendLeg -> underlyer -> basket -> basketConstituent
                     extract
                         DividendPayoutRatio {
-                            totalRatio: dividendPayout -> dividendPayoutSequence -> dividendPayoutRatio,
+                            totalRatio: dividendPayout -> dividendPayoutRatio,
                             basketConstituent: MapBasketConstituentWithAddress,
-                            cashRatio: fpmlDividendPercentageModel -> declaredCashDividendPercentage,
-                            nonCashRatio: fpmlDividendPercentageModel -> declaredCashEquivalentDividendPercentage,
+                            cashRatio: fpmlDividendLeg -> declaredCashDividendPercentage,
+                            nonCashRatio: fpmlDividendLeg -> declaredCashEquivalentDividendPercentage,
                         }
-                else if fpmlUnderlyer -> singleUnderlyer exists
+                else if fpmlDividendLeg -> underlyer -> singleUnderlyer exists
                 then DividendPayoutRatio {
-                        totalRatio: fpmlUnderlyer -> singleUnderlyer -> dividendPayout -> dividendPayoutSequence -> dividendPayoutRatio,
-                        cashRatio: fpmlDividendPercentageModel -> declaredCashDividendPercentage,
-                        nonCashRatio: fpmlDividendPercentageModel -> declaredCashEquivalentDividendPercentage,
+                        totalRatio: fpmlDividendLeg -> underlyer -> singleUnderlyer -> dividendPayout -> dividendPayoutRatio,
+                        cashRatio: fpmlDividendLeg -> declaredCashDividendPercentage,
+                        nonCashRatio: fpmlDividendLeg -> declaredCashEquivalentDividendPercentage,
                         ...
                     },
             dividendPeriod: fpmlDividendPeriodPaymentList
@@ -195,7 +204,8 @@ func MapFixedPaymentLegToFixedPricePayout:
             FixedPricePayout:
                 FixedPricePayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlFixedPaymentLeg -> payerReceiverModel,
+                                fpmlFixedPaymentLeg -> payerPartyReference,
+                                fpmlFixedPaymentLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
@@ -209,6 +219,7 @@ func MapFixedPaymentLegToFixedPricePayout:
                     // REMEMBER - Java needed to have these populate with multiple dividendPeriods and FixedPayments as no IDs to correctly match
                     settlementTerms: MapFixedLegSettlementTerms(
                                 fpmlFixedPaymentLeg,
+                                empty,
                                 empty,
                                 empty,
                                 empty,
@@ -232,7 +243,8 @@ func MapFixedPaymentLegToFixedPricePayout:
 func MapFixedLegSettlementTerms:
     inputs:
         fpmlFixedPaymentLeg fpml.FixedPaymentLeg (0..1)
-        fpmlOptionSettlementModel fpml.OptionSettlementModel (0..1)
+        fpmlSettlementType fpml.SettlementTypeEnum (0..1)
+        fpmlSettlementCurrency fpml.Currency (0..1)
         fpmlRelativeDateOffset fpml.RelativeDateOffset (0..1)
         fpmlUnadjustedDate date (0..1)
         fpmlAdjustableDate fpml.AdjustableDate (0..1)
@@ -241,10 +253,8 @@ func MapFixedLegSettlementTerms:
 
     set settlementTerms:
         SettlementTerms {
-            settlementType: fpmlOptionSettlementModel -> settlementType to-enum SettlementTypeEnum,
-            settlementCurrency: MapCurrency(
-                        fpmlOptionSettlementModel -> settlementAmountOrCurrencyModel -> settlementCurrency
-                    ),
+            settlementType: fpmlSettlementType to-enum SettlementTypeEnum,
+            settlementCurrency: MapCurrency(fpmlSettlementCurrency),
             settlementDate:
                 SettlementDate {
                     adjustableOrRelativeDate: MapAdjustableOrAdjustedOrRelativeDate(
@@ -305,16 +315,16 @@ func MapDividendLegToPriceQuantity:
 
 func MapSingleUnderlyerToNonNegativeQuantityScheduleWithLocation:
     inputs:
-        singleUnderlyer fpml.SingleUnderlyer (0..1)
+        fpmlSingleUnderlyer fpml.SingleUnderlyer (0..1)
     output:
         nonNegativeQuantitySchedule NonNegativeQuantitySchedule (0..1)
             [metadata location]
 
     set nonNegativeQuantitySchedule:
-        if singleUnderlyer -> openUnits exists
+        if fpmlSingleUnderlyer -> openUnits exists
         then CreateQuantityWithLocation(
                     NonNegativeQuantitySchedule {
-                        value: singleUnderlyer -> openUnits,
+                        value: fpmlSingleUnderlyer -> openUnits,
                         unit:
                             UnitType {
                                 financialUnit: Share,
@@ -334,7 +344,12 @@ func MapDividendSwapTransactionSupplementAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                fpmlDividendSwapTransactionSupplement -> dividendLeg -> payerReceiverModel
-            )
+        fpmlDividendSwapTransactionSupplement -> dividendLeg
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-equityforward-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-equityforward-func.rosetta
@@ -26,8 +26,12 @@ func MapEquityForwardNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlEquityForward -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlEquityForward -> productModel),
+            identifier: MapProductIdentifierList(fpmlEquityForward -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlEquityForward -> primaryAssetClass,
+                        fpmlEquityForward -> secondaryAssetClass,
+                        fpmlEquityForward -> productType
+                    ),
             economicTerms: MapEquityForwardEconomicTerms(
                         fpmlEquityForward,
                         cdmCounterpartyList
@@ -76,5 +80,6 @@ func MapEquityForwardAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlEquityForward -> buyerSellerModel
+                fpmlEquityForward -> buyerAccountReference,
+                fpmlEquityForward -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-equityoption-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-equityoption-func.rosetta
@@ -4,10 +4,12 @@ version "${project.version}"
 import cdm.base.math.*
 import cdm.base.staticdata.party.*
 import cdm.ingest.fpml.confirmation.common.*
+import cdm.ingest.fpml.confirmation.datetime.*
 import cdm.ingest.fpml.confirmation.party.*
 import cdm.ingest.fpml.confirmation.pricequantity.*
 import cdm.ingest.fpml.confirmation.settlement.*
 import cdm.observable.asset.*
+import cdm.observable.event.*
 import cdm.product.common.schedule.*
 import cdm.product.common.settlement.*
 import cdm.product.template.*
@@ -24,7 +26,10 @@ func MapEquityOptionCounterpartyList:
         counterpartyList Counterparty (0..2)
 
     add counterpartyList:
-        MapBuyerSellerModelToCounterpartyList(fpmlEquityOption -> buyerSellerModel)
+        MapBuyerSellerModelToCounterpartyList(
+                fpmlEquityOption -> buyerPartyReference,
+                fpmlEquityOption -> sellerPartyReference
+            )
 
 func MapEquityOptionNonTransferableProduct:
     inputs:
@@ -35,8 +40,12 @@ func MapEquityOptionNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlEquityOption -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlEquityOption -> productModel),
+            identifier: MapProductIdentifierList(fpmlEquityOption -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlEquityOption -> primaryAssetClass,
+                        fpmlEquityOption -> secondaryAssetClass,
+                        fpmlEquityOption -> productType
+                    ),
             economicTerms: MapEquityOptionEconomicTerms(
                         fpmlEquityOption,
                         cdmCounterpartyList
@@ -75,17 +84,17 @@ func MapEquityOptionPayout:
         GetUnitTypeForUnderlyingAsset(
                 fpmlEquityOption -> underlyer -> singleUnderlyer -> underlyingAsset
             )
-    alias prm:
-        fpmlEquityOption -> featureModel -> feature -> passThrough -> passThroughItem -> payerReceiverModel only-element
-    alias apo: fpmlEquityOption -> featureModel -> feature -> asian -> averagingPeriodOut
-    alias api: fpmlEquityOption -> featureModel -> feature -> asian -> averagingPeriodIn
+    alias passThroughItem: fpmlEquityOption -> feature -> passThrough -> passThroughItem
+    alias apo: fpmlEquityOption -> feature -> asian -> averagingPeriodOut
+    alias api: fpmlEquityOption -> feature -> asian -> averagingPeriodIn
 
     set payout:
         Payout {
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlEquityOption -> buyerSellerModel,
+                                fpmlEquityOption -> sellerPartyReference,
+                                fpmlEquityOption -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
@@ -101,7 +110,8 @@ func MapEquityOptionPayout:
                                 empty
                             ),
                     buyerSeller: MapBuyerSeller(
-                                fpmlEquityOption -> buyerSellerModel,
+                                fpmlEquityOption -> buyerPartyReference,
+                                fpmlEquityOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     feature:
@@ -134,13 +144,18 @@ func MapEquityOptionPayout:
                                 PassThrough {
                                     passThroughItem:
                                         PassThroughItem {
-                                            payerReceiver: prm
-                                                    extract
-                                                        MapPayerReceiver(
-                                                                item,
+                                            payerReceiver:
+                                                PayerReceiver {
+                                                    payer: MapCounterpartyRoleEnum(
+                                                                passThroughItem only-element -> payerPartyReference -> href,
                                                                 cdmCounterpartyList
                                                             ),
-                                            passThroughPercentage: fpmlEquityOption -> featureModel -> feature -> passThrough -> passThroughItem -> passThroughPercentage only-element
+                                                    receiver: MapCounterpartyRoleEnum(
+                                                                passThroughItem only-element -> receiverPartyReference -> href,
+                                                                cdmCounterpartyList
+                                                            )
+                                                },
+                                            passThroughPercentage: passThroughItem only-element -> passThroughPercentage
                             },},
                             ...
                         },
@@ -155,13 +170,14 @@ func MapEquityOptionPayout:
                     exerciseTerms: MapExerciseTerms(
                                 GetFpmlEquityExercise(fpmlEquityOption -> equityExercise),
                                 empty,
-                                fpmlEquityOption -> equityExercise -> equityExerciseValuationSettlementSequence -> automaticExercise,
-                                fpmlEquityOption -> buyerSellerModel,
+                                fpmlEquityOption -> equityExercise -> automaticExercise,
+                                fpmlEquityOption -> buyerPartyReference,
+                                fpmlEquityOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     strike: MapOptionStrikePrice(
                                 fpmlEquityOption -> strike -> strikePrice,
-                                fpmlEquityOption -> strike -> equityStrikeSequence -> strikePercentage,
+                                fpmlEquityOption -> strike -> strikePercentage,
                                 unit,
                                 perUnitOf
                             ),
@@ -172,11 +188,11 @@ func MapEquityOptionPayout:
 
 func MapAveragingObservations:
     inputs:
-        averagingObservationList fpml.AveragingObservationList (0..*)
+        fpmlAveragingObservationList fpml.AveragingObservationList (0..*)
     output:
         observationList AveragingObservationList (0..*)
 
-    alias averagingObservation: averagingObservationList -> averagingObservation first
+    alias averagingObservation: fpmlAveragingObservationList -> averagingObservation first
 
     add observationList:
         AveragingObservationList {
@@ -216,5 +232,6 @@ func MapEquityOptionAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlEquityOption -> buyerSellerModel
+                fpmlEquityOption -> buyerAccountReference,
+                fpmlEquityOption -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-equityoptiontransactionsupplement-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-equityoptiontransactionsupplement-func.rosetta
@@ -23,7 +23,8 @@ func MapEquityOptionTransactionSupplementCounterpartyList:
 
     add counterpartyList:
         MapBuyerSellerModelToCounterpartyList(
-                fpmlEquityOptionTransactionSupplement -> buyerSellerModel
+                fpmlEquityOptionTransactionSupplement -> buyerPartyReference,
+                fpmlEquityOptionTransactionSupplement -> sellerPartyReference
             )
 
 func MapEquityOptionTransactionSupplementNonTransferableProduct:
@@ -36,10 +37,12 @@ func MapEquityOptionTransactionSupplementNonTransferableProduct:
     set nonTransferableProduct:
         NonTransferableProduct {
             identifier: MapProductIdentifierList(
-                        fpmlEquityOptionTransactionSupplement -> productModel
+                        fpmlEquityOptionTransactionSupplement -> productId
                     ),
             taxonomy: MapProductTaxonomyList(
-                        fpmlEquityOptionTransactionSupplement -> productModel
+                        fpmlEquityOptionTransactionSupplement -> primaryAssetClass,
+                        fpmlEquityOptionTransactionSupplement -> secondaryAssetClass,
+                        fpmlEquityOptionTransactionSupplement -> productType
                     ),
             economicTerms: MapEquityOptionTransactionSupplementEconomicTerms(
                         fpmlEquityOptionTransactionSupplement,
@@ -88,7 +91,8 @@ func MapEquityOptionTransactionSupplementPayout:
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlEquityOptionTransactionSupplement -> buyerSellerModel,
+                                fpmlEquityOptionTransactionSupplement -> sellerPartyReference,
+                                fpmlEquityOptionTransactionSupplement -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
@@ -104,7 +108,8 @@ func MapEquityOptionTransactionSupplementPayout:
                                 empty
                             ),
                     buyerSeller: MapBuyerSeller(
-                                fpmlEquityOptionTransactionSupplement -> buyerSellerModel,
+                                fpmlEquityOptionTransactionSupplement -> buyerPartyReference,
+                                fpmlEquityOptionTransactionSupplement -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -120,13 +125,14 @@ func MapEquityOptionTransactionSupplementPayout:
                                         fpmlEquityOptionTransactionSupplement -> equityExercise
                                     ),
                                 empty,
-                                fpmlEquityOptionTransactionSupplement -> equityExercise -> equityExerciseValuationSettlementSequence -> automaticExercise,
-                                fpmlEquityOptionTransactionSupplement -> buyerSellerModel,
+                                fpmlEquityOptionTransactionSupplement -> equityExercise -> automaticExercise,
+                                fpmlEquityOptionTransactionSupplement -> buyerPartyReference,
+                                fpmlEquityOptionTransactionSupplement -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     strike: MapOptionStrikePrice(
                                 fpmlEquityOptionTransactionSupplement -> strike -> strikePrice,
-                                fpmlEquityOptionTransactionSupplement -> strike -> equityStrikeSequence -> strikePercentage,
+                                fpmlEquityOptionTransactionSupplement -> strike -> strikePercentage,
                                 unit,
                                 perUnitOf
                             ),
@@ -166,5 +172,6 @@ func MapEquityOptionTransactionSupplementAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlEquityOptionTransactionSupplement -> buyerSellerModel
+                fpmlEquityOptionTransactionSupplement -> buyerAccountReference,
+                fpmlEquityOptionTransactionSupplement -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-equityswaptransactionsupplement-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-equityswaptransactionsupplement-func.rosetta
@@ -22,7 +22,8 @@ func MapEquitySwapTransactionSupplementCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlEquitySwapTransactionSupplement -> returnSwapLeg first -> payerReceiverModel
+                fpmlEquitySwapTransactionSupplement -> returnSwapLeg first -> payerPartyReference,
+                fpmlEquitySwapTransactionSupplement -> returnSwapLeg first -> receiverPartyReference
             )
 
 func MapEquitySwapTransactionSupplementNonTransferableProduct:
@@ -35,10 +36,12 @@ func MapEquitySwapTransactionSupplementNonTransferableProduct:
     set nonTransferableProduct:
         NonTransferableProduct {
             identifier: MapProductIdentifierList(
-                        fpmlEquitySwapTransactionSupplement -> productModel
+                        fpmlEquitySwapTransactionSupplement -> productId
                     ),
             taxonomy: MapProductTaxonomyList(
-                        fpmlEquitySwapTransactionSupplement -> productModel
+                        fpmlEquitySwapTransactionSupplement -> primaryAssetClass,
+                        fpmlEquitySwapTransactionSupplement -> secondaryAssetClass,
+                        fpmlEquitySwapTransactionSupplement -> productType
                     ),
             economicTerms: MapEquitySwapTransactionSupplementEconomicTerms(
                         fpmlEquitySwapTransactionSupplement,
@@ -153,5 +156,6 @@ func MapEquitySwapTransactionSupplementAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlEquitySwapTransactionSupplement -> buyerSellerModel
+                fpmlEquitySwapTransactionSupplement -> buyerAccountReference,
+                fpmlEquitySwapTransactionSupplement -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fra-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fra-func.rosetta
@@ -26,7 +26,11 @@ func MapFraCounterpartyList:
     output:
         counterpartyList Counterparty (0..2)
 
-    add counterpartyList: MapBuyerSellerModelToCounterpartyList(fpmlFra -> buyerSellerModel)
+    add counterpartyList:
+        MapBuyerSellerModelToCounterpartyList(
+                fpmlFra -> buyerPartyReference,
+                fpmlFra -> sellerPartyReference
+            )
 
 func MapFraNonTransferableProduct:
     inputs:
@@ -37,8 +41,12 @@ func MapFraNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlFra -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlFra -> productModel),
+            identifier: MapProductIdentifierList(fpmlFra -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlFra -> primaryAssetClass,
+                        fpmlFra -> secondaryAssetClass,
+                        fpmlFra -> productType
+                    ),
             economicTerms: MapFraEconomicTerms(fpmlFra, cdmCounterpartyList)
         }
 
@@ -63,7 +71,11 @@ func MapFraPayoutList:
         payoutList Payout (0..2)
 
     alias floatingPayerReceiver:
-        MapSellerAsPayerAndBuyerAsReceiver(fpmlFra -> buyerSellerModel, cdmCounterpartyList)
+        MapSellerAsPayerAndBuyerAsReceiver(
+                fpmlFra -> sellerPartyReference,
+                fpmlFra -> buyerPartyReference,
+                cdmCounterpartyList
+            )
 
     alias dayCountFraction: MapDayCountFractionEnum(fpmlFra -> dayCountFraction -> value)
 
@@ -300,20 +312,24 @@ func MapFraAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapBuyerSellerToAccountPartyReference(fpmlAccount, fpmlFra -> buyerSellerModel)
+        MapBuyerSellerToAccountPartyReference(
+                fpmlAccount,
+                fpmlFra -> buyerAccountReference,
+                fpmlFra -> sellerAccountReference
+            )
 
 func FixedLeg:
     output:
-        fixedLeg fpml.Leg (1..1)
-    set fixedLeg:
+        fpmlFixedLeg fpml.Leg (1..1)
+    set fpmlFixedLeg:
         fpml.Leg {
             id: "fixedLeg"
         }
 
 func FloatingLeg:
     output:
-        floatingLeg fpml.Leg (1..1)
-    set floatingLeg:
+        fpmlFloatingLeg fpml.Leg (1..1)
+    set fpmlFloatingLeg:
         fpml.Leg {
             id: "floatingLeg"
         }

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxdigitaloption-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxdigitaloption-func.rosetta
@@ -19,8 +19,12 @@ func MapFxDigitalOptionNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlFxDigitalOption -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlFxDigitalOption -> productModel),
+            identifier: MapProductIdentifierList(fpmlFxDigitalOption -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlFxDigitalOption -> primaryAssetClass,
+                        fpmlFxDigitalOption -> secondaryAssetClass,
+                        fpmlFxDigitalOption -> productType
+                    ),
             economicTerms: MapFxDigitalOptionEconomicTerms(
                         fpmlFxDigitalOption,
                         cdmCounterpartyList
@@ -34,7 +38,10 @@ func MapFxDigitalOptionCounterpartyList:
         counterpartyList Counterparty (0..2)
 
     add counterpartyList:
-        MapBuyerSellerModelToCounterpartyList(fpmlFxDigitalOption -> buyerSellerModel)
+        MapBuyerSellerModelToCounterpartyList(
+                fpmlFxDigitalOption -> buyerPartyReference,
+                fpmlFxDigitalOption -> sellerPartyReference
+            )
 
 func MapFxDigitalOptionAncillaryPartyList:
     inputs:
@@ -74,14 +81,16 @@ func MapFxDigitalOptionPayout:
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlFxDigitalOption -> buyerSellerModel,
+                                fpmlFxDigitalOption -> sellerPartyReference,
+                                fpmlFxDigitalOption -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     settlementTerms: MapFxDigitalOptionToSettlementTerms(
                                 fpmlFxDigitalOption
                             ),
                     buyerSeller: MapBuyerSeller(
-                                fpmlFxDigitalOption -> buyerSellerModel,
+                                fpmlFxDigitalOption -> buyerPartyReference,
+                                fpmlFxDigitalOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier: empty,
@@ -89,7 +98,8 @@ func MapFxDigitalOptionPayout:
                                 GetFpmlFxDigitalExercise(fpmlFxDigitalOption),
                                 fpmlFxDigitalOption -> exerciseProcedure,
                                 empty,
-                                fpmlFxDigitalOption -> buyerSellerModel,
+                                fpmlFxDigitalOption -> buyerPartyReference,
+                                fpmlFxDigitalOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     ...

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxoption-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxoption-func.rosetta
@@ -26,7 +26,10 @@ func MapFxOptionCounterpartyList:
         counterpartyList Counterparty (0..2)
 
     add counterpartyList:
-        MapBuyerSellerModelToCounterpartyList(fpmlFxOption -> buyerSellerModel)
+        MapBuyerSellerModelToCounterpartyList(
+                fpmlFxOption -> buyerPartyReference,
+                fpmlFxOption -> sellerPartyReference
+            )
 
 func MapFxOptionAncillaryPartyList:
     inputs:
@@ -50,8 +53,12 @@ func MapFxOptionNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlFxOption -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlFxOption -> productModel),
+            identifier: MapProductIdentifierList(fpmlFxOption -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlFxOption -> primaryAssetClass,
+                        fpmlFxOption -> secondaryAssetClass,
+                        fpmlFxOption -> productType
+                    ),
             economicTerms: MapFxOptionEconomicTerms(fpmlFxOption, cdmCounterpartyList)
         }
 
@@ -83,7 +90,8 @@ func MapFxOptionPayout:
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlFxOption -> buyerSellerModel,
+                                fpmlFxOption -> sellerPartyReference,
+                                fpmlFxOption -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
@@ -93,7 +101,8 @@ func MapFxOptionPayout:
                         },
                     settlementTerms: MapFxOptionToSettlementTerms(fpmlFxOption),
                     buyerSeller: MapBuyerSeller(
-                                fpmlFxOption -> buyerSellerModel,
+                                fpmlFxOption -> buyerPartyReference,
+                                fpmlFxOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     observationTerms: MapFxOptionFeaturesToObservationTerms(
@@ -115,7 +124,8 @@ func MapFxOptionPayout:
                                 GetFpmlFxExercise(fpmlFxOption),
                                 fpmlFxOption -> exerciseProcedure,
                                 empty,
-                                fpmlFxOption -> buyerSellerModel,
+                                fpmlFxOption -> buyerPartyReference,
+                                fpmlFxOption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     strike: MapFxOptionStrikePrice(fpmlFxOption),
@@ -131,7 +141,7 @@ func MapFxOptionFeaturesToObservationTerms:
         observationTerms ObservationTerms (0..1)
 
     set observationTerms:
-        fpmlFeatures -> fxOptionFeaturesSequence -> asian
+        fpmlFeatures -> asian
             then extract
                 ObservationTerms {
                     observationTime: MapBusinessCenterTime(fixingTime),
@@ -141,7 +151,7 @@ func MapFxOptionFeaturesToObservationTerms:
                             ...
                         },
                     observationDates: MapObservationScheduleToObservationDates(
-                                fxAsianFeatureSequence -> observationSchedule
+                                observationSchedule
                             ),
                     ...
                 }
@@ -185,8 +195,9 @@ func GetExchangedCurrencyAmount:
     inputs:
         fpmlFxOption fpml.FxOption (0..1)
     output:
-        nonNegativeMoney fpml.NonNegativeMoney (0..1)
-    set nonNegativeMoney:
+        fpmlNonNegativeMoney fpml.NonNegativeMoney (0..1)
+
+    set fpmlNonNegativeMoney:
         if fpmlFxOption -> strike -> strikeQuoteBasis = CallCurrencyPerPutCurrency
         then fpmlFxOption -> putCurrencyAmount
         else fpmlFxOption -> callCurrencyAmount
@@ -261,4 +272,8 @@ func MapFxOptionAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapBuyerSellerToAccountPartyReference(fpmlAccount, fpmlFxOption -> buyerSellerModel)
+        MapBuyerSellerToAccountPartyReference(
+                fpmlAccount,
+                fpmlFxOption -> buyerAccountReference,
+                fpmlFxOption -> sellerAccountReference
+            )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxsingleleg-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxsingleleg-func.rosetta
@@ -20,9 +20,17 @@ func MapFxSingleLegCounterpartyList:
     output:
         counterpartyList Counterparty (0..2)
 
+    alias fpmlExchangedCurrency:
+        GetFpmlExchangedCurrency(
+                fpmlFxSingleLeg -> exchangeRate,
+                fpmlFxSingleLeg -> exchangedCurrency1,
+                fpmlFxSingleLeg -> exchangedCurrency2
+            )
+
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                GetFpmlExchangedCurrency(fpmlFxSingleLeg -> fxCoreDetailsModel) -> payerReceiverModel
+                fpmlExchangedCurrency -> payerPartyReference,
+                fpmlExchangedCurrency -> receiverPartyReference
             )
 
 func MapFxSingleLegNonTransferableProduct:
@@ -34,8 +42,12 @@ func MapFxSingleLegNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlFxSingleLeg -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlFxSingleLeg -> productModel),
+            identifier: MapProductIdentifierList(fpmlFxSingleLeg -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlFxSingleLeg -> primaryAssetClass,
+                        fpmlFxSingleLeg -> secondaryAssetClass,
+                        fpmlFxSingleLeg -> productType
+                    ),
             economicTerms: MapFxSingleLegEconomicTerms(fpmlFxSingleLeg, cdmCounterpartyList)
         }
 
@@ -49,7 +61,11 @@ func MapFxSingleLegEconomicTerms:
     set economicTerms:
         EconomicTerms {
             payout: MapFxCoreDetailsModelToSettlementPayout(
-                        fpmlFxSingleLeg -> fxCoreDetailsModel,
+                        fpmlFxSingleLeg -> exchangeRate,
+                        fpmlFxSingleLeg -> exchangedCurrency1,
+                        fpmlFxSingleLeg -> exchangedCurrency2,
+                        fpmlFxSingleLeg -> nonDeliverableSettlement,
+                        fpmlFxSingleLeg -> valueDate,
                         empty,
                         cdmCounterpartyList
                     ),
@@ -58,37 +74,47 @@ func MapFxSingleLegEconomicTerms:
 
 func MapFxCoreDetailsModelToSettlementPayout:
     inputs:
-        fpmlFxCoreDetailsModel fpml.FxCoreDetailsModel (0..1)
+        fpmlExchangeRate fpml.ExchangeRate (0..1)
+        fpmlExchangedCurrency1 fpml.Payment (0..1)
+        fpmlExchangedCurrency2 fpml.Payment (0..1)
+        fpmlNonDeliverableSettlement fpml.FxCashSettlement (0..1)
+        valueDate zonedDateTime (0..1)
         fpmlLeg fpml.Leg (0..1)
         cdmCounterpartyList Counterparty (0..2)
     output:
         payout Payout (0..1)
 
-    alias exchangedCurrency: GetFpmlExchangedCurrency(fpmlFxCoreDetailsModel)
+    alias exchangedCurrency:
+        GetFpmlExchangedCurrency(
+                fpmlExchangeRate,
+                fpmlExchangedCurrency1,
+                fpmlExchangedCurrency2
+            )
 
     set payout:
         Payout {
             SettlementPayout:
                 SettlementPayout {
                     payerReceiver: MapPayerReceiver(
-                                exchangedCurrency -> payerReceiverModel,
+                                exchangedCurrency -> payerPartyReference,
+                                exchangedCurrency -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
                         ResolvablePriceQuantity {
                             quantitySchedule: MapFxCoreDetailsModelQuantityWithAddress(
-                                        fpmlFxCoreDetailsModel,
+                                        fpmlExchangeRate,
                                         fpmlLeg
                                     ),
                             priceSchedule: MapFxCoreDetailsModelPriceWithAddress(
-                                        fpmlFxCoreDetailsModel,
+                                        fpmlExchangeRate,
                                         fpmlLeg
                                     ),
                             ...
                         },
                     settlementTerms: MapFxCashSettlementToSettlementTerms(
-                                fpmlFxCoreDetailsModel -> nonDeliverableSettlement,
-                                fpmlFxCoreDetailsModel -> valueDate -> date
+                                fpmlNonDeliverableSettlement,
+                                valueDate -> date
                             ),
                     underlier:
                         Underlier {
@@ -110,7 +136,12 @@ func MapFxSingleLegPriceQuantityList:
         priceQuantityList PriceQuantity (0..*)
 
     add priceQuantityList:
-        MapFxCoreDetailsModelPriceQuantityList(fpmlFxSingleLeg -> fxCoreDetailsModel, empty)
+        MapFxCoreDetailsModelPriceQuantityList(
+                fpmlFxSingleLeg -> exchangeRate,
+                fpmlFxSingleLeg -> exchangedCurrency1,
+                fpmlFxSingleLeg -> exchangedCurrency2,
+                empty
+            )
 
 func MapFxSingleLegAccountPartyReference:
     inputs:
@@ -121,7 +152,14 @@ func MapFxSingleLegAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                [fpmlFxSingleLeg -> fxCoreDetailsModel -> exchangedCurrency1 -> payerReceiverModel, fpmlFxSingleLeg -> fxCoreDetailsModel -> exchangedCurrency2 -> payerReceiverModel]
-            )
+        [fpmlFxSingleLeg -> exchangedCurrency1, fpmlFxSingleLeg -> exchangedCurrency2]
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )
+            then filter reference exists
+            then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxsingleleg-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxsingleleg-func.rosetta
@@ -161,5 +161,5 @@ func MapFxSingleLegAccountPartyReference:
                         payerPartyReference,
                         receiverPartyReference
                     )
-            then filter reference exists
+                        // then filter reference exists (TODO: bring this back when Python code generator can handle this syntax)
             then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxswap-func.rosetta
@@ -21,7 +21,8 @@ func MapFxSwapCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlFxSwap -> nearLeg -> fxCoreDetailsModel -> exchangedCurrency1 -> payerReceiverModel
+                fpmlFxSwap -> nearLeg -> exchangedCurrency1 -> payerPartyReference,
+                fpmlFxSwap -> nearLeg -> exchangedCurrency1 -> receiverPartyReference
             )
 
 func MapFxSwapNonTransferableProduct:
@@ -33,8 +34,12 @@ func MapFxSwapNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlFxSwap -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlFxSwap -> productModel),
+            identifier: MapProductIdentifierList(fpmlFxSwap -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlFxSwap -> primaryAssetClass,
+                        fpmlFxSwap -> secondaryAssetClass,
+                        fpmlFxSwap -> productType
+                    ),
             economicTerms: MapFxSwapEconomicTerms(fpmlFxSwap, cdmCounterpartyList)
         }
 
@@ -60,14 +65,22 @@ func MapFxSwapPayoutList:
 
     add payoutList:
         MapFxCoreDetailsModelToSettlementPayout(
-                fpmlFxSwap -> nearLeg -> fxCoreDetailsModel,
+                fpmlFxSwap -> nearLeg -> exchangeRate,
+                fpmlFxSwap -> nearLeg -> exchangedCurrency1,
+                fpmlFxSwap -> nearLeg -> exchangedCurrency2,
+                fpmlFxSwap -> nearLeg -> nonDeliverableSettlement,
+                fpmlFxSwap -> nearLeg -> valueDate,
                 fpmlFxSwap -> nearLeg,
                 cdmCounterpartyList
             )
 
     add payoutList:
         MapFxCoreDetailsModelToSettlementPayout(
-                fpmlFxSwap -> farLeg -> fxCoreDetailsModel,
+                fpmlFxSwap -> farLeg -> exchangeRate,
+                fpmlFxSwap -> farLeg -> exchangedCurrency1,
+                fpmlFxSwap -> farLeg -> exchangedCurrency2,
+                fpmlFxSwap -> farLeg -> nonDeliverableSettlement,
+                fpmlFxSwap -> farLeg -> valueDate,
                 fpmlFxSwap -> farLeg,
                 cdmCounterpartyList
             )
@@ -80,13 +93,17 @@ func MapFxSwapPriceQuantityList:
 
     add priceQuantityList:
         MapFxCoreDetailsModelPriceQuantityList(
-                fpmlFxSwap -> nearLeg -> fxCoreDetailsModel,
+                fpmlFxSwap -> nearLeg -> exchangeRate,
+                fpmlFxSwap -> nearLeg -> exchangedCurrency1,
+                fpmlFxSwap -> nearLeg -> exchangedCurrency2,
                 fpmlFxSwap -> nearLeg
             )
 
     add priceQuantityList:
         MapFxCoreDetailsModelPriceQuantityList(
-                fpmlFxSwap -> farLeg -> fxCoreDetailsModel,
+                fpmlFxSwap -> farLeg -> exchangeRate,
+                fpmlFxSwap -> farLeg -> exchangedCurrency1,
+                fpmlFxSwap -> farLeg -> exchangedCurrency2,
                 fpmlFxSwap -> farLeg
             )
 
@@ -99,7 +116,14 @@ func MapFxSwapAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                [fpmlFxSwap -> nearLeg -> fxCoreDetailsModel -> exchangedCurrency1 -> payerReceiverModel, fpmlFxSwap -> nearLeg -> fxCoreDetailsModel -> exchangedCurrency2 -> payerReceiverModel, fpmlFxSwap -> farLeg -> fxCoreDetailsModel -> exchangedCurrency1 -> payerReceiverModel, fpmlFxSwap -> farLeg -> fxCoreDetailsModel -> exchangedCurrency2 -> payerReceiverModel]
-            )
+        [fpmlFxSwap -> nearLeg -> exchangedCurrency1, fpmlFxSwap -> nearLeg -> exchangedCurrency2, fpmlFxSwap -> farLeg -> exchangedCurrency1, fpmlFxSwap -> farLeg -> exchangedCurrency2]
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )
+            then filter reference exists
+            then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxswap-func.rosetta
@@ -125,5 +125,5 @@ func MapFxSwapAccountPartyReference:
                         payerPartyReference,
                         receiverPartyReference
                     )
-            then filter reference exists
+                        // then filter reference exists (TODO: bring this back when Python code generator can handle this syntax)
             then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxvarianceswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxvarianceswap-func.rosetta
@@ -27,12 +27,12 @@ func MapFxVarianceSwapCounterpartyList:
     add counterpartyList:
         MapCounterparty(
                 CounterpartyRoleEnum -> Party1,
-                fpmlFxVarianceSwap -> floatingLeg -> payerModel -> payerPartyReference
+                fpmlFxVarianceSwap -> floatingLeg -> payerPartyReference
             )
     add counterpartyList:
         MapCounterparty(
                 CounterpartyRoleEnum -> Party2,
-                fpmlFxVarianceSwap -> fixedLeg -> payerModel -> payerPartyReference
+                fpmlFxVarianceSwap -> fixedLeg -> payerPartyReference
             )
 
 func MapFxVarianceSwapNonTransferableProduct:
@@ -44,8 +44,12 @@ func MapFxVarianceSwapNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlFxVarianceSwap -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlFxVarianceSwap -> productModel),
+            identifier: MapProductIdentifierList(fpmlFxVarianceSwap -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlFxVarianceSwap -> primaryAssetClass,
+                        fpmlFxVarianceSwap -> secondaryAssetClass,
+                        fpmlFxVarianceSwap -> productType
+                    ),
             economicTerms: MapFxVarianceSwapEconomicTerms(
                         fpmlFxVarianceSwap,
                         cdmCounterpartyList
@@ -84,11 +88,11 @@ func MapFxVarianceSwapPayout:
                     payerReceiver:
                         PayerReceiver {
                             payer: MapCounterpartyRoleEnum(
-                                        fpmlFxVarianceSwap -> floatingLeg -> payerModel -> payerPartyReference -> href,
+                                        fpmlFxVarianceSwap -> floatingLeg -> payerPartyReference -> href,
                                         cdmCounterpartyList
                                     ),
                             receiver: MapCounterpartyRoleEnum(
-                                        fpmlFxVarianceSwap -> fixedLeg -> payerModel -> payerPartyReference -> href,
+                                        fpmlFxVarianceSwap -> fixedLeg -> payerPartyReference -> href,
                                         cdmCounterpartyList
                                     )
                         },
@@ -166,12 +170,12 @@ func MapFxPerformanceSwapToObservationTerms:
     set observationTerms:
         ObservationTerms {
             observationTime: MapBusinessCenterTime(
-                        fpmlFixingInformationSource -> fixingTime
+                        fpmlFxPerformanceSwap -> fixingInformationSource -> fixingTime
                     ),
             informationSource:
                 FxSpotRateSource {
                     primarySource: MapInformationSource(
-                                fpmlFixingInformationSource -> primaryRateSource
+                                fpmlFxPerformanceSwap -> fixingInformationSource -> primaryRateSource
                             ),
                     ...
                 },
@@ -193,14 +197,14 @@ func MapFxFixingScheduleToObservationDates:
             periodicSchedule:
                 PeriodicDates {
                     startDate: MapUnadjustedDateToAdjustableOrRelativeDate(
-                                if fpmlFixingSchedule -> fxFixingScheduleSimpleSequence -> startDate exists
-                                then fpmlFixingSchedule -> fxFixingScheduleSimpleSequence -> startDate -> date
+                                if fpmlFixingSchedule -> startDate exists
+                                then fpmlFixingSchedule -> startDate -> date
                                 else fpmlFixingSchedule -> startDate -> date,
                                 empty
                             ),
                     endDate: MapUnadjustedDateToAdjustableOrRelativeDate(
-                                if fpmlFixingSchedule -> fxFixingScheduleSimpleSequence -> endDate exists
-                                then fpmlFixingSchedule -> fxFixingScheduleSimpleSequence -> endDate -> date
+                                if fpmlFixingSchedule -> endDate exists
+                                then fpmlFixingSchedule -> endDate -> date
                                 else fpmlFixingSchedule -> endDate -> date,
                                 empty
                             ),
@@ -208,7 +212,8 @@ func MapFxFixingScheduleToObservationDates:
                         BusinessDayAdjustments {
                             businessDayConvention: empty,
                             businessCenters: MapBusinessCenterOrBusinessCenterReference(
-                                        fpmlFixingSchedule -> businessCentersOrReferenceModel
+                                        fpmlFixingSchedule -> businessCenters,
+                                        fpmlFixingSchedule -> businessCentersReference
                             ),
                         },
                     dayType: fpmlFixingSchedule -> dayType to-enum DayTypeEnum,
@@ -236,7 +241,7 @@ func MapFxValuationDateOffsetToValuationDates:
                                     period: fpmlFxValuationDateOffset -> period to-enum PeriodEnum,
                                     dayType: fpmlFxValuationDateOffset -> dayType to-enum DayTypeEnum,
                                     businessCenters: MapBusinessCenters(
-                                                fpmlFxValuationDateOffset -> businessCentersOrReferenceModel -> businessCenters
+                                                fpmlFxValuationDateOffset -> businessCenters
                                             ),
                                     ...
                                 },
@@ -269,17 +274,17 @@ func MapFxPerformanceSwapToReturnTerms:
                             unit:
                                 UnitType {
                                     currency: if fpmlQuoteBasis = Currency1PerCurrency2
-                                            then fpmlQuotedCurrencyPair -> currency1 -> value
+                                            then fpmlFxPerformanceSwap -> quotedCurrencyPair -> currency1 -> value
                                         else if fpmlQuoteBasis = Currency2PerCurrency1
-                                        then fpmlQuotedCurrencyPair -> currency2 -> value,
+                                        then fpmlFxPerformanceSwap -> quotedCurrencyPair -> currency2 -> value,
                                     ...
                                 },
                             perUnitOf:
                                 UnitType {
                                     currency: if fpmlQuoteBasis = Currency1PerCurrency2
-                                            then fpmlQuotedCurrencyPair -> currency2 -> value
+                                            then fpmlFxPerformanceSwap -> quotedCurrencyPair -> currency2 -> value
                                         else if fpmlQuoteBasis = Currency2PerCurrency1
-                                        then fpmlQuotedCurrencyPair -> currency1 -> value,
+                                        then fpmlFxPerformanceSwap -> quotedCurrencyPair -> currency1 -> value,
                                     ...
                                 },
                             priceType: InterestRate,

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxvolatilityswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-fxvolatilityswap-func.rosetta
@@ -23,12 +23,12 @@ func MapFxVolatilitySwapCounterpartyList:
     add counterpartyList:
         MapCounterparty(
                 CounterpartyRoleEnum -> Party1,
-                fpmlFxVolatilitySwap -> floatingLeg -> payerModel -> payerPartyReference
+                fpmlFxVolatilitySwap -> floatingLeg -> payerPartyReference
             )
     add counterpartyList:
         MapCounterparty(
                 CounterpartyRoleEnum -> Party2,
-                fpmlFxVolatilitySwap -> fixedLeg -> payerModel -> payerPartyReference
+                fpmlFxVolatilitySwap -> fixedLeg -> payerPartyReference
             )
 
 func MapFxVolatilitySwapNonTransferableProduct:
@@ -40,8 +40,12 @@ func MapFxVolatilitySwapNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlFxVolatilitySwap -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlFxVolatilitySwap -> productModel),
+            identifier: MapProductIdentifierList(fpmlFxVolatilitySwap -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlFxVolatilitySwap -> primaryAssetClass,
+                        fpmlFxVolatilitySwap -> secondaryAssetClass,
+                        fpmlFxVolatilitySwap -> productType
+                    ),
             economicTerms: MapFxVolatilitySwapEconomicTerms(
                         fpmlFxVolatilitySwap,
                         cdmCounterpartyList
@@ -96,17 +100,17 @@ func MapFxVolatilitySwapReturnTerms:
                             unit:
                                 UnitType {
                                     currency: if fpmlQuoteBasis = Currency1PerCurrency2
-                                            then fpmlQuotedCurrencyPair -> currency1 -> value
+                                            then fpmlFxPerformanceSwap -> quotedCurrencyPair -> currency1 -> value
                                         else if fpmlQuoteBasis = Currency2PerCurrency1
-                                        then fpmlQuotedCurrencyPair -> currency2 -> value,
+                                        then fpmlFxPerformanceSwap -> quotedCurrencyPair -> currency2 -> value,
                                     ...
                                 },
                             perUnitOf:
                                 UnitType {
                                     currency: if fpmlQuoteBasis = Currency1PerCurrency2
-                                            then fpmlQuotedCurrencyPair -> currency2 -> value
+                                            then fpmlFxPerformanceSwap -> quotedCurrencyPair -> currency2 -> value
                                         else if fpmlQuoteBasis = Currency2PerCurrency1
-                                        then fpmlQuotedCurrencyPair -> currency1 -> value,
+                                        then fpmlFxPerformanceSwap -> quotedCurrencyPair -> currency1 -> value,
                                     ...
                                 },
                             priceType: InterestRate,

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-genericproduct-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-genericproduct-func.rosetta
@@ -13,6 +13,7 @@ import cdm.product.common.settlement.*
 import cdm.product.template.*
 
 import fpml.consolidated.* as fpml
+import fpml.consolidated.asset.* as fpml
 import fpml.consolidated.doc.* as fpml
 import fpml.consolidated.generic.* as fpml
 import fpml.consolidated.shared.* as fpml
@@ -23,24 +24,31 @@ func MapGenericProductCounterpartyList:
     output:
         counterpartyList Counterparty (0..2)
     add counterpartyList:
-        MapBuyerSellerModelToCounterpartyList(fpmlGenericProduct -> buyerSellerModel)
+        MapBuyerSellerModelToCounterpartyList(
+                fpmlGenericProduct -> buyerPartyReference,
+                fpmlGenericProduct -> sellerPartyReference
+            )
 
 func MapGenericProductNonTransferableProduct:
     inputs:
         fpmlGenericProduct fpml.GenericProduct (0..1)
         cdmCounterpartyList Counterparty (0..2)
-        fpmlpartyTradeInformation fpml.PartyTradeInformation (0..*)
+        fpmlpartyTradeInformationList fpml.PartyTradeInformation (0..*)
     output:
         nonTransferableProduct NonTransferableProduct (0..1)
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlGenericProduct -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlGenericProduct -> productModel),
+            identifier: MapProductIdentifierList(fpmlGenericProduct -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlGenericProduct -> primaryAssetClass,
+                        fpmlGenericProduct -> secondaryAssetClass,
+                        fpmlGenericProduct -> productType
+                    ),
             economicTerms: MapGenericProductEconomicTerms(
                         fpmlGenericProduct,
                         cdmCounterpartyList,
-                        fpmlpartyTradeInformation
+                        fpmlpartyTradeInformationList
                     )
         }
 
@@ -48,7 +56,7 @@ func MapGenericProductEconomicTerms:
     inputs:
         fpmlGenericProduct fpml.GenericProduct (0..1)
         cdmCounterpartyList Counterparty (0..2)
-        fpmlPartyTradeInformation fpml.PartyTradeInformation (0..*)
+        fpmlPartyTradeInformationList fpml.PartyTradeInformation (0..*)
     output:
         economicTerms EconomicTerms (0..1)
 
@@ -67,7 +75,7 @@ func MapGenericProductEconomicTerms:
             dateAdjustments: empty, // MapBusinessDayAdjustments(fpmlTrade, fpmlPartiesAndAccountsModel),
             payout: MapGenericProductPayout(fpmlGenericProduct, cdmCounterpartyList),
             terminationProvision: empty, // MapTerminationProvision(fpmlTrade, fpmlPartiesAndAccountsModel),
-            nonStandardisedTerms: fpmlPartyTradeInformation
+            nonStandardisedTerms: fpmlPartyTradeInformationList
                     filter nonStandardTerms exists
                     then extract nonStandardTerms
                     then distinct only-element,
@@ -89,7 +97,8 @@ func MapGenericProductPayout:
                     SettlementPayout:
                         SettlementPayout {
                             payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                        buyerSellerModel,
+                                        sellerPartyReference,
+                                        buyerPartyReference,
                                         cdmCounterpartyList
                                     ),
                             priceQuantity:
@@ -120,15 +129,14 @@ func MapGenericProductPayout:
 func MapGenericProductPriceQuantityList:
     inputs:
         fpmlGenericProduct fpml.GenericProduct (0..1)
-        quotationModel fpml.asset.QuotationModel (0..1)
+        fpmlQuotation fpml.BasicQuotation (0..1)
     output:
         priceQuantityList PriceQuantity (0..*)
 
-    alias quotationModelValue: quotationModel -> value / 100
+    alias quotationModelValue: fpmlQuotation -> value / 100
     alias unitFromQuotation:
-        if quotationModel -> quotationCharacteristicsModel -> currency exists
-        then quotationModel -> quotationCharacteristicsModel
-            then extract MapCurrency(if currency exists then currency)
+        if fpmlQuotation -> currency exists
+        then MapCurrency(fpmlQuotation -> currency)
 
     alias unitFromNotional:
         fpmlGenericProduct -> notional
@@ -180,7 +188,8 @@ func MapGenericProductAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlGenericProduct -> buyerSellerModel
+                fpmlGenericProduct -> buyerAccountReference,
+                fpmlGenericProduct -> sellerAccountReference
             )
 
 func MapGenericProductBaseQuantityListWithAddress:

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-returnswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-returnswap-func.rosetta
@@ -30,7 +30,8 @@ func MapReturnSwapCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlReturnSwap -> returnSwapLeg first -> payerReceiverModel
+                fpmlReturnSwap -> returnSwapLeg first -> payerPartyReference,
+                fpmlReturnSwap -> returnSwapLeg first -> receiverPartyReference
             )
 
 func MapReturnSwapNonTransferableProduct:
@@ -42,8 +43,12 @@ func MapReturnSwapNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlReturnSwap -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlReturnSwap -> productModel),
+            identifier: MapProductIdentifierList(fpmlReturnSwap -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlReturnSwap -> primaryAssetClass,
+                        fpmlReturnSwap -> secondaryAssetClass,
+                        fpmlReturnSwap -> productType
+                    ),
             economicTerms: MapReturnSwapEconomicTerms(fpmlReturnSwap, cdmCounterpartyList)
         }
 
@@ -126,7 +131,8 @@ func MapInterestLegToInterestRatePayout:
             InterestRatePayout:
                 InterestRatePayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlInterestLeg -> payerReceiverModel,
+                                fpmlInterestLeg -> payerPartyReference,
+                                fpmlInterestLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity: MapResolvablePriceQuantity(
@@ -237,9 +243,7 @@ func MapStubCalculationPeriodToStubPeriod:
         StubPeriod {
             calculationPeriodDatesReference: empty,
             finalStub: swap.MapStubValue(fpmlStubCalculationPeriod -> finalStub),
-            initialStub: swap.MapStubValue(
-                        fpmlStubCalculationPeriod -> stubCalculationPeriodSequence -> initialStub
-                    )
+            initialStub: swap.MapStubValue(fpmlStubCalculationPeriod -> initialStub)
         }
 
 func MapInterestLegPaymentDates:
@@ -304,7 +308,8 @@ func MapReturnLegToPerformancePayout:
             PerformancePayout:
                 PerformancePayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlReturnLeg -> payerReceiverModel,
+                                fpmlReturnLeg -> payerPartyReference,
+                                fpmlReturnLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     paymentDates:
@@ -379,15 +384,15 @@ func MapReturnLegValuationToValuationDates:
     set valuationDates:
         ValuationDates {
             interimValuationDate: MapPerformanceValuationDates(
-                        fpmlReturnLegValuation -> valuationPriceInterim -> priceSequence -> determinationMethod,
+                        fpmlReturnLegValuation -> valuationPriceInterim -> determinationMethod,
                         fpmlReturnLegValuation -> valuationPriceInterim -> valuationRules
                     ),
             finalValuationDate: MapPerformanceValuationDates(
-                        fpmlReturnLegValuation -> valuationPriceFinal -> priceSequence -> determinationMethod,
+                        fpmlReturnLegValuation -> valuationPriceFinal -> determinationMethod,
                         fpmlReturnLegValuation -> valuationPriceFinal -> valuationRules
                     ),
             initialValuationDate: MapPerformanceValuationDates(
-                        fpmlReturnLegValuation -> initialPrice -> priceSequence -> determinationMethod,
+                        fpmlReturnLegValuation -> initialPrice -> determinationMethod,
                         fpmlReturnLegValuation -> initialPrice -> valuationRules
                     )
         }
@@ -406,9 +411,9 @@ func MapReturnSwapDividendReturnTerms:
                 DividendReturnTerms {
                     dividendPayoutRatio:
                         DividendPayoutRatio {
-                            totalRatio: fpmlDividendPayout -> dividendPayoutSequence -> dividendPayoutRatio,
-                            cashRatio: fpmlDividendConditions -> declaredCashAndCashEquivalentDividendPercentageModel -> declaredCashDividendPercentage,
-                            nonCashRatio: fpmlDividendConditions -> declaredCashAndCashEquivalentDividendPercentageModel -> declaredCashEquivalentDividendPercentage,
+                            totalRatio: fpmlDividendPayout -> dividendPayoutRatio,
+                            cashRatio: fpmlDividendConditions -> declaredCashDividendPercentage,
+                            nonCashRatio: fpmlDividendConditions -> declaredCashEquivalentDividendPercentage,
                             ...
                         },
                     firstOrSecondPeriod: MapDividendPeriodEnum(dividendPeriod to-string),
@@ -420,17 +425,19 @@ func MapReturnSwapDividendReturnTerms:
                                 excessDividendAmount to-string
                             ),
                     dividendCurrency: MapDividendCurrency(
-                                currencyAndDeterminationMethodModel
+                                currency,
+                                determinationMethod,
+                                currencyReference
                             ),
                     dividendComposition: fpmlDividendConditions -> dividendComposition to-enum DividendCompositionEnum,
                     nonCashDividendTreatment: fpmlDividendConditions -> nonCashDividendTreatment to-enum NonCashDividendTreatmentEnum,
                     dividendPeriod:
                         DividendPeriod {
                             startDate: MapDateReferenceToDividendPaymentDate(
-                                        dividendConditionsSequence -> dividendPeriodEffectiveDate
+                                        dividendPeriodEffectiveDate
                                     ),
                             endDate: MapDateReferenceToDividendPaymentDate(
-                                        dividendConditionsSequence -> dividendPeriodEndDate
+                                        dividendPeriodEndDate
                                     ),
                             dividendPaymentDate: MapDividendPaymentDate(dividendPaymentDate),
                             dateAdjustments: empty,
@@ -441,17 +448,17 @@ func MapReturnSwapDividendReturnTerms:
 
 func MapDividendCurrency:
     inputs:
-        fpmlCurrencyAndDeterminationMethodModel fpml.CurrencyAndDeterminationMethodModel (0..1)
+        fpmlCurrency fpml.IdentifiedCurrency (0..1)
+        fpmlDeterminationMethod fpml.DeterminationMethod (0..1)
+        fpmlCurrencyReference fpml.IdentifiedCurrencyReference (0..1)
     output:
         dividendCurrency DividendCurrency (0..1)
 
     set dividendCurrency:
         DividendCurrency {
-            currency: MapCurrency(fpmlCurrencyAndDeterminationMethodModel -> currency),
-            determinationMethod: fpmlCurrencyAndDeterminationMethodModel -> determinationMethod -> value to-enum DeterminationMethodEnum,
-            currencyReference: MapCurrencyReference(
-                        fpmlCurrencyAndDeterminationMethodModel -> currencyReference
-                    )
+            currency: MapCurrency(fpmlCurrency),
+            determinationMethod: fpmlDeterminationMethod -> value to-enum DeterminationMethodEnum,
+            currencyReference: MapCurrencyReference(fpmlCurrencyReference)
         }
 
 func MapReturnSwapPriceQuantityList:
@@ -584,7 +591,14 @@ func MapReturnSwapAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                fpmlReturnSwap -> returnSwapLeg -> payerReceiverModel
-            )
+        fpmlReturnSwap -> returnSwapLeg
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )
+            then filter reference exists
+            then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-returnswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-returnswap-func.rosetta
@@ -600,5 +600,5 @@ func MapReturnSwapAccountPartyReference:
                         payerPartyReference,
                         receiverPartyReference
                     )
-            then filter reference exists
+                        // then filter reference exists (TODO: bring this back when Python code generator can handle this syntax)
             then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-swap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-swap-func.rosetta
@@ -818,5 +818,5 @@ func MapSwapAccountPartyReference:
                         payerPartyReference,
                         receiverPartyReference
                     )
-            then filter reference exists
+                        // then filter reference exists (TODO: bring this back when Python code generator can handle this syntax)
             then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-swap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-swap-func.rosetta
@@ -765,17 +765,12 @@ func MapCalculationPeriodAmountToPriceList:
         MapSpreadScheduleToPriceWithLocation(fpmlRate, fpmlCurrency, fpmlLeg)
 
     add priceSchedules:
-        MapFloatingRateMultiplerScheduleToPriceWithLocation(
-                fpmlRate,
-                fpmlCurrency,
-                fpmlLeg
-            )
+        MapFloatingRateMultiplerScheduleToPriceWithLocation(fpmlRate, fpmlCurrency, fpmlLeg)
 
 // add priceSchedules:
 // MapCapRateScheduleToPriceWithLocation(fpmlRate, fpmlCurrency, fpmlLeg)
 // add priceSchedules:
 // MapFloorRateScheduleToPriceWithLocation(fpmlRate, fpmlCurrency, fpmlLeg)
-
 func GetInterestRatePriceCurrency:
     inputs:
         fpmlCalculationPeriodAmount fpml.CalculationPeriodAmount (0..1)

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-swap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-swap-func.rosetta
@@ -30,7 +30,8 @@ func MapSwapCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlSwap -> swapStream first -> payerReceiverModel
+                fpmlSwap -> swapStream first -> payerPartyReference,
+                fpmlSwap -> swapStream first -> receiverPartyReference
             )
 
 func MapSwapAncillaryPartyList:
@@ -65,8 +66,12 @@ func MapSwapNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlSwap -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlSwap -> productModel),
+            identifier: MapProductIdentifierList(fpmlSwap -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlSwap -> primaryAssetClass,
+                        fpmlSwap -> secondaryAssetClass,
+                        fpmlSwap -> productType
+                    ),
             economicTerms: MapSwapEconomicTerms(fpmlSwap, cdmCounterpartyList)
         }
 
@@ -101,7 +106,8 @@ func MapSwapPayout:
     alias notionalStepScheduleCalculation:
         fpmlSwapStream -> calculationPeriodAmount -> calculation
 
-    alias fpmlRateCalculation: notionalStepScheduleCalculation -> rateCalculation
+    alias fpmlRateCalculation:
+        fpmlSwapStream -> calculationPeriodAmount -> calculation -> rateCalculation
 
     alias floatingRateSpecification:
         fpmlRateCalculation switch
@@ -116,10 +122,10 @@ func MapSwapPayout:
             default empty
 
     alias principalPaymentCurrency:
-        fpmlSwapStream -> settlementProvision -> settlementCurrency default notionalStepScheduleCalculation -> notionalSchedule -> notionalStepSchedule -> currency
+        fpmlSwapStream -> settlementProvision -> settlementCurrency default fpmlSwapStream -> calculationPeriodAmount -> calculation -> notionalSchedule -> notionalStepSchedule -> currency
 
     alias fixedRateSchedule:
-        notionalStepScheduleCalculation -> calculationSequence -> fixedRateSchedule default notionalStepScheduleCalculation -> calculationSequence1 -> fixedRateSchedule
+        fpmlSwapStream -> calculationPeriodAmount -> calculation -> fixedRateSchedule default fpmlSwapStream -> calculationPeriodAmount -> calculation -> fixedRateSchedule
 
     set payout:
         Payout {
@@ -129,11 +135,13 @@ func MapSwapPayout:
                                 fpmlSwapStream -> principalExchanges,
                                 fpmlSwapStream -> cashflows -> principalExchange,
                                 principalPaymentCurrency,
-                                fpmlSwapStream -> payerReceiverModel,
+                                fpmlSwapStream -> payerPartyReference,
+                                fpmlSwapStream -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     payerReceiver: MapPayerReceiver(
-                                fpmlSwapStream -> payerReceiverModel,
+                                fpmlSwapStream -> payerPartyReference,
+                                fpmlSwapStream -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
@@ -141,7 +149,7 @@ func MapSwapPayout:
                             priceSchedule: if notionalAmountScheduleCalculation exists
                                     then MapScheduleToInterestRatePriceSchedule(
                                             notionalAmountScheduleCalculation,
-                                            notionalAmountScheduleCalculation -> currency,
+                                            fpmlSwapStream -> calculationPeriodAmount -> knownAmountSchedule -> currency,
                                             empty
                                         ),
                             quantitySchedule: if notionalStepScheduleCalculation -> notionalSchedule -> notionalStepSchedule exists
@@ -155,13 +163,13 @@ func MapSwapPayout:
                                             fpmlSwapStream
                                         ),
                             quantityReference: MapResolvablePriceQuantityReference(
-                                        notionalStepScheduleCalculation -> fxLinkedNotionalSchedule -> constantNotionalScheduleReference -> href
+                                        fpmlSwapStream -> calculationPeriodAmount -> calculation -> fxLinkedNotionalSchedule -> constantNotionalScheduleReference -> href
                                     ),
                             quantityMultiplier: MapQuantityMultiplier(
                                         notionalStepScheduleCalculation
                                     ),
                             futureValueNotional: MapFutureValueAmount(
-                                        fpmlSwapStream -> calculationPeriodAmount -> calculation -> calculationSequence -> futureValueNotional
+                                        fpmlSwapStream -> calculationPeriodAmount -> calculation -> futureValueNotional
                                     ),
                             ...
                         },
@@ -187,12 +195,12 @@ func MapSwapPayout:
                             InflationRateSpecification: inflationRateSpecification
                         },
                     dayCountFraction: MapDayCountFractionEnum(
-                                notionalStepScheduleCalculation -> dayCountFraction -> value
+                                fpmlSwapStream -> calculationPeriodAmount -> calculation -> dayCountFraction -> value
                             ),
                     calculationPeriodDates: MapSwapCalculationPeriodDates(
                                 fpmlSwapStream -> calculationPeriodDates
                             ),
-                    compoundingMethod: notionalStepScheduleCalculation -> compoundingMethod to-enum CompoundingMethodEnum,
+                    compoundingMethod: fpmlSwapStream -> calculationPeriodAmount -> calculation -> compoundingMethod to-enum CompoundingMethodEnum,
                     paymentDates: MapSwapPaymentDates(fpmlSwapStream -> paymentDates),
                     stubPeriod: MapStubCalculationPeriodAmountToStubPeriod(
                                 fpmlSwapStream -> stubCalculationPeriodAmount
@@ -263,25 +271,25 @@ func MapFloatingRateSpecification:
         FloatingRateSpecification {
             rateOption: MapRateOptionWithAddress(fpmlFloatingRateCalculation, fpmlLeg),
             spreadSchedule: MapSpreadScheduleWithAddress(
-                        fpmlFloatingRateCalculation -> floatingRateModel,
+                        fpmlFloatingRateCalculation -> spreadSchedule,
                         fpmlLeg
                     ),
             capRateSchedule: MapCapRateScheduleWithAddress(
-                        fpmlFloatingRateCalculation -> floatingRateModel,
+                        fpmlFloatingRateCalculation -> capRateSchedule,
                         fpmlLeg
                     ),
             floorRateSchedule: MapFloorRateScheduleWithAddress(
-                        fpmlFloatingRateCalculation -> floatingRateModel,
+                        fpmlFloatingRateCalculation -> floorRateSchedule,
                         fpmlLeg
                     ),
             initialRate: MapInitialRate(
-                        fpmlFloatingRateCalculation -> floatingRateCalculationModel,
-                        fpmlFloatingRateCalculation -> floatingRateIndexModel
+                        fpmlFloatingRateCalculation -> initialRate,
+                        fpmlFloatingRateCalculation -> floatingRateIndex
                     ),
             finalRateRounding: MapFinalRateRounding(
-                        fpmlFloatingRateCalculation -> floatingRateCalculationModel -> finalRateRounding
+                        fpmlFloatingRateCalculation -> finalRateRounding
                     ),
-            rateTreatment: fpmlFloatingRateCalculation -> floatingRateModel -> rateTreatment to-enum RateTreatmentEnum,
+            rateTreatment: fpmlFloatingRateCalculation -> rateTreatment to-enum RateTreatmentEnum,
             ...
         }
 
@@ -296,25 +304,25 @@ func MapInflationRateSpecification:
         InflationRateSpecification {
             rateOption: MapRateOptionWithAddress(fpmlInflationRateCalculation, fpmlLeg),
             spreadSchedule: MapSpreadScheduleWithAddress(
-                        fpmlInflationRateCalculation -> floatingRateModel,
+                        fpmlInflationRateCalculation -> spreadSchedule,
                         fpmlLeg
                     ),
             capRateSchedule: MapCapRateScheduleWithAddress(
-                        fpmlInflationRateCalculation -> floatingRateModel,
+                        fpmlInflationRateCalculation -> capRateSchedule,
                         fpmlLeg
                     ),
             floorRateSchedule: MapFloorRateScheduleWithAddress(
-                        fpmlInflationRateCalculation -> floatingRateModel,
+                        fpmlInflationRateCalculation -> floorRateSchedule,
                         fpmlLeg
                     ),
             initialRate: MapInitialRate(
-                        fpmlInflationRateCalculation -> floatingRateCalculationModel,
-                        fpmlInflationRateCalculation -> floatingRateIndexModel
+                        fpmlInflationRateCalculation -> initialRate,
+                        fpmlInflationRateCalculation -> floatingRateIndex
                     ),
             finalRateRounding: MapFinalRateRounding(
-                        fpmlInflationRateCalculation -> floatingRateCalculationModel -> finalRateRounding
+                        fpmlInflationRateCalculation -> finalRateRounding
                     ),
-            rateTreatment: fpmlInflationRateCalculation -> floatingRateModel -> rateTreatment to-enum RateTreatmentEnum,
+            rateTreatment: fpmlInflationRateCalculation -> rateTreatment to-enum RateTreatmentEnum,
             inflationLag: empty,
             indexSource: empty,
             mainPublication: empty,
@@ -325,18 +333,18 @@ func MapInflationRateSpecification:
 
 func MapInitialRate:
     inputs:
-        fpmlFloatingRateCalculationModel fpml.FloatingRateCalculationModel (0..1)
-        fpmlFloatingRateIndexModel fpml.FloatingRateIndexModel (0..1)
+        fpmlInitialRate number (0..1)
+        fpmlFloatingRateIndex fpml.FloatingRateIndex (0..1)
     output:
         initialRate Price (0..1)
 
     set initialRate:
-        if fpmlFloatingRateCalculationModel -> initialRate exists
+        if fpmlInitialRate exists
         then Price {
-                value: fpmlFloatingRateCalculationModel -> initialRate,
+                value: fpmlInitialRate,
                 unit: empty,
                 perUnitOf: empty,
-                priceType: if fpmlFloatingRateIndexModel exists
+                priceType: if fpmlFloatingRateIndex exists
                         then InterestRate,
                 ...
             }
@@ -372,7 +380,7 @@ func MapTerminationProvision:
             cancelableProvision: MapCancelableProvision(
                         fpmlCancelableProvision,
                         cdmCounterpartyList
-                    ), // TODO
+                    ),
             extendibleProvision: empty, // TODO
             ...
         }
@@ -386,11 +394,11 @@ func MapCancelableProvision:
     set cancelableProvision:
         CancelableProvision {
             buyer: MapCounterpartyRoleEnum(
-                        fpmlCancelableProvision -> buyerSellerModel -> buyerPartyReference -> href,
+                        fpmlCancelableProvision -> buyerPartyReference -> href,
                         cdmCounterpartyList
                     ),
             seller: MapCounterpartyRoleEnum(
-                        fpmlCancelableProvision -> buyerSellerModel -> sellerPartyReference -> href,
+                        fpmlCancelableProvision -> sellerPartyReference -> href,
                         cdmCounterpartyList
                     ),
             followUpConfirmation: fpmlCancelableProvision -> followUpConfirmation,
@@ -403,6 +411,7 @@ func MapCancelableProvision:
                         },
             exerciseTerms: MapExerciseTerms(
                         fpmlCancelableProvision -> exercise,
+                        empty,
                         empty,
                         empty,
                         empty,
@@ -421,11 +430,11 @@ func MapEarlyTerminationProvision:
     set earlyTerminationProvision:
         EarlyTerminationProvision {
             optionalEarlyTermination: MapOptionalEarlyTermination(
-                        fpmlEarlyTerminationProvision -> optionalEarlyTerminationModel -> optionalEarlyTermination,
+                        fpmlEarlyTerminationProvision -> optionalEarlyTermination,
                         cdmCounterpartyList
                     ),
             mandatoryEarlyTermination: MapMandatoryEarlyTermination(
-                        fpmlEarlyTerminationProvision -> earlyTerminationProvisionSequence -> mandatoryEarlyTerminationModel -> mandatoryEarlyTermination,
+                        fpmlEarlyTerminationProvision -> mandatoryEarlyTermination,
                         cdmCounterpartyList
                     ),
             ...
@@ -454,6 +463,7 @@ func MapOptionalEarlyTermination:
                     ),
             exerciseTerms: MapExerciseTerms(
                         fpmlOptionalEarlyTermination -> exercise,
+                        empty,
                         empty,
                         empty,
                         empty,
@@ -491,9 +501,7 @@ func MapStubCalculationPeriodAmountToStubPeriod:
         StubPeriod {
             calculationPeriodDatesReference: empty,
             finalStub: MapStubValue(fpmlStubCalculationPeriodAmount -> finalStub),
-            initialStub: MapStubValue(
-                        fpmlStubCalculationPeriodAmount -> stubCalculationPeriodAmountSequence -> initialStub
-                    )
+            initialStub: MapStubValue(fpmlStubCalculationPeriodAmount -> initialStub)
         }
     set stubPeriod -> calculationPeriodDatesReference -> reference:
         fpmlStubCalculationPeriodAmount -> calculationPeriodDatesReference -> href
@@ -527,10 +535,8 @@ func MapStubFloatingRate:
 
     set stubFloatingRate:
         StubFloatingRate {
-            floatingRateIndex: fpmlStubFloatingRate -> stubFloatingRateIndexModel -> floatingRateIndex -> value to-enum FloatingRateIndexEnum,
-            indexTenor: MapPeriod(
-                        fpmlStubFloatingRate -> stubFloatingRateIndexModel -> indexTenor
-                    ),
+            floatingRateIndex: fpmlStubFloatingRate -> floatingRateIndex -> value to-enum FloatingRateIndexEnum,
+            indexTenor: MapPeriod(fpmlStubFloatingRate -> indexTenor),
             ...
         }
 
@@ -750,8 +756,7 @@ func MapCalculationPeriodAmountToPriceList:
 
     alias fpmlCurrency: GetInterestRatePriceCurrency(fpmlCalculationPeriodAmount)
 
-    alias fixedRateSchedule:
-        fpmlCalculationPeriodAmount -> calculation -> calculationSequence -> fixedRateSchedule default fpmlCalculationPeriodAmount -> calculation -> calculationSequence1 -> fixedRateSchedule
+    alias fixedRateSchedule: fpmlCalculationPeriodAmount -> calculation -> fixedRateSchedule
 
     add priceSchedules:
         MapFixedRateScheduleToPriceWithLocation(fixedRateSchedule, fpmlCurrency, fpmlLeg)
@@ -760,12 +765,17 @@ func MapCalculationPeriodAmountToPriceList:
         MapSpreadScheduleToPriceWithLocation(fpmlRate, fpmlCurrency, fpmlLeg)
 
     add priceSchedules:
-        MapFloatingRateMultiplerScheduleToPriceWithLocation(fpmlRate, fpmlCurrency, fpmlLeg)
+        MapFloatingRateMultiplerScheduleToPriceWithLocation(
+                fpmlRate,
+                fpmlCurrency,
+                fpmlLeg
+            )
 
 // add priceSchedules:
 // MapCapRateScheduleToPriceWithLocation(fpmlRate, fpmlCurrency, fpmlLeg)
 // add priceSchedules:
 // MapFloorRateScheduleToPriceWithLocation(fpmlRate, fpmlCurrency, fpmlLeg)
+
 func GetInterestRatePriceCurrency:
     inputs:
         fpmlCalculationPeriodAmount fpml.CalculationPeriodAmount (0..1)
@@ -804,7 +814,14 @@ func MapSwapAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                fpmlSwap -> swapStream -> payerReceiverModel
-            )
+        fpmlSwap -> swapStream
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )
+            then filter reference exists
+            then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-swaption-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-swaption-func.rosetta
@@ -4,6 +4,7 @@ version "${project.version}"
 import cdm.base.staticdata.party.*
 import cdm.ingest.fpml.confirmation.common.*
 import cdm.ingest.fpml.confirmation.party.*
+import cdm.ingest.fpml.confirmation.party.*
 import cdm.ingest.fpml.confirmation.product.swap.* as swap
 import cdm.ingest.fpml.confirmation.settlement.*
 import cdm.observable.asset.*
@@ -22,7 +23,10 @@ func MapSwaptionCounterpartyList:
         counterpartyList Counterparty (0..2)
 
     add counterpartyList:
-        MapBuyerSellerModelToCounterpartyList(fpmlSwaption -> buyerSellerModel)
+        MapBuyerSellerModelToCounterpartyList(
+                fpmlSwaption -> buyerPartyReference,
+                fpmlSwaption -> sellerPartyReference
+            )
 
 func MapSwaptionAncillaryPartyList:
     inputs:
@@ -55,8 +59,12 @@ func MapSwaptionNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlSwaption -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlSwaption -> productModel),
+            identifier: MapProductIdentifierList(fpmlSwaption -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlSwaption -> primaryAssetClass,
+                        fpmlSwaption -> secondaryAssetClass,
+                        fpmlSwaption -> productType
+                    ),
             economicTerms: MapSwaptionEconomicTerms(fpmlSwaption, cdmCounterpartyList)
         }
 
@@ -91,7 +99,8 @@ func MapSwaptionPayout:
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlSwaption -> buyerSellerModel,
+                                fpmlSwaption -> sellerPartyReference,
+                                fpmlSwaption -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     settlementTerms: if fpmlSwaption -> cashSettlement exists
@@ -102,7 +111,8 @@ func MapSwaptionPayout:
                                 fpmlSwaption -> physicalSettlement
                             ),
                     buyerSeller: MapBuyerSeller(
-                                fpmlSwaption -> buyerSellerModel,
+                                fpmlSwaption -> buyerPartyReference,
+                                fpmlSwaption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -125,7 +135,8 @@ func MapSwaptionPayout:
                                 fpmlSwaption -> exercise,
                                 fpmlSwaption -> exerciseProcedure,
                                 empty,
-                                fpmlSwaption -> buyerSellerModel,
+                                fpmlSwaption -> buyerPartyReference,
+                                fpmlSwaption -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     ...
@@ -168,4 +179,8 @@ func MapSwaptionAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapBuyerSellerToAccountPartyReference(fpmlAccount, fpmlSwaption -> buyerSellerModel)
+        MapBuyerSellerToAccountPartyReference(
+                fpmlAccount,
+                fpmlSwaption -> buyerAccountReference,
+                fpmlSwaption -> sellerAccountReference
+            )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-varianceoptiontransactionsupplement-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-varianceoptiontransactionsupplement-func.rosetta
@@ -21,7 +21,8 @@ func MapVarianceOptionTransactionSupplementCounterpartyList:
 
     add counterpartyList:
         MapBuyerSellerModelToCounterpartyList(
-                fpmlVarianceOptionTransactionSupplement -> buyerSellerModel
+                fpmlVarianceOptionTransactionSupplement -> buyerPartyReference,
+                fpmlVarianceOptionTransactionSupplement -> sellerPartyReference
             )
 
 func MapVarianceOptionTransactionSupplementAncillaryPartyList:
@@ -46,10 +47,12 @@ func MapVarianceOptionTransactionSupplementNonTransferableProduct:
     set nonTransferableProduct:
         NonTransferableProduct {
             identifier: MapProductIdentifierList(
-                        fpmlVarianceOptionTransactionSupplement -> productModel
+                        fpmlVarianceOptionTransactionSupplement -> productId
                     ),
             taxonomy: MapProductTaxonomyList(
-                        fpmlVarianceOptionTransactionSupplement -> productModel
+                        fpmlVarianceOptionTransactionSupplement -> primaryAssetClass,
+                        fpmlVarianceOptionTransactionSupplement -> secondaryAssetClass,
+                        fpmlVarianceOptionTransactionSupplement -> productType
                     ),
             economicTerms: MapVarianceOptionTransactionSupplementEconomicTerms(
                         fpmlVarianceOptionTransactionSupplement,
@@ -85,7 +88,8 @@ func MapVarianceOptionTransactionSupplementPayout:
             OptionPayout:
                 OptionPayout {
                     payerReceiver: MapSellerAsPayerAndBuyerAsReceiver(
-                                fpmlVarianceOptionTransactionSupplement -> buyerSellerModel,
+                                fpmlVarianceOptionTransactionSupplement -> sellerPartyReference,
+                                fpmlVarianceOptionTransactionSupplement -> buyerPartyReference,
                                 cdmCounterpartyList
                             ),
                     settlementTerms: MapEquityExerciseValuationSettlementToSettlementTerms(
@@ -93,7 +97,8 @@ func MapVarianceOptionTransactionSupplementPayout:
                                 fpmlVarianceOptionTransactionSupplement -> clearingInstructions
                             ),
                     buyerSeller: MapBuyerSeller(
-                                fpmlVarianceOptionTransactionSupplement -> buyerSellerModel,
+                                fpmlVarianceOptionTransactionSupplement -> buyerPartyReference,
+                                fpmlVarianceOptionTransactionSupplement -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -115,7 +120,8 @@ func MapVarianceOptionTransactionSupplementPayout:
                                     ),
                                 empty,
                                 empty,
-                                fpmlVarianceOptionTransactionSupplement -> buyerSellerModel,
+                                fpmlVarianceOptionTransactionSupplement -> buyerPartyReference,
+                                fpmlVarianceOptionTransactionSupplement -> sellerPartyReference,
                                 cdmCounterpartyList
                             ),
                     ...
@@ -145,5 +151,6 @@ func MapVarianceOptionTransactionSupplementAccountPartyReference:
     set partyReference:
         MapBuyerSellerToAccountPartyReference(
                 fpmlAccount,
-                fpmlVarianceOptionTransactionSupplement -> buyerSellerModel
+                fpmlVarianceOptionTransactionSupplement -> buyerAccountReference,
+                fpmlVarianceOptionTransactionSupplement -> sellerAccountReference
             )

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-varianceswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-varianceswap-func.rosetta
@@ -240,5 +240,5 @@ func MapVarianceSwapAccountPartyReference:
                         payerPartyReference,
                         receiverPartyReference
                     )
-            then filter reference exists
+                        // then filter reference exists (TODO: bring this back when Python code generator can handle this syntax)
             then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-varianceswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-varianceswap-func.rosetta
@@ -25,7 +25,8 @@ func MapVarianceSwapCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlVarianceSwap -> varianceLeg first -> payerReceiverModel
+                fpmlVarianceSwap -> varianceLeg first -> payerPartyReference,
+                fpmlVarianceSwap -> varianceLeg first -> receiverPartyReference
             )
 
 func MapVarianceSwapNonTransferableProduct:
@@ -37,8 +38,12 @@ func MapVarianceSwapNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlVarianceSwap -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlVarianceSwap -> productModel),
+            identifier: MapProductIdentifierList(fpmlVarianceSwap -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlVarianceSwap -> primaryAssetClass,
+                        fpmlVarianceSwap -> secondaryAssetClass,
+                        fpmlVarianceSwap -> productType
+                    ),
             economicTerms: MapVarianceSwapEconomicTerms(
                         fpmlVarianceSwap,
                         cdmCounterpartyList
@@ -57,10 +62,10 @@ func MapVarianceSwapEconomicTerms:
     set economicTerms:
         EconomicTerms {
             effectiveDate: MapAdjustableOrRelativeDate(
-                        fpmlEffectiveDates -> effectiveDate first
+                        fpmlVarianceSwap -> varianceLeg -> effectiveDate first
                     ),
             terminationDate: MapAdjustableOrRelativeDate(
-                        (fpmlVarianceSwap -> varianceLeg filter terminationDate exists) -> terminationDate first
+                        fpmlVarianceSwap -> varianceLeg -> terminationDate first
                     ),
             payout: fpmlVarianceSwap -> varianceLeg
                     extract MapVarianceLegToPerformancePayout(item, cdmCounterpartyList),
@@ -79,7 +84,8 @@ func MapVarianceLegToPerformancePayout:
             PerformancePayout:
                 PerformancePayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlVarianceLeg -> payerReceiverModel,
+                                fpmlVarianceLeg -> payerPartyReference,
+                                fpmlVarianceLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     priceQuantity:
@@ -91,7 +97,9 @@ func MapVarianceLegToPerformancePayout:
                             ...
                         },
                     settlementTerms: MapOptionSettlementModelToSettlementTerms(
-                                fpmlVarianceLeg -> optionSettlementModel
+                                fpmlVarianceLeg -> settlementType,
+                                fpmlVarianceLeg -> settlementCurrency,
+                                fpmlVarianceLeg -> settlementDate
                             ),
                     observationTerms: MapAdjustableOrRelativeDateToObservationTerms(
                                 fpmlVarianceLeg -> amount -> observationStartDate
@@ -143,14 +151,14 @@ func MapVarianceLegToVarianceReturnTerms:
                 },
             dividendApplicability:
                 DividendApplicability {
-                    optionsExchangeDividends: fpmlVarianceLeg -> amount -> dividendsModel -> optionsExchangeDividends,
-                    additionalDividends: fpmlVarianceLeg -> amount -> dividendsModel -> additionalDividends,
-                    allDividends: fpmlVarianceLeg -> amount -> dividendsModel -> allDividends
+                    optionsExchangeDividends: fpmlVarianceLeg -> amount -> optionsExchangeDividends,
+                    additionalDividends: fpmlVarianceLeg -> amount -> additionalDividends,
+                    allDividends: fpmlVarianceLeg -> amount -> allDividends
                 },
-            initialLevel: fpmlVariance -> calculationFromObservationChoice -> calculationFromObservationChoiceSequence -> initialLevel,
-            varianceStrikePrice: if fpmlVariance -> varianceStrikePrice exists
+            initialLevel: fpmlVarianceLeg -> amount -> variance -> initialLevel,
+            varianceStrikePrice: if fpmlVarianceLeg -> amount -> variance -> varianceStrikePrice exists
                     then Price {
-                        value: fpmlVariance -> varianceStrikePrice,
+                        value: fpmlVarianceLeg -> amount -> variance -> varianceStrikePrice,
                         priceType: Variance,
                         ...
                     },
@@ -158,21 +166,21 @@ func MapVarianceLegToVarianceReturnTerms:
                 VarianceCapFloor {
                     boundedVariance:
                         BoundedVariance {
-                            realisedVarianceMethod: fpmlVariance -> boundedVariance -> realisedVarianceMethod to-enum RealisedVarianceMethodEnum,
-                            daysInRangeAdjustment: fpmlVariance -> boundedVariance -> daysInRangeAdjustment,
-                            upperBarrier: fpmlVariance -> boundedVariance -> upperBarrier,
-                            lowerBarrier: fpmlVariance -> boundedVariance -> lowerBarrier
+                            realisedVarianceMethod: fpmlVarianceLeg -> amount -> variance -> boundedVariance -> realisedVarianceMethod to-enum RealisedVarianceMethodEnum,
+                            daysInRangeAdjustment: fpmlVarianceLeg -> amount -> variance -> boundedVariance -> daysInRangeAdjustment,
+                            upperBarrier: fpmlVarianceLeg -> amount -> variance -> boundedVariance -> upperBarrier,
+                            lowerBarrier: fpmlVarianceLeg -> amount -> variance -> boundedVariance -> lowerBarrier
                         },
-                    varianceCap: fpmlVariance -> varianceCap,
+                    varianceCap: fpmlVarianceLeg -> amount -> variance -> varianceCap,
                     ...
                 },
             vegaNotionalAmount:
                 NonNegativeQuantitySchedule {
-                    value: fpmlVariance -> vegaNotionalAmount,
+                    value: fpmlVarianceLeg -> amount -> variance -> vegaNotionalAmount,
                     unit:
                         UnitType {
-                            currency: if fpmlVariance -> vegaNotionalAmount exists
-                                    then fpmlVariance -> varianceAmount -> currency -> value,
+                            currency: if fpmlVarianceLeg -> amount -> variance -> vegaNotionalAmount exists
+                                    then fpmlVarianceLeg -> amount -> variance -> varianceAmount -> currency -> value,
                             ...
                         },
                     ...
@@ -183,7 +191,7 @@ func MapVarianceLegToVarianceReturnTerms:
                             then MapAsset(fpmlAsset),
                     ...
                 },
-            expectedN: fpmlVariance -> expectedN,
+            expectedN: fpmlVarianceLeg -> amount -> variance -> expectedN,
             ...
         }
 
@@ -223,7 +231,14 @@ func MapVarianceSwapAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                fpmlVarianceSwap -> varianceLeg -> payerReceiverModel
-            )
+        fpmlVarianceSwap -> varianceLeg
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )
+            then filter reference exists
+            then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-varianceswaptransactionsupplement-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-varianceswaptransactionsupplement-func.rosetta
@@ -20,7 +20,8 @@ func MapVarianceSwapTransactionSupplementCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlVarianceSwapTransactionSupplement -> varianceLeg first -> payerReceiverModel
+                fpmlVarianceSwapTransactionSupplement -> varianceLeg first -> payerPartyReference,
+                fpmlVarianceSwapTransactionSupplement -> varianceLeg first -> receiverPartyReference
             )
 
 func MapVarianceSwapTransactionSupplementNonTransferableProduct:
@@ -33,10 +34,12 @@ func MapVarianceSwapTransactionSupplementNonTransferableProduct:
     set nonTransferableProduct:
         NonTransferableProduct {
             identifier: MapProductIdentifierList(
-                        fpmlVarianceSwapTransactionSupplement -> productModel
+                        fpmlVarianceSwapTransactionSupplement -> productId
                     ),
             taxonomy: MapProductTaxonomyList(
-                        fpmlVarianceSwapTransactionSupplement -> productModel
+                        fpmlVarianceSwapTransactionSupplement -> primaryAssetClass,
+                        fpmlVarianceSwapTransactionSupplement -> secondaryAssetClass,
+                        fpmlVarianceSwapTransactionSupplement -> productType
                     ),
             economicTerms: MapVarianceSwapTransactionSupplementEconomicTerms(
                         fpmlVarianceSwapTransactionSupplement,
@@ -77,7 +80,14 @@ func MapVarianceSwapTransactionSupplementAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                fpmlVarianceSwapTransactionSupplement -> varianceLeg -> payerReceiverModel
-            )
+        fpmlVarianceSwapTransactionSupplement -> varianceLeg
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )
+            then filter reference exists
+            then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-varianceswaptransactionsupplement-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-varianceswaptransactionsupplement-func.rosetta
@@ -89,5 +89,5 @@ func MapVarianceSwapTransactionSupplementAccountPartyReference:
                         payerPartyReference,
                         receiverPartyReference
                     )
-            then filter reference exists
+                        // then filter reference exists (TODO: bring this back when Python code generator can handle this syntax)
             then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-volatilityswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-volatilityswap-func.rosetta
@@ -24,7 +24,8 @@ func MapVolatilitySwapCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlVolatilitySwap -> volatilityLeg first -> payerReceiverModel
+                fpmlVolatilitySwap -> volatilityLeg first -> payerPartyReference,
+                fpmlVolatilitySwap -> volatilityLeg first -> receiverPartyReference
             )
 
 func MapVolatilitySwapNonTransferableProduct:
@@ -36,8 +37,12 @@ func MapVolatilitySwapNonTransferableProduct:
 
     set nonTransferableProduct:
         NonTransferableProduct {
-            identifier: MapProductIdentifierList(fpmlVolatilitySwap -> productModel),
-            taxonomy: MapProductTaxonomyList(fpmlVolatilitySwap -> productModel),
+            identifier: MapProductIdentifierList(fpmlVolatilitySwap -> productId),
+            taxonomy: MapProductTaxonomyList(
+                        fpmlVolatilitySwap -> primaryAssetClass,
+                        fpmlVolatilitySwap -> secondaryAssetClass,
+                        fpmlVolatilitySwap -> productType
+                    ),
             economicTerms: MapVolatilitySwapEconomicTerms(
                         fpmlVolatilitySwap,
                         cdmCounterpartyList
@@ -70,7 +75,8 @@ func MapVolatilityLegToPerformancePayout:
             PerformancePayout:
                 PerformancePayout {
                     payerReceiver: MapPayerReceiver(
-                                fpmlVolatilityLeg -> payerReceiverModel,
+                                fpmlVolatilityLeg -> payerPartyReference,
+                                fpmlVolatilityLeg -> receiverPartyReference,
                                 cdmCounterpartyList
                             ),
                     underlier:
@@ -86,7 +92,7 @@ func MapVolatilityLegToPerformancePayout:
                     settlementTerms:
                         SettlementTerms {
                             settlementCurrency: MapCurrency(
-                                        fpmlVolatilityLeg -> optionSettlementModel -> settlementAmountOrCurrencyModel -> settlementCurrency
+                                        fpmlVolatilityLeg -> settlementCurrency
                                     ),
                             settlementType: empty,
                             ...
@@ -131,7 +137,7 @@ func MapVolatilitySwapReturnTerms:
                         VolatilityCapFloor {
                             applicable: fpmlVolatilityLeg -> amount -> volatility -> volatilityCap -> applicable,
                             totalVolatilityCap: fpmlVolatilityLeg -> amount -> volatility -> volatilityCap -> totalVolatilityCap,
-                            volatilityCapFactor: fpmlVolatilityLeg -> amount -> volatility -> volatilityCap -> volatilityCapSequence -> volatilityCapFactor
+                            volatilityCapFactor: fpmlVolatilityLeg -> amount -> volatility -> volatilityCap -> volatilityCapFactor
                         },
                     valuationTerms: empty,
                     ...
@@ -189,9 +195,7 @@ func MapVolatilityLegToNonNegativeQuantityScheduleWithLocation:
             value: fpmlVolatilityLeg -> amount -> volatility -> vegaNotionalAmount,
             unit:
                 UnitType {
-                    currency: MapCurrency(
-                                fpmlVolatilityLeg -> optionSettlementModel -> settlementAmountOrCurrencyModel -> settlementCurrency
-                            ),
+                    currency: MapCurrency(fpmlVolatilityLeg -> settlementCurrency),
                     ...
                 },
             ...
@@ -221,7 +225,14 @@ func MapVolatilitySwapAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                fpmlVolatilitySwap -> volatilityLeg -> payerReceiverModel
-            )
+        fpmlVolatilitySwap -> volatilityLeg
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )
+            then filter reference exists
+            then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-volatilityswap-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-volatilityswap-func.rosetta
@@ -234,5 +234,5 @@ func MapVolatilitySwapAccountPartyReference:
                         payerPartyReference,
                         receiverPartyReference
                     )
-            then filter reference exists
+                        // then filter reference exists (TODO: bring this back when Python code generator can handle this syntax)
             then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-volatilityswaptransactionsupplement-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-volatilityswaptransactionsupplement-func.rosetta
@@ -20,7 +20,8 @@ func MapVolatilitySwapTransactionSupplementCounterpartyList:
 
     add counterpartyList:
         MapPayerReceiverModelToCounterpartyList(
-                fpmlVolatilitySwapTransactionSupplement -> volatilityLeg first -> payerReceiverModel
+                fpmlVolatilitySwapTransactionSupplement -> volatilityLeg first -> payerPartyReference,
+                fpmlVolatilitySwapTransactionSupplement -> volatilityLeg first -> receiverPartyReference
             )
 
 func MapVolatilitySwapTransactionSupplementNonTransferableProduct:
@@ -33,10 +34,12 @@ func MapVolatilitySwapTransactionSupplementNonTransferableProduct:
     set nonTransferableProduct:
         NonTransferableProduct {
             identifier: MapProductIdentifierList(
-                        fpmlVolatilitySwapTransactionSupplement -> productModel
+                        fpmlVolatilitySwapTransactionSupplement -> productId
                     ),
             taxonomy: MapProductTaxonomyList(
-                        fpmlVolatilitySwapTransactionSupplement -> productModel
+                        fpmlVolatilitySwapTransactionSupplement -> primaryAssetClass,
+                        fpmlVolatilitySwapTransactionSupplement -> secondaryAssetClass,
+                        fpmlVolatilitySwapTransactionSupplement -> productType
                     ),
             economicTerms: MapVolatilitySwapTransactionSupplementEconomicTerms(
                         fpmlVolatilitySwapTransactionSupplement,
@@ -77,7 +80,14 @@ func MapVolatilitySwapTransactionSupplementAccountPartyReference:
             [metadata reference]
 
     set partyReference:
-        MapPayerReceiverToAccountPartyReference(
-                fpmlAccount,
-                fpmlVolatilitySwapTransactionSupplement -> volatilityLeg -> payerReceiverModel
-            )
+        fpmlVolatilitySwapTransactionSupplement -> volatilityLeg
+            extract
+                MapPayerReceiverToAccountPartyReference(
+                        fpmlAccount,
+                        payerAccountReference,
+                        receiverAccountReference,
+                        payerPartyReference,
+                        receiverPartyReference
+                    )
+            then filter reference exists
+            then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-volatilityswaptransactionsupplement-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-product-volatilityswaptransactionsupplement-func.rosetta
@@ -89,5 +89,5 @@ func MapVolatilitySwapTransactionSupplementAccountPartyReference:
                         payerPartyReference,
                         receiverPartyReference
                     )
-            then filter reference exists
+                        // then filter reference exists (TODO: bring this back when Python code generator can handle this syntax)
             then first

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-settlement-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-settlement-func.rosetta
@@ -24,19 +24,19 @@ import fpml.consolidated.shared.* as fpml
 
 func MapSettlementProvisionToSettlementTerms:
     inputs:
-        settlementProvision fpml.SettlementProvision (0..1)
-        paymentDates fpml.PaymentDates (0..1)
+        fpmlSettlementProvision fpml.SettlementProvision (0..1)
+        fpmlPaymentDates fpml.PaymentDates (0..1)
     output:
         settlementTerms SettlementTerms (0..1)
 
     alias settlementType:
-        if settlementProvision -> nonDeliverableSettlement exists
+        if fpmlSettlementProvision -> nonDeliverableSettlement exists
         then SettlementTypeEnum -> Cash
 
     set settlementTerms:
         SettlementTerms {
             settlementType: settlementType,
-            settlementCurrency: MapCurrency(settlementProvision -> settlementCurrency),
+            settlementCurrency: MapCurrency(fpmlSettlementProvision -> settlementCurrency),
             cashSettlementTerms:
                 CashSettlementTerms {
                     valuationMethod:
@@ -46,8 +46,8 @@ func MapSettlementProvisionToSettlementTerms:
                                     settlementRateOption:
                                         SettlementRateOption {
                                             settlementRateOption: MapStringWithScheme(
-                                                        settlementProvision -> nonDeliverableSettlement -> settlementRateOption -> value,
-                                                        settlementProvision -> nonDeliverableSettlement -> settlementRateOption -> settlementRateOptionScheme
+                                                        fpmlSettlementProvision -> nonDeliverableSettlement -> settlementRateOption -> value,
+                                                        fpmlSettlementProvision -> nonDeliverableSettlement -> settlementRateOption -> settlementRateOptionScheme
                                                     )
                                                     to-enum SettlementRateOptionEnum,
                                             ...
@@ -58,10 +58,10 @@ func MapSettlementProvisionToSettlementTerms:
                         },
                     valuationDate:
                         ValuationDate {
-                            fxFixingDate: if settlementProvision -> nonDeliverableSettlement -> fxFixingDate exists
+                            fxFixingDate: if fpmlSettlementProvision -> nonDeliverableSettlement -> fxFixingDate exists
                                     then MapFxFixingDate(
-                                            settlementProvision -> nonDeliverableSettlement -> fxFixingDate,
-                                            paymentDates
+                                            fpmlSettlementProvision -> nonDeliverableSettlement -> fxFixingDate,
+                                            fpmlPaymentDates
                                         ),
                             ...
                         },
@@ -80,31 +80,27 @@ func MapReturnSwapLegToSettlementTerms:
         SettlementTerms {
             settlementType: if fpmlReturnLeg -> amount -> cashSettlement = True
                     then Cash
-                else fpmlReturnLeg -> optionSettlementModel -> settlementType to-enum SettlementTypeEnum,
+                else fpmlReturnLeg -> settlementType to-enum SettlementTypeEnum,
             settlementCurrency: if fpmlReturnLeg -> amount exists
-                    then MapCurrency(
-                            fpmlReturnLeg -> amount -> currencyAndDeterminationMethodModel -> currency
-                        )
-                else if fpmlReturnLeg -> optionSettlementModel -> settlementAmountOrCurrencyModel -> settlementCurrency exists
-                then MapCurrency(
-                            fpmlReturnLeg -> optionSettlementModel -> settlementAmountOrCurrencyModel -> settlementCurrency
-                        ),
+                    then MapCurrency(fpmlReturnLeg -> amount -> currency)
+                else if fpmlReturnLeg -> settlementCurrency exists
+                then MapCurrency(fpmlReturnLeg -> settlementCurrency),
             ...
         }
 
 func MapOptionSettlementModelToSettlementTerms:
     inputs:
-        fpmlOptionSettlementModel fpml.OptionSettlementModel (0..1)
+        fpmlSettlementType fpml.SettlementTypeEnum (0..1)
+        fpmlSettlementCurrency fpml.Currency (0..1)
+        fpmlSettlementDate fpml.AdjustableOrRelativeDate (0..1)
     output:
         settlementTerms SettlementTerms (0..1)
 
     set settlementTerms:
         SettlementTerms {
-            settlementType: fpmlOptionSettlementModel -> settlementType to-enum SettlementTypeEnum,
-            settlementCurrency: MapCurrency(
-                        fpmlOptionSettlementModel -> settlementAmountOrCurrencyModel -> settlementCurrency
-                    ),
-            settlementDate: fpmlOptionSettlementModel -> settlementDate
+            settlementType: fpmlSettlementType to-enum SettlementTypeEnum,
+            settlementCurrency: MapCurrency(fpmlSettlementCurrency),
+            settlementDate: fpmlSettlementDate
                     extract
                         SettlementDate {
                             adjustableOrRelativeDate: MapAdjustableOrAdjustedOrRelativeDate(
@@ -174,24 +170,24 @@ func GetFpmlCashSettlementCurrency:
         fpmlCurrency fpml.Currency (0..*)
 
     add fpmlCurrency:
-        if fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> indicativeQuotations exists
-        then fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> indicativeQuotations -> cashSettlementCurrency
-        else if fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> indicativeQuotationsAlternate exists
-        then fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> indicativeQuotationsAlternate -> cashSettlementCurrency
-        else if fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> calculationAgentDetermination exists
-        then fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> calculationAgentDetermination -> cashSettlementCurrency
-        else if fpmlCashSettlement -> cashSettlementMethods2021Model -> replacementValue -> firmQuotations exists
-        then fpmlCashSettlement -> cashSettlementMethods2021Model -> replacementValue -> firmQuotations -> cashSettlementCurrency
-        else if fpmlCashSettlement -> cashSettlementMethods2021Model -> replacementValue -> calculationAgentDetermination exists
-        then fpmlCashSettlement -> cashSettlementMethods2021Model -> replacementValue -> calculationAgentDetermination -> cashSettlementCurrency
-        else if fpmlCashSettlement -> cashSettlementMethods2006and2021Model -> collateralizedCashPriceMethod exists
-        then fpmlCashSettlement -> cashSettlementMethods2006and2021Model -> collateralizedCashPriceMethod -> cashSettlementCurrency
-        else if fpmlCashSettlement -> cashSettlementMethods2006Model -> cashPriceMethod exists
-        then fpmlCashSettlement -> cashSettlementMethods2006Model -> cashPriceMethod -> cashSettlementCurrency
-        else if fpmlCashSettlement -> cashSettlementMethods2006Model -> cashPriceAlternateMethod exists
-        then fpmlCashSettlement -> cashSettlementMethods2006Model -> cashPriceAlternateMethod -> cashSettlementCurrency
-        else if fpmlCashSettlement -> cashSettlementMethods2006Model -> crossCurrencyMethod exists
-        then fpmlCashSettlement -> cashSettlementMethods2006Model -> crossCurrencyMethod -> cashSettlementCurrency
+        if fpmlCashSettlement -> midMarketValuation -> indicativeQuotations exists
+        then fpmlCashSettlement -> midMarketValuation -> indicativeQuotations -> cashSettlementCurrency
+        else if fpmlCashSettlement -> midMarketValuation -> indicativeQuotationsAlternate exists
+        then fpmlCashSettlement -> midMarketValuation -> indicativeQuotationsAlternate -> cashSettlementCurrency
+        else if fpmlCashSettlement -> midMarketValuation -> calculationAgentDetermination exists
+        then fpmlCashSettlement -> midMarketValuation -> calculationAgentDetermination -> cashSettlementCurrency
+        else if fpmlCashSettlement -> replacementValue -> firmQuotations exists
+        then fpmlCashSettlement -> replacementValue -> firmQuotations -> cashSettlementCurrency
+        else if fpmlCashSettlement -> replacementValue -> calculationAgentDetermination exists
+        then fpmlCashSettlement -> replacementValue -> calculationAgentDetermination -> cashSettlementCurrency
+        else if fpmlCashSettlement -> collateralizedCashPriceMethod exists
+        then fpmlCashSettlement -> collateralizedCashPriceMethod -> cashSettlementCurrency
+        else if fpmlCashSettlement -> cashPriceMethod exists
+        then fpmlCashSettlement -> cashPriceMethod -> cashSettlementCurrency
+        else if fpmlCashSettlement -> cashPriceAlternateMethod exists
+        then fpmlCashSettlement -> cashPriceAlternateMethod -> cashSettlementCurrency
+        else if fpmlCashSettlement -> crossCurrencyMethod exists
+        then fpmlCashSettlement -> crossCurrencyMethod -> cashSettlementCurrency
 
 func MapCashSettlementToCashSettlementTerms:
     inputs:
@@ -200,61 +196,61 @@ func MapCashSettlementToCashSettlementTerms:
         cashSettlementTerms CashSettlementTerms (0..1)
 
     set cashSettlementTerms:
-        if fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> indicativeQuotations exists
+        if fpmlCashSettlement -> midMarketValuation -> indicativeQuotations exists
         then MapMidMarketValuationMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> indicativeQuotations,
+                    fpmlCashSettlement -> midMarketValuation -> indicativeQuotations,
                     MidMarketIndicativeQuotations
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> indicativeQuotationsAlternate exists
+        else if fpmlCashSettlement -> midMarketValuation -> indicativeQuotationsAlternate exists
         then MapMidMarketValuationMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> indicativeQuotationsAlternate,
+                    fpmlCashSettlement -> midMarketValuation -> indicativeQuotationsAlternate,
                     MidMarketIndicativeQuotationsAlternate
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> calculationAgentDetermination exists
+        else if fpmlCashSettlement -> midMarketValuation -> calculationAgentDetermination exists
         then MapMidMarketValuationMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2021Model -> midMarketValuation -> calculationAgentDetermination,
+                    fpmlCashSettlement -> midMarketValuation -> calculationAgentDetermination,
                     MidMarketCalculationAgentDetermination
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2021Model -> replacementValue -> firmQuotations exists
+        else if fpmlCashSettlement -> replacementValue -> firmQuotations exists
         then MapReplacementValueFirmQuotationsMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2021Model -> replacementValue -> firmQuotations
+                    fpmlCashSettlement -> replacementValue -> firmQuotations
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2021Model -> replacementValue -> calculationAgentDetermination exists
+        else if fpmlCashSettlement -> replacementValue -> calculationAgentDetermination exists
         then MapReplacementValueCalculationAgentDeterminationMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2021Model -> replacementValue -> calculationAgentDetermination
+                    fpmlCashSettlement -> replacementValue -> calculationAgentDetermination
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2006and2021Model -> parYieldCurveUnadjustedMethod exists
+        else if fpmlCashSettlement -> parYieldCurveUnadjustedMethod exists
         then MapYieldCurveMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2006and2021Model -> parYieldCurveUnadjustedMethod,
+                    fpmlCashSettlement -> parYieldCurveUnadjustedMethod,
                     ParYieldCurveUnadjustedMethod
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2006and2021Model -> collateralizedCashPriceMethod exists
+        else if fpmlCashSettlement -> collateralizedCashPriceMethod exists
         then MapCollateralizedCashPriceMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2006and2021Model -> collateralizedCashPriceMethod
+                    fpmlCashSettlement -> collateralizedCashPriceMethod
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2006Model -> cashPriceMethod exists
+        else if fpmlCashSettlement -> cashPriceMethod exists
         then MapCashPriceMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2006Model -> cashPriceMethod,
+                    fpmlCashSettlement -> cashPriceMethod,
                     CashPriceMethod
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2006Model -> cashPriceAlternateMethod exists
+        else if fpmlCashSettlement -> cashPriceAlternateMethod exists
         then MapCashPriceMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2006Model -> cashPriceAlternateMethod,
+                    fpmlCashSettlement -> cashPriceAlternateMethod,
                     CashPriceAlternateMethod
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2006Model -> parYieldCurveAdjustedMethod exists
+        else if fpmlCashSettlement -> parYieldCurveAdjustedMethod exists
         then MapYieldCurveMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2006Model -> parYieldCurveAdjustedMethod,
+                    fpmlCashSettlement -> parYieldCurveAdjustedMethod,
                     ParYieldCurveAdjustedMethod
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2006Model -> zeroCouponYieldAdjustedMethod exists
+        else if fpmlCashSettlement -> zeroCouponYieldAdjustedMethod exists
         then MapYieldCurveMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2006Model -> zeroCouponYieldAdjustedMethod,
+                    fpmlCashSettlement -> zeroCouponYieldAdjustedMethod,
                     ZeroCouponYieldAdjustedMethod
                 )
-        else if fpmlCashSettlement -> cashSettlementMethods2006Model -> crossCurrencyMethod exists
+        else if fpmlCashSettlement -> crossCurrencyMethod exists
         then MapCrossCurrencyMethodToCashSettlementTerms(
-                    fpmlCashSettlement -> cashSettlementMethods2006Model -> crossCurrencyMethod
+                    fpmlCashSettlement -> crossCurrencyMethod
                 )
     set cashSettlementTerms -> valuationDate:
         ValuationDate {
@@ -269,24 +265,24 @@ func MapCashSettlementToCashSettlementTerms:
 
 func MapMidMarketValuationMethodToCashSettlementTerms:
     inputs:
-        fpmMidMarketValuationMethod fpml.MidMarketValuationMethod (0..1)
+        fpmlMidMarketValuationMethod fpml.MidMarketValuationMethod (0..1)
         cdmCashSettlementMethod CashSettlementMethodEnum (1..1)
     output:
         cashSettlementTerms CashSettlementTerms (0..1)
 
     set cashSettlementTerms:
-        if fpmMidMarketValuationMethod exists
+        if fpmlMidMarketValuationMethod exists
         then CashSettlementTerms {
                 cashSettlementMethod: cdmCashSettlementMethod,
                 valuationMethod: MapValuationMethod(
                             empty,
-                            fpmMidMarketValuationMethod -> cashSettlementReferenceBanks,
+                            fpmlMidMarketValuationMethod -> cashSettlementReferenceBanks,
                             empty,
                             MapCashCollateralValuationMethod(
-                                    fpmMidMarketValuationMethod -> applicableCsa,
-                                    fpmMidMarketValuationMethod -> cashCollateralCurrency,
-                                    fpmMidMarketValuationMethod -> cashCollateralInterestRate,
-                                    fpmMidMarketValuationMethod -> agreedDiscountRate,
+                                    fpmlMidMarketValuationMethod -> applicableCsa,
+                                    fpmlMidMarketValuationMethod -> cashCollateralCurrency,
+                                    fpmlMidMarketValuationMethod -> cashCollateralInterestRate,
+                                    fpmlMidMarketValuationMethod -> agreedDiscountRate,
                                     empty,
                                     empty
                                 )
@@ -296,25 +292,25 @@ func MapMidMarketValuationMethodToCashSettlementTerms:
 
 func MapReplacementValueFirmQuotationsMethodToCashSettlementTerms:
     inputs:
-        fpmReplacementValueFirmQuotationsMethod fpml.ReplacementValueFirmQuotationsMethod (0..1)
+        fpmlReplacementValueFirmQuotationsMethod fpml.ReplacementValueFirmQuotationsMethod (0..1)
     output:
         cashSettlementTerms CashSettlementTerms (0..1)
 
     set cashSettlementTerms:
-        if fpmReplacementValueFirmQuotationsMethod exists
+        if fpmlReplacementValueFirmQuotationsMethod exists
         then CashSettlementTerms {
                 cashSettlementMethod: ReplacementValueFirmQuotations,
                 valuationMethod: MapValuationMethod(
                             empty,
-                            fpmReplacementValueFirmQuotationsMethod -> cashSettlementReferenceBanks,
+                            fpmlReplacementValueFirmQuotationsMethod -> cashSettlementReferenceBanks,
                             empty,
                             MapCashCollateralValuationMethod(
                                     empty,
-                                    fpmReplacementValueFirmQuotationsMethod -> cashCollateralCurrency,
+                                    fpmlReplacementValueFirmQuotationsMethod -> cashCollateralCurrency,
                                     empty,
                                     empty,
-                                    fpmReplacementValueFirmQuotationsMethod -> protectedParty,
-                                    fpmReplacementValueFirmQuotationsMethod -> prescribedDocumentationAdjustment
+                                    fpmlReplacementValueFirmQuotationsMethod -> protectedParty,
+                                    fpmlReplacementValueFirmQuotationsMethod -> prescribedDocumentationAdjustment
                                 )
                         ),
                 ...
@@ -322,24 +318,24 @@ func MapReplacementValueFirmQuotationsMethodToCashSettlementTerms:
 
 func MapReplacementValueCalculationAgentDeterminationMethodToCashSettlementTerms:
     inputs:
-        fpmReplacementValueCalculationAgentDeterminationMethod fpml.ReplacementValueCalculationAgentDeterminationMethod (0..1)
+        fpmlReplacementValueCalculationAgentDeterminationMethod fpml.ReplacementValueCalculationAgentDeterminationMethod (0..1)
     output:
         cashSettlementTerms CashSettlementTerms (0..1)
 
     set cashSettlementTerms:
-        if fpmReplacementValueCalculationAgentDeterminationMethod exists
+        if fpmlReplacementValueCalculationAgentDeterminationMethod exists
         then CashSettlementTerms {
                 cashSettlementMethod: ReplacementValueCalculationAgentDetermination,
                 valuationMethod: MapValuationMethod(
                             empty,
-                            fpmReplacementValueCalculationAgentDeterminationMethod -> cashSettlementReferenceBanks,
+                            fpmlReplacementValueCalculationAgentDeterminationMethod -> cashSettlementReferenceBanks,
                             empty,
                             MapCashCollateralValuationMethod(
                                     empty,
-                                    fpmReplacementValueCalculationAgentDeterminationMethod -> cashCollateralCurrency,
+                                    fpmlReplacementValueCalculationAgentDeterminationMethod -> cashCollateralCurrency,
                                     empty,
                                     empty,
-                                    fpmReplacementValueCalculationAgentDeterminationMethod -> protectedParty,
+                                    fpmlReplacementValueCalculationAgentDeterminationMethod -> protectedParty,
                                     empty
                                 )
                         ),
@@ -466,7 +462,7 @@ func MapCashCollateralValuationMethod:
         fpmlCashCollateralCurrency fpml.Currency (0..1)
         fpmlCashCollateralInterestRate fpml.BenchmarkRate (0..1)
         fpmlAgreedDiscountRate fpml.BenchmarkRate (0..1)
-        fpmlProtectedParty fpml.PartySelector (0..*)
+        fpmlProtectedPartyList fpml.PartySelector (0..*)
         fpmlPrescribedDocumentationAdjustment boolean (0..1)
     output:
         cashCollateralValuationMethod CashCollateralValuationMethod (0..1)
@@ -483,7 +479,7 @@ func MapCashCollateralValuationMethod:
                         fpmlAgreedDiscountRate -> value,
                         fpmlAgreedDiscountRate -> benchmarkRateScheme
                     ),
-            protectedParty: fpmlProtectedParty
+            protectedParty: fpmlProtectedPartyList
                     extract partyDetermination to-enum PartyDeterminationEnum,
             prescribedDocumentationAdjustment: fpmlPrescribedDocumentationAdjustment
         }
@@ -547,10 +543,10 @@ func MapFxCashSettlementToSettlementTerms:
                             valuationSource:
                                 ValuationSource {
                                     quotedCurrencyPair: MapQuotedCurrencyPair(
-                                                fpmlFxCashSettlement -> fixing -> quotedCurrencyPair
+                                                fpmlFxCashSettlement -> fixing -> quotedCurrencyPair first
                                             ),
                                     informationSource: MapFxSpotRateSource(
-                                                fpmlFxCashSettlement -> fixing -> fxSpotRateSource
+                                                fpmlFxCashSettlement -> fixing -> fxSpotRateSource first
                                             ),
                                     referenceBanks: empty,
                                     ...
@@ -569,7 +565,7 @@ func MapFxCashSettlementToSettlementTerms:
                                         AdjustableOrRelativeDate {
                                             adjustableDate:
                                                 AdjustableDate {
-                                                    adjustedDate: fpmlFxCashSettlement -> fixing -> fixingDate -> date,
+                                                    adjustedDate: fpmlFxCashSettlement -> fixing -> fixingDate -> date first,
                                                     ...
                                                 },
                                             ...
@@ -677,10 +673,8 @@ func MapFxDigitalOptionToSettlementTerms:
     output:
         settlementTerms SettlementTerms (0..1)
 
-    alias AmericanExercise:
-        fpmlFxDigitalOption -> fxDigitalOptionSequence0 -> americanExercise -> latestValueDate
-    alias EuropeanExercise:
-        fpmlFxDigitalOption -> fxDigitalOptionSequence1 -> europeanExercise -> valueDate
+    alias AmericanExercise: fpmlFxDigitalOption -> americanExercise -> latestValueDate
+    alias EuropeanExercise: fpmlFxDigitalOption -> europeanExercise -> valueDate
 
     alias settlementDate:
         if EuropeanExercise exists
@@ -701,12 +695,12 @@ func MapFxDigitalOptionToSettlementTerms:
 
 func MapCreditDefaultSwapChoiceToSettlementTerms:
     inputs:
-        fpmlCreditDefaultSwapChoice fpml.CreditDefaultSwapChoice (0..*)
+        fpmlCreditDefaultSwapChoiceList fpml.CreditDefaultSwapChoice (0..*)
     output:
         settlementTerms SettlementTerms (0..1)
 
-    alias physical: fpmlCreditDefaultSwapChoice first -> physicalSettlementTerms
-    alias cash: fpmlCreditDefaultSwapChoice first -> cashSettlementTerms
+    alias physical: fpmlCreditDefaultSwapChoiceList first -> physicalSettlementTerms
+    alias cash: fpmlCreditDefaultSwapChoiceList first -> cashSettlementTerms
 
     set settlementTerms:
         if physical exists
@@ -766,7 +760,7 @@ func MapCreditDefaultSwapChoiceToSettlementTerms:
                 settlementCurrency: MapCurrency(cash -> settlementCurrency),
                 cashSettlementTerms:
                     CashSettlementTerms {
-                        recoveryFactor: cash -> fixedRecoveryModel -> recoveryFactor,
+                        recoveryFactor: cash -> recoveryFactor,
                         ...
                     },
                 ...
@@ -774,17 +768,17 @@ func MapCreditDefaultSwapChoiceToSettlementTerms:
 
 func MapCommoditySettlementModelToSettlementTerms:
     inputs:
-        fpmlCommoditySwapDetailsModel fpml.CommoditySwapDetailsModel (0..1)
+        fpmlSettlementCurrency fpml.IdentifiedCurrency (0..1)
     output:
         settlementTerms SettlementTerms (0..1)
 
     set settlementTerms:
         SettlementTerms {
-            settlementType: if fpmlCommoditySwapDetailsModel -> settlementCurrency exists
+            settlementType: if fpmlSettlementCurrency exists
                     then SettlementTypeEnum -> Cash,
             settlementCurrency: MapStringWithScheme(
-                        fpmlCommoditySwapDetailsModel -> settlementCurrency -> value,
-                        fpmlCommoditySwapDetailsModel -> settlementCurrency -> currencyScheme
+                        fpmlSettlementCurrency -> value,
+                        fpmlSettlementCurrency -> currencyScheme
                     ),
             ...
         }
@@ -820,20 +814,16 @@ func MapCorrelationLegToSettlementTerms:
     output:
         settlementTerms SettlementTerms (0..1)
 
-    alias fpmlOptionSettlementModel: fpmlCorrelationLeg -> optionSettlementModel
-
     set settlementTerms:
         SettlementTerms {
-            settlementType: fpmlOptionSettlementModel -> settlementType to-enum SettlementTypeEnum,
-            settlementCurrency: MapCurrency(
-                        fpmlOptionSettlementModel -> settlementAmountOrCurrencyModel -> settlementCurrency
-                    ),
+            settlementType: fpmlCorrelationLeg -> settlementType to-enum SettlementTypeEnum,
+            settlementCurrency: MapCurrency(fpmlCorrelationLeg -> settlementCurrency),
             settlementDate:
                 SettlementDate {
                     adjustableOrRelativeDate: MapAdjustableOrAdjustedOrRelativeDate(
                                 empty,
-                                fpmlOptionSettlementModel -> settlementDate -> adjustableDate,
-                                fpmlOptionSettlementModel -> settlementDate -> relativeDate
+                                fpmlCorrelationLeg -> settlementDate -> adjustableDate,
+                                fpmlCorrelationLeg -> settlementDate -> relativeDate
                             ),
                     ...
                 },
@@ -856,7 +846,7 @@ func MapCommodityExerciseToSettlementTerms:
                     adjustableOrRelativeDate:
                         AdjustableOrAdjustedOrRelativeDate {
                             relativeDate: MapDateOffsetToRelativeDateOffset(
-                                        fpmlCommodityExercise -> commodityPaymentDatesModel -> relativePaymentDates -> paymentDaysOffset
+                                        fpmlCommodityExercise -> relativePaymentDates -> paymentDaysOffset
                                     ),
                             ...
                         },

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-tradestate-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-tradestate-func.rosetta
@@ -48,8 +48,9 @@ import cdm.observable.asset.*
 import cdm.product.collateral.*
 import cdm.product.template.*
 
-import fpml.consolidated.* as fpml
+import fpml.consolidated.asset.* as fpml
 import fpml.consolidated.bond.option.* as fpml
+import fpml.consolidated.business.events.* as fpml
 import fpml.consolidated.cd.* as fpml
 import fpml.consolidated.com.* as fpml
 import fpml.consolidated.correlation.swaps.* as fpml
@@ -68,9 +69,10 @@ import fpml.consolidated.volatility.swaps.* as fpml
 func MapTradeState:
     inputs:
         fpmlTrade fpml.Trade (0..1)
-        fpmlPartiesAndAccountsModel fpml.PartiesAndAccountsModel (0..1)
-        fpmlEventValuationModel fpml.business.events.EventValuationModel (0..1)
-        fpmlAdditionalPartyTradeIdentifier fpml.PartyTradeIdentifier (0..*) <"Additional PartyTradeIdentifier - i.e., not specified on the FpML trade.">
+        fpmlPartyList fpml.Party (0..*)
+        fpmlAccountList fpml.Account (0..*)
+        fpmlQuoteList fpml.BasicQuotation (0..*)
+        fpmlAdditionalPartyTradeIdentifierList fpml.PartyTradeIdentifier (0..*) <"Additional PartyTradeIdentifier - i.e., not specified on the FpML trade.">
     output:
         tradeState TradeState (0..1)
 
@@ -78,9 +80,10 @@ func MapTradeState:
         TradeState {
             trade: MapTrade(
                         fpmlTrade,
-                        fpmlPartiesAndAccountsModel,
-                        fpmlEventValuationModel,
-                        fpmlAdditionalPartyTradeIdentifier
+                        fpmlPartyList,
+                        fpmlAccountList,
+                        fpmlQuoteList,
+                        fpmlAdditionalPartyTradeIdentifierList
                     ),
             transferHistory: MapTransferStateList(fpmlTrade),
             ...
@@ -89,9 +92,10 @@ func MapTradeState:
 func MapTrade:
     inputs:
         fpmlTrade fpml.Trade (0..1)
-        fpmlPartiesAndAccountsModel fpml.PartiesAndAccountsModel (0..1)
-        fpmlEventValuationModel fpml.business.events.EventValuationModel (0..1)
-        fpmlAdditionalPartyTradeIdentifier fpml.PartyTradeIdentifier (0..*) <"Additional PartyTradeIdentifier - i.e., not specified on the FpML trade.">
+        fpmlPartyList fpml.Party (0..*)
+        fpmlAccountList fpml.Account (0..*)
+        fpmlQuoteList fpml.BasicQuotation (0..*)
+        fpmlAdditionalPartyTradeIdentifierList fpml.PartyTradeIdentifier (0..*) <"Additional PartyTradeIdentifier - i.e., not specified on the FpML trade.">
     output:
         trade Trade (0..1)
 
@@ -100,51 +104,47 @@ func MapTrade:
     set trade:
         Trade {
             product: MapNonTransferableProduct(fpmlTrade, counterpartyList),
-            tradeLot: MapTradeLotList(
-                        fpmlTrade,
-                        fpmlPartiesAndAccountsModel,
-                        fpmlEventValuationModel
-                    ),
+            tradeLot: MapTradeLotList(fpmlTrade, fpmlQuoteList),
             counterparty: counterpartyList,
             ancillaryParty: MapAncillaryPartyList(fpmlTrade, counterpartyList),
             adjustment: MapNotionalAdjustmentEnum(ExtractNotionalAdjustmentByLeg(fpmlTrade)),
             tradeIdentifier: MapTradeIdentifierList(
                         fpmlTrade -> tradeHeader,
-                        fpmlAdditionalPartyTradeIdentifier
+                        fpmlAdditionalPartyTradeIdentifierList
                     ),
             tradeDate: MapIdentifiedDate(fpmlTrade -> tradeHeader -> tradeDate),
             party: MapPartyList(
-                        fpmlPartiesAndAccountsModel -> party,
+                        fpmlPartyList,
                         fpmlTrade -> tradeHeader -> partyTradeInformation
                     ),
             partyRole: MapPartyRoleList(fpmlTrade),
             contractDetails: MapContractDetails(fpmlTrade, counterpartyList),
-            account: MapAccountList(fpmlTrade, fpmlPartiesAndAccountsModel),
+            account: MapAccountList(fpmlTrade, fpmlAccountList),
             collateral: MapCollateral(fpmlTrade -> tradeHeader),
-            executionDetails: MapExecutionDetails(fpmlTrade, fpmlEventValuationModel),
+            executionDetails: MapExecutionDetails(fpmlTrade, fpmlQuoteList),
             ...
         }
 
 func MapExecutionDetails:
     inputs:
         fpmlTrade fpml.Trade (0..1)
-        fpmlEventValuationModel fpml.business.events.EventValuationModel (0..1)
+        fpmlQuoteList fpml.BasicQuotation (0..*)
     output:
         executionDetails ExecutionDetails (0..1)
 
     alias quotationModel:
-        fpmlEventValuationModel -> quote -> quotationModel
+        fpmlQuoteList
             filter
-                quotationCharacteristicsModel -> measureType -> value = "PackagePrice"
-                    or quotationCharacteristicsModel -> measureType -> value = "PackageSpread"
+                measureType -> value = "PackagePrice"
+                    or measureType -> value = "PackageSpread"
             then only-element
 
     alias unitFromQuotation:
-        if quotationModel -> quotationCharacteristicsModel -> currency exists
-        then MapCurrency(quotationModel -> quotationCharacteristicsModel -> currency)
+        if quotationModel -> currency exists
+        then MapCurrency(quotationModel -> currency)
 
     alias arithmeticOp:
-        if quotationModel -> quotationCharacteristicsModel -> measureType -> value = "PackageSpread"
+        if quotationModel -> measureType -> value = "PackageSpread"
         then ArithmeticOperationEnum -> Add
         else empty
 
@@ -168,7 +168,8 @@ func MapExecutionDetails:
             packageReference:
                 IdentifiedList {
                     listId: MapIssuerTradeIdModelToIdentifier(
-                                fpmlTrade -> tradeHeader -> originatingPackage -> packageIdentifier -> issuerTradeIdModel
+                                fpmlTrade -> tradeHeader -> originatingPackage -> packageIdentifier -> issuer,
+                                fpmlTrade -> tradeHeader -> originatingPackage -> packageIdentifier -> tradeId
                             ),
                     price:
                         Price {
@@ -183,9 +184,9 @@ func MapExecutionDetails:
                                     currency: unitValue,
                                     ...
                                 },
-                            priceType: if quotationModel -> quotationCharacteristicsModel -> measureType -> value = "PackagePrice"
-                                    then CashPrice
-                                else if quotationModel -> quotationCharacteristicsModel -> measureType -> value = "PackageSpread"
+                            priceType: if quotationModel -> measureType -> value = "PackagePrice"
+                                    then AssetPrice
+                                else if quotationModel -> measureType -> value = "PackageSpread"
                                 then InterestRate,
                             arithmeticOperator: arithmeticOp,
                             ...
@@ -363,7 +364,10 @@ func MapNonTransferableProduct:
         }
 
     set nonTransferableProduct -> economicTerms -> calculationAgent:
-        MapCalculationAgent(fpmlTrade -> calculationAgentModel)
+        MapCalculationAgent(
+                fpmlTrade -> calculationAgent,
+                fpmlTrade -> calculationAgentBusinessCenter
+            )
 
     set nonTransferableProduct -> economicTerms -> nonStandardisedTerms:
         if fpmlTrade -> tradeHeader -> partyTradeInformation -> nonStandardTerms exists
@@ -371,31 +375,31 @@ func MapNonTransferableProduct:
 
 func MapCalculationAgent:
     inputs:
-        fpmlCalculationAgentModel fpml.CalculationAgentModel (0..1)
+        fpmlCalculationAgent fpml.CalculationAgent (0..1)
+        fpmlCalculationAgentBusinessCenter fpml.BusinessCenter (0..1)
     output:
         calculationAgent CalculationAgent (0..1)
 
     set calculationAgent:
         CalculationAgent {
-            calculationAgentParty: if fpmlCalculationAgentModel -> calculationAgent -> calculationAgentPartyReference -> href exists
+            calculationAgentParty: if fpmlCalculationAgent -> calculationAgentPartyReference -> href exists
                     then CalculationAgentIndependent,
             calculationAgentPartyEnum: empty,
             calculationAgentBusinessCenter: MapBusinessCenter(
-                        fpmlCalculationAgentModel -> calculationAgentBusinessCenter
+                        fpmlCalculationAgentBusinessCenter
             ),
         }
 
 func MapTradeLotList:
     inputs:
         fpmlTrade fpml.Trade (0..1)
-        fpmlPartiesAndAccountsModel fpml.PartiesAndAccountsModel (0..1)
-        fpmlEventValuationModel fpml.business.events.EventValuationModel (0..1)
+        fpmlQuoteList fpml.BasicQuotation (0..*)
     output:
         tradeLotList TradeLot (0..*)
 
     alias quotationModel:
-        fpmlEventValuationModel -> quote -> quotationModel
-            filter quotationCharacteristicsModel -> measureType -> value = "PriceNotation"
+        fpmlQuoteList
+            filter measureType -> value = "PriceNotation"
             then only-element
 
     add tradeLotList:
@@ -407,7 +411,7 @@ func MapTradeLotList:
 func MapPriceQuantityList:
     inputs:
         fpmlTrade fpml.Trade (0..1)
-        quotationModel fpml.asset.QuotationModel (0..1)
+        fpmlQuotation fpml.BasicQuotation (0..1)
     output:
         priceQuantityList PriceQuantity (0..*)
 
@@ -436,7 +440,7 @@ func MapPriceQuantityList:
             fpml.FxVarianceSwap then MapFxVarianceSwapPriceQuantityList,
             fpml.FxVolatilitySwap then MapFxVolatilitySwapPriceQuantityList,
             fpml.GenericProduct then
-                MapGenericProductPriceQuantityList(item, quotationModel),
+                MapGenericProductPriceQuantityList(item, fpmlQuotation),
             fpml.ReturnSwap then MapReturnSwapPriceQuantityList,
             fpml.Swap then MapSwapPriceQuantityList,
             fpml.Swaption then MapSwaptionPriceQuantityList,

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-tradestate-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-tradestate-func.rosetta
@@ -185,7 +185,7 @@ func MapExecutionDetails:
                                     ...
                                 },
                             priceType: if quotationModel -> measureType -> value = "PackagePrice"
-                                    then AssetPrice
+                                    then CashPrice
                                 else if quotationModel -> measureType -> value = "PackageSpread"
                                 then InterestRate,
                             arithmeticOperator: arithmeticOp,

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-workflowstep-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-workflowstep-func.rosetta
@@ -182,9 +182,7 @@ func MapAmendmentToPrimitiveInstruction:
 
     alias payment: fpmlAmendment -> payment
     alias feeType:
-        if payment exists
-        then FeeTypeEnum -> Renegotiation
-        else empty
+        if payment exists then FeeTypeEnum -> Renegotiation else empty
 
     set primitiveInstruction:
         PrimitiveInstruction {

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-workflowstep-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-workflowstep-func.rosetta
@@ -15,8 +15,10 @@ import cdm.ingest.fpml.confirmation.payment.*
 import cdm.ingest.fpml.confirmation.pricequantity.*
 import cdm.ingest.fpml.confirmation.tradestate.*
 import cdm.observable.asset.*
+import cdm.product.common.settlement.*
 
 import fpml.consolidated.* as fpml
+import fpml.consolidated.asset.* as fpml
 import fpml.consolidated.business.events.* as fpml
 import fpml.consolidated.doc.* as fpml
 import fpml.consolidated.msg.* as fpml
@@ -24,19 +26,23 @@ import fpml.consolidated.shared.* as fpml
 
 func MapWorkflowStep:
     inputs:
-        messageId fpml.MessageId (0..1)
-        messageHeaderModel fpml.MessageHeaderModel (0..1)
+        fpmlMessageId fpml.MessageId (0..1)
+        creationTimestamp zonedDateTime (0..1)
+        fpmlSentBy fpml.MessageAddress (0..1)
+        fpmlSendToList fpml.MessageAddress (0..*)
         action ActionEnum (0..1)
         fpmlTrade fpml.Trade (0..1)
-        fpmlPartiesAndAccountsModel fpml.PartiesAndAccountsModel (0..1)
+        fpmlNovation fpml.TradeNovationContent (0..1)
+        fpmlTermination fpml.TradeNotionalChange (0..1)
+        fpmlAmendment fpml.TradeAmendmentContent (0..1)
+        fpmlPartyList fpml.Party (0..*)
+        fpmlAccountList fpml.Account (0..*)
+        fpmlQuoteList fpml.BasicQuotation (0..*)
         intent EventIntentEnum (0..1)
         eventDate date (0..1)
         effectiveDate date (0..1)
-        fpmlPostTradeEventsBaseModel fpml.PostTradeEventsBaseModel (0..1)
-        tradingEventsBaseModel fpml.TradingEventsBaseModel (0..1)
-        tradingEvents fpml.TradingEventSummary (0..1)
-        fpmlEventValuationModel fpml.business.events.EventValuationModel (0..1)
-        fpmlAdditionalPartyTradeIdentifier fpml.PartyTradeIdentifier (0..*) <"Additional PartyTradeIdentifier - i.e., not specified on the FpML trade.">
+        fpmlTradingEvents fpml.TradingEventSummary (0..1)
+        fpmlAdditionalPartyTradeIdentifierList fpml.PartyTradeIdentifier (0..*) <"Additional PartyTradeIdentifier - i.e., not specified on the FpML trade.">
     output:
         workflowStep WorkflowStep (0..1)
 
@@ -51,22 +57,28 @@ func MapWorkflowStep:
                             Instruction {
                                 primitiveInstruction: MapPrimitiveInstruction(
                                             fpmlTrade,
-                                            fpmlPostTradeEventsBaseModel,
-                                            tradingEventsBaseModel
+                                            fpmlNovation,
+                                            fpmlTermination,
+                                            fpmlAmendment
                                         ),
                                 before: MapTradeState(
                                             fpmlTrade,
-                                            fpmlPartiesAndAccountsModel,
-                                            fpmlEventValuationModel,
-                                            fpmlAdditionalPartyTradeIdentifier
+                                            fpmlPartyList,
+                                            fpmlAccountList,
+                                            fpmlQuoteList,
+                                            fpmlAdditionalPartyTradeIdentifierList
                                         )
                             }
                         ],
                     ...
                 },
-            timestamp: MapEventTimestamp(messageHeaderModel, fpmlTrade),
-            eventIdentifier: MapEventIdentifier(messageId, tradingEvents),
-            messageInformation: MapMessageInformation(messageId, messageHeaderModel),
+            timestamp: MapEventTimestamp(creationTimestamp, fpmlTrade),
+            eventIdentifier: MapEventIdentifier(fpmlMessageId, fpmlTradingEvents),
+            messageInformation: MapMessageInformation(
+                        fpmlMessageId,
+                        fpmlSentBy,
+                        fpmlSendToList
+                    ),
             action: action,
             nextEvent: MapNextEvent(fpmlTrade -> tradeHeader -> partyTradeInformation),
             ...
@@ -74,28 +86,28 @@ func MapWorkflowStep:
 
 func MapNextEvent:
     inputs:
-        partyTradeInformation fpml.PartyTradeInformation (0..*)
+        fpmlPartyTradeInformationList fpml.PartyTradeInformation (0..*)
     output:
         nextEvent EventInstruction (0..1)
     set nextEvent:
         EventInstruction {
-            intent: if partyTradeInformation -> clearingStatus -> value any = "Uncleared"
-                        and partyTradeInformation -> intentToClear any = True
+            intent: if fpmlPartyTradeInformationList -> clearingStatus -> value any = "Uncleared"
+                        and fpmlPartyTradeInformationList -> intentToClear any = True
                     then Clearing
-                else if partyTradeInformation -> allocationStatus -> value any = "PreAllocation"
-                        and partyTradeInformation -> intentToAllocate any = True
+                else if fpmlPartyTradeInformationList -> allocationStatus -> value any = "PreAllocation"
+                        and fpmlPartyTradeInformationList -> intentToAllocate any = True
                 then Allocation
-                else if partyTradeInformation -> intentToClear any = True
+                else if fpmlPartyTradeInformationList -> intentToClear any = True
                 then Clearing
-                else if partyTradeInformation -> intentToAllocate any = True
+                else if fpmlPartyTradeInformationList -> intentToAllocate any = True
                 then Allocation,
             ...
         }
 
 func MapEventIdentifier:
     inputs:
-        messageId fpml.MessageId (0..1)
-        tradeEvent fpml.TradingEventSummary (0..1)
+        fpmlMessageId fpml.MessageId (0..1)
+        fpmlTradeEvent fpml.TradingEventSummary (0..1)
     output:
         eventIdentifier Identifier (0..*)
 
@@ -103,14 +115,14 @@ func MapEventIdentifier:
         Identifier {
             assignedIdentifier:
                 AssignedIdentifier {
-                    identifier: messageId -> value,
+                    identifier: fpmlMessageId -> value,
                     ...
                 },
             ...
         }
 
     add eventIdentifier:
-        tradeEvent -> eventIdentifier
+        fpmlTradeEvent -> eventIdentifier
             extract
                 Identifier {
                     assignedIdentifier:
@@ -118,37 +130,26 @@ func MapEventIdentifier:
                             identifier: eventId -> value,
                             ...
                         },
-                    issuerReference: MapPartyReference(
-                                partyAndAccountReferencesModel -> partyReference -> href
-                            ),
+                    issuerReference: MapPartyReference(partyReference -> href),
                     ...
                 }
 
 func MapPrimitiveInstruction:
     inputs:
         fpmlTrade fpml.Trade (0..1)
-        fpmlTradeNotionalChange fpml.PostTradeEventsBaseModel (0..1)
-        fpmlTradingEventsBaseModel fpml.TradingEventsBaseModel (0..1)
+        fpmlNovation fpml.TradeNovationContent (0..1)
+        fpmlTermination fpml.TradeNotionalChange (0..1)
+        fpmlAmendment fpml.TradeAmendmentContent (0..1)
     output:
         primitiveInstruction PrimitiveInstruction (0..1)
 
     set primitiveInstruction:
-        if fpmlTradeNotionalChange -> novation exists
-        then MapNovationToPrimitiveInstruction(fpmlTradeNotionalChange)
-        else if fpmlTradeNotionalChange -> postTradeEventsBaseModelSequence -> termination exists
-        then MapTerminationToPrimitiveInstruction(
-                    fpmlTrade,
-                    fpmlTradeNotionalChange -> postTradeEventsBaseModelSequence -> termination
-                )
-        else if fpmlTradeNotionalChange -> amendment exists
-        then MapAmendmentToPrimitiveInstruction(
-                    fpmlTrade,
-                    fpmlTradeNotionalChange -> amendment
-                )
-        else if fpmlTradingEventsBaseModel exists
-        then MapTradeToPrimitiveInstruction(
-                    fpmlTradingEventsBaseModel -> tradingEventsBaseModelSequence -> trade
-                )
+        if fpmlNovation exists
+        then MapNovationToPrimitiveInstruction(fpmlNovation)
+        else if fpmlTermination exists
+        then MapTerminationToPrimitiveInstruction(fpmlTrade, fpmlTermination)
+        else if fpmlAmendment exists
+        then MapAmendmentToPrimitiveInstruction(fpmlTrade, fpmlAmendment)
         else if fpmlTrade exists
         then MapTradeToPrimitiveInstruction(fpmlTrade)
 
@@ -175,13 +176,15 @@ func MapTradeToPrimitiveInstruction:
 func MapAmendmentToPrimitiveInstruction:
     inputs:
         fpmlTrade fpml.Trade (0..1)
-        amendment fpml.TradeAmendmentContent (0..1)
+        fpmlAmendment fpml.TradeAmendmentContent (0..1)
     output:
         primitiveInstruction PrimitiveInstruction (0..1)
 
-    alias payment: amendment -> tradeAlterationPaymentModel -> payment
+    alias payment: fpmlAmendment -> payment
     alias feeType:
-        if payment exists then FeeTypeEnum -> Renegotiation else empty
+        if payment exists
+        then FeeTypeEnum -> Renegotiation
+        else empty
 
     set primitiveInstruction:
         PrimitiveInstruction {
@@ -191,41 +194,33 @@ func MapAmendmentToPrimitiveInstruction:
 
 func MapNovationToPrimitiveInstruction:
     inputs:
-        fpmlPostTradeEventsBaseModel fpml.PostTradeEventsBaseModel (0..1)
+        fpmlNovation fpml.TradeNovationContent (0..1)
     output:
         primitiveInstruction PrimitiveInstruction (0..1)
 
-    add primitiveInstruction -> split -> breakdown:
-        fpmlPostTradeEventsBaseModel extract MapBreakdown
+    add primitiveInstruction -> split -> breakdown: fpmlNovation extract MapBreakdown
 
 func MapBreakdown:
     inputs:
-        fpmlPostTradeEventsBaseModel fpml.PostTradeEventsBaseModel (0..1)
+        fpmlNovation fpml.TradeNovationContent (0..1)
     output:
         breakdown PrimitiveInstruction (0..*)
 
-    alias novatedAmount:
-        fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmountsOldModel -> novationAmountsOldModelSequence0 -> novatedAmount
-    alias changeInNotionalAmount:
-        fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmount -> tradeLegNotionalChangeModel -> changeInNotionalAmount
+    alias novatedAmount: fpmlNovation -> novatedAmount
+    alias changeInNotionalAmount: fpmlNovation -> novationAmount -> changeInNotionalAmount
     alias newTradeAmount:
         changeInNotionalAmount
             extract MapNonNegativeMoneyNonNegativeQuantitySchedule
             then default novatedAmount extract MapMoneyToNonNegativeQuantitySchedule
     alias outstandingNotionalAmount:
-        fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmount -> tradeLegNotionalChangeModel -> outstandingNotionalAmount
-    alias remainingAmount:
-        fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmountsOldModel -> novationAmountsOldModelSequence0 -> remainingAmount
+        fpmlNovation -> novationAmount -> outstandingNotionalAmount
+    alias remainingAmount: fpmlNovation -> remainingAmount
     alias oldTradeAmount:
         outstandingNotionalAmount
             extract MapNonNegativeMoneyNonNegativeQuantitySchedule
             then default remainingAmount extract MapMoneyToNonNegativeQuantitySchedule
-    alias partyChange: MapPartyChangeInstruction(fpmlPostTradeEventsBaseModel)
-    alias transfer:
-        MapTransferInstruction(
-                fpmlPostTradeEventsBaseModel -> novation -> payment,
-                Novation
-            )
+    alias partyChange: MapPartyChangeInstruction(fpmlNovation)
+    alias transfer: MapTransferInstruction(fpmlNovation -> payment, Novation)
 
     add breakdown:
         if newTradeAmount exists
@@ -265,60 +260,56 @@ func MapBreakdown:
 
 func MapPartyChangeInstruction:
     inputs:
-        fpmlPostTradeEventsBaseModel fpml.PostTradeEventsBaseModel (0..1)
+        fpmlNovation fpml.TradeNovationContent (0..1)
     output:
         partyChange PartyChangeInstruction (0..1)
 
-    alias counterpartyList:
-        MapCounterpartyList(
-                fpmlPostTradeEventsBaseModel -> novation -> tradeNovationContentSequence0 -> oldTradeModel -> oldTrade
-            )
+    alias counterpartyList: MapCounterpartyList(fpmlNovation -> oldTrade)
 
     set partyChange:
         PartyChangeInstruction {
             counterparty: MapPartyChangePayerReceiverModelToCounterparty(
-                        fpmlPostTradeEventsBaseModel -> novation -> novationRolesModel -> transferee,
-                        fpmlPostTradeEventsBaseModel -> novation -> novationRolesModel -> transferor,
+                        fpmlNovation -> transferee,
+                        fpmlNovation -> transferor,
                         counterpartyList
                     ),
-            tradeId: fpmlPostTradeEventsBaseModel -> novation -> newTradeModel -> newTradeIdentifier
-                    extract
-                        MapTradeIdentifierSequenceToTradeIdentifier(tradeIdentifierSequence),
+            tradeId: fpmlNovation -> newTradeIdentifier
+                    extract MapTradeIdentifierSequenceToTradeIdentifier(item),
             ...
         }
 
 func MapPartyChangePayerReceiverModelToCounterparty:
     inputs:
-        transferee fpml.PartyReference (0..1)
-        transferor fpml.PartyReference (0..1)
+        fpmlTransferee fpml.PartyReference (0..1)
+        fpmlTransferor fpml.PartyReference (0..1)
         counterpartyList Counterparty (0..2)
     output:
         counterparty Counterparty (0..1)
 
     alias transferorRole:
         counterpartyList
-            then filter partyReference -> reference = transferor -> href
+            then filter partyReference -> reference = fpmlTransferor -> href
             then role only-element
 
-    set counterparty: MapCounterparty(transferorRole, transferee)
+    set counterparty: MapCounterparty(transferorRole, fpmlTransferee)
 
 func MapTerminationToPrimitiveInstruction:
     inputs:
         fpmlTrade fpml.Trade (0..1)
-        termination fpml.TradeNotionalChange (0..1)
+        fpmlTermination fpml.TradeNotionalChange (0..1)
     output:
         primitiveInstruction PrimitiveInstruction (0..1)
 
     alias counterpartyList: MapCounterpartyList(fpmlTrade)
-    alias terminationPayment: termination -> tradeAlterationPaymentModel -> payment
+    alias terminationPayment: fpmlTermination -> payment
     alias transferExpression:
-        if termination exists
+        if fpmlTermination exists
         then FeeTypeEnum -> Termination
         else empty
 
     set primitiveInstruction:
         PrimitiveInstruction {
-            quantityChange: MapQuantityChangeInstruction(termination, empty, Replace),
+            quantityChange: MapQuantityChangeInstruction(fpmlTermination, empty, Replace),
             transfer: MapTransferInstruction(terminationPayment, transferExpression),
             ...
         }
@@ -337,13 +328,12 @@ func MapTransferInstruction:
 func MapQuantityChangeInstruction:
     inputs:
         fpmlTradeNotionalChange fpml.TradeNotionalChange (0..1)
-        fpmlPostTradeEventsBaseModel fpml.PostTradeEventsBaseModel (0..1)
+        fpmlNovation fpml.TradeNovationContent (0..1)
         quantityChangeDirection QuantityChangeDirectionEnum (0..1)
     output:
         quantityChange QuantityChangeInstruction (0..1)
 
-    alias changeAmount:
-        MapPriceQuantity(fpmlTradeNotionalChange, fpmlPostTradeEventsBaseModel)
+    alias changeAmount: MapPriceQuantity(fpmlTradeNotionalChange, fpmlNovation)
     set quantityChange:
         if changeAmount exists
         then QuantityChangeInstruction {
@@ -355,33 +345,31 @@ func MapQuantityChangeInstruction:
 func MapPriceQuantity:
     inputs:
         fpmlTradeNotionalChange fpml.TradeNotionalChange (0..1)
-        fpmlPostTradeEventsBaseModel fpml.PostTradeEventsBaseModel (0..1)
+        fpmlNovation fpml.TradeNovationContent (0..1)
     output:
         priceQuantityList PriceQuantity (0..*)
 
     alias outstandingTradeNotional:
-        fpmlTradeNotionalChange -> tradeNotionalChangeModel -> tradeNotionalChangeModelSequence0 -> outstandingNotionalAmount
+        fpmlTradeNotionalChange -> outstandingNotionalAmount
             extract MapNonNegativeMoneyNonNegativeQuantitySchedule
 
     alias outstandingSizeChange:
-        fpmlTradeNotionalChange -> sizeChange -> tradeLegNotionalChangeModel -> outstandingNotionalAmount
+        fpmlTradeNotionalChange -> sizeChange -> outstandingNotionalAmount
             extract MapNonNegativeMoneyNonNegativeQuantitySchedule
 
     alias novatedAmount:
-        fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmountsOldModel -> novationAmountsOldModelSequence0 -> novatedAmount
-            extract MapMoneyToNonNegativeQuantitySchedule
+        fpmlNovation -> novatedAmount extract MapMoneyToNonNegativeQuantitySchedule
 
     alias changeInNotionalAmount:
-        fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmount -> tradeLegNotionalChangeModel -> changeInNotionalAmount
+        fpmlNovation -> novationAmount -> changeInNotionalAmount
             extract MapNonNegativeMoneyNonNegativeQuantitySchedule
 
     alias outstandingNotionalAmount:
-        fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmount -> tradeLegNotionalChangeModel -> outstandingNotionalAmount
+        fpmlNovation -> novationAmount -> outstandingNotionalAmount
             extract MapNonNegativeMoneyNonNegativeQuantitySchedule
 
     alias remainingAmount:
-        fpmlPostTradeEventsBaseModel -> novation -> novationAmountsModel -> novationAmountsOldModel -> novationAmountsOldModelSequence0 -> remainingAmount
-            extract MapMoneyToNonNegativeQuantitySchedule
+        fpmlNovation -> remainingAmount extract MapMoneyToNonNegativeQuantitySchedule
 
     alias q:
         [outstandingTradeNotional, outstandingSizeChange, novatedAmount, changeInNotionalAmount, outstandingNotionalAmount, remainingAmount]
@@ -414,16 +402,16 @@ func MapMoneyToNonNegativeQuantitySchedule:
 
 func MapNonNegativeMoneyNonNegativeQuantitySchedule:
     inputs:
-        f fpml.consolidated.shared.NonNegativeMoney (0..1)
+        fpmlNonNegativeMoney fpml.NonNegativeMoney (0..1)
     output:
         priceQuantityList NonNegativeQuantitySchedule (0..1)
 
     set priceQuantityList:
         NonNegativeQuantitySchedule {
-            value: f -> amount,
+            value: fpmlNonNegativeMoney -> amount,
             unit:
                 UnitType {
-                    currency: f -> currency -> value,
+                    currency: fpmlNonNegativeMoney -> currency -> value,
                     ...
                 },
             ...
@@ -431,23 +419,22 @@ func MapNonNegativeMoneyNonNegativeQuantitySchedule:
 
 func MapMessageInformation:
     inputs:
-        messageId fpml.MessageId (0..1)
-        messageHeaderModel fpml.MessageHeaderModel (0..1)
+        fpmlMessageId fpml.MessageId (0..1)
+        fpmlSentBy fpml.MessageAddress (0..1)
+        fpmlSendToList fpml.MessageAddress (0..*)
     output:
         messageInfo MessageInformation (0..1)
     set messageInfo:
         MessageInformation {
-            messageId: MapStringWithScheme(messageId -> value, messageId -> messageIdScheme),
-            sentBy: MapStringWithScheme(
-                        messageHeaderModel -> sentBy -> value,
-                        messageHeaderModel -> sentBy -> messageAddressScheme
+            messageId: MapStringWithScheme(
+                        fpmlMessageId -> value,
+                        fpmlMessageId -> messageIdScheme
                     ),
-            sentTo: [
-                    MapStringWithScheme(
-                            messageHeaderModel -> sendTo only-element -> value,
-                            messageHeaderModel -> sendTo only-element -> messageAddressScheme
-                        )
-                ],
+            sentBy: MapStringWithScheme(
+                        fpmlSentBy -> value,
+                        fpmlSentBy -> messageAddressScheme
+                    ),
+            sentTo: fpmlSendToList extract MapStringWithScheme(value, messageAddressScheme),
             ...
         }
 
@@ -456,8 +443,10 @@ func MapIntent:
         fpmlTrade fpml.Trade (0..1)
         fpmlOriginatingEvent fpml.OriginatingEvent (0..1)
         fpmlTerminatingEvent fpml.TerminatingEvent (0..1)
-        fpmlPostTradeEventsBaseModel fpml.PostTradeEventsBaseModel (0..1)
-        fpmlOptionsEventsBaseModel fpml.OptionsEventsBaseModel (0..1)
+        fpmlNovation fpml.TradeNovationContent (0..1)
+        fpmlTermination fpml.TradeNotionalChange (0..1)
+        fpmlAmendment fpml.TradeAmendmentContent (0..1)
+        fpmlOptionExercise fpml.OptionExercise (0..1)
     output:
         intent EventIntentEnum (0..1)
 
@@ -473,10 +462,9 @@ func MapIntent:
         partyTradeInformation extract allocationStatus -> value = "PostAllocation"
 
     set intent:
-        if fpmlOriginatingEvent -> value = "Novation"
-                or fpmlPostTradeEventsBaseModel -> novation exists
+        if fpmlOriginatingEvent -> value = "Novation" or fpmlNovation exists
         then Novation
-        else if fpmlPostTradeEventsBaseModel -> postTradeEventsBaseModelSequence -> termination exists
+        else if fpmlTermination exists
         then empty
         else if fpmlOriginatingEvent -> value = "Netting"
                 or fpmlOriginatingEvent -> value = "PortfolioCompression"
@@ -490,10 +478,9 @@ func MapIntent:
         else if fpmlOriginatingEvent -> value = "PortfolioRebalancing"
                 or fpmlTerminatingEvent -> value = "PortfolioRebalancing"
         then PortfolioRebalancing
-        else if fpmlOptionsEventsBaseModel -> optionExercise exists
-                or fpmlOriginatingEvent -> value = "Exercise"
+        else if fpmlOptionExercise exists or fpmlOriginatingEvent -> value = "Exercise"
         then OptionExercise
-        else if fpmlPostTradeEventsBaseModel -> amendment exists
+        else if fpmlAmendment exists
         then ContractTermsAmendment
         else if clearing exists
         then Clearing
@@ -514,22 +501,18 @@ func GetEventDate:
         eventDate date (0..1)
 
     set eventDate:
-        if fpmlAmendment -> agreementAndEffectiveDatesModel -> agreementDate exists
-        then MapZoneDateTimeToDate(
-                    fpmlAmendment -> agreementAndEffectiveDatesModel -> agreementDate
-                )
-        else if fpmlTermination -> agreementAndEffectiveDatesModel -> agreementDate exists
-        then MapZoneDateTimeToDate(
-                    fpmlTermination -> agreementAndEffectiveDatesModel -> agreementDate
-                )
+        if fpmlAmendment -> agreementDate exists
+        then MapZoneDateTimeToDate(fpmlAmendment -> agreementDate)
+        else if fpmlTermination -> agreementDate exists
+        then MapZoneDateTimeToDate(fpmlTermination -> agreementDate)
         else if fpmlTrade -> tradeHeader -> partyTradeInformation -> executionDateTime -> value exists
         then MapZoneDateTimeToDate(
                     fpmlTrade -> tradeHeader -> partyTradeInformation -> executionDateTime -> value
                         filter exists
                         then only-element
                 )
-        else if fpmlNovation -> novationDatesModel -> novationDate exists
-        then MapZoneDateTimeToDate(fpmlNovation -> novationDatesModel -> novationDate)
+        else if fpmlNovation -> novationDate exists
+        then MapZoneDateTimeToDate(fpmlNovation -> novationDate)
 
 func GetEffectiveDate:
     inputs:
@@ -540,13 +523,9 @@ func GetEffectiveDate:
         effectiveDate date (0..1)
 
     set effectiveDate:
-        if fpmlAmendment -> agreementAndEffectiveDatesModel -> effectiveDate exists
-        then MapZoneDateTimeToDate(
-                    fpmlAmendment -> agreementAndEffectiveDatesModel -> effectiveDate
-                )
-        else if fpmlTermination -> agreementAndEffectiveDatesModel -> effectiveDate exists
-        then MapZoneDateTimeToDate(
-                    fpmlTermination -> agreementAndEffectiveDatesModel -> effectiveDate
-                )
-        else if fpmlNovation -> novationDatesModel -> novationDate exists
-        then MapZoneDateTimeToDate(fpmlNovation -> novationDatesModel -> novationDate)
+        if fpmlAmendment -> effectiveDate exists
+        then MapZoneDateTimeToDate(fpmlAmendment -> effectiveDate)
+        else if fpmlTermination -> effectiveDate exists
+        then MapZoneDateTimeToDate(fpmlTermination -> effectiveDate)
+        else if fpmlNovation -> novationDate exists
+        then MapZoneDateTimeToDate(fpmlNovation -> novationDate)

--- a/tests/src/test/resources/ingest/diagnostics/product_diagnostics.md
+++ b/tests/src/test/resources/ingest/diagnostics/product_diagnostics.md
@@ -23,8 +23,8 @@
 | volatilitySwapTransactionSupplement | 4 | 99% |
 | fxSwap | 7 | 99% |
 | equitySwapTransactionSupplement | 30 | 99% |
-| varianceSwapTransactionSupplement | 6 | 98% |
 | swap | 166 | 98% |
+| varianceSwapTransactionSupplement | 6 | 98% |
 | swaption | 25 | 98% |
 | bondOption | 12 | 98% |
 | commodityPerformanceSwap | 8 | 98% |
@@ -37,6 +37,6 @@
 | commoditySwaption | 11 | 93% |
 | fxOption | 26 | 93% |
 | commodityOption | 26 | 92% |
-| instrumentTradeDetails | 2 | 88% |
+| instrumentTradeDetails | 2 | 91% |
 | dividendSwapTransactionSupplement | 12 | 81% |
 | bulletPayment | 2 | 71% |

--- a/tests/src/test/resources/ingest/diagnostics/test_pack_diagnostics.md
+++ b/tests/src/test/resources/ingest/diagnostics/test_pack_diagnostics.md
@@ -19,14 +19,14 @@
 | fpml-5-10-products-volatility-swaps | 2 | 99% |
 | fpml-5-13-incomplete-products-equity-options | 20 | 99% |
 | fpml-5-13-products-bond-options | 4 | 99% |
+| fpml-5-10-products-commodity | 14 | 99% |
 | fpml-5-12-processes | 2 | 99% |
 | fpml-5-13-products-variance-swaps | 5 | 99% |
 | fpml-5-10-incomplete-products-fx-derivatives | 20 | 99% |
+| fpml-5-13-products-commodity-derivatives | 18 | 99% |
 | fpml-5-10-products-rates | 74 | 99% |
 | fpml-5-10-invalid-products | 42 | 99% |
-| fpml-5-10-products-commodity | 14 | 98% |
 | fpml-5-13-incomplete-products-commodity-derivatives | 31 | 98% |
-| fpml-5-13-products-commodity-derivatives | 18 | 98% |
 | fpml-5-13-products-interest-rate-derivatives | 67 | 98% |
 | fpml-5-13-incomplete-products-equity-swaps | 3 | 98% |
 | fpml-5-10-incomplete-products-commodity-derivatives | 32 | 98% |

--- a/tests/src/test/resources/ingest/diagnostics/test_pack_diagnostics.md
+++ b/tests/src/test/resources/ingest/diagnostics/test_pack_diagnostics.md
@@ -2,7 +2,7 @@
 
 | Test Pack | Samples | Completeness |
 |:-----------------------------------------------------|:-------:|:-------:|
-| fpml-5-13-incomplete-processes-execution-advice | 3 | 270% |
+| fpml-5-13-incomplete-processes-execution-advice | 3 | 272% |
 | fpml-5-10-incomplete-processes | 11 | 121% |
 | fpml-5-13-processes-execution-advice | 14 | 107% |
 | fpml-5-10-processes | 15 | 106% |
@@ -29,8 +29,8 @@
 | fpml-5-13-incomplete-products-commodity-derivatives | 31 | 98% |
 | fpml-5-13-products-interest-rate-derivatives | 67 | 98% |
 | fpml-5-13-incomplete-products-equity-swaps | 3 | 98% |
-| fpml-5-10-incomplete-products-commodity-derivatives | 32 | 98% |
 | fpml-5-12-products-rates | 27 | 98% |
+| fpml-5-10-incomplete-products-commodity-derivatives | 32 | 98% |
 | fpml-5-10-incomplete-products-bond-options | 3 | 98% |
 | fpml-5-13-products-credit-derivatives | 44 | 98% |
 | fpml-5-13-products-correlation-swaps | 3 | 98% |
@@ -46,7 +46,7 @@
 | fpml-5-13-products-fx-derivatives | 17 | 95% |
 | fpml-5-12-products-fx | 15 | 95% |
 | fpml-5-10-products-fx | 15 | 95% |
-| fpml-5-13-products-inflation-swaps | 13 | 94% |
+| fpml-5-13-products-inflation-swaps | 13 | 95% |
 | fpml-5-10-products-inflation-swaps | 5 | 93% |
 | fpml-5-13-products-equity-options | 7 | 90% |
 | fpml-5-12-products-commodity | 5 | 87% |

--- a/tests/src/test/resources/ingest/diagnostics/test_pack_product_diagnostics.md
+++ b/tests/src/test/resources/ingest/diagnostics/test_pack_product_diagnostics.md
@@ -80,7 +80,7 @@
 | fpml-5-12-products-rates | swaption | 4 | 98% |
 | fpml-5-12-products-repo | securityLending | 2 | 106% |
 | fpml-5-13-incomplete-processes-execution-advice | creditDefaultSwap | 2 | 425% |
-| fpml-5-13-incomplete-processes-execution-advice | instrumentTradeDetails | 1 | 85% |
+| fpml-5-13-incomplete-processes-execution-advice | instrumentTradeDetails | 1 | 89% |
 | fpml-5-13-incomplete-products-commodity-derivatives | commodityBasketOption | 1 | 100% |
 | fpml-5-13-incomplete-products-commodity-derivatives | commodityDigitalOption | 1 | 100% |
 | fpml-5-13-incomplete-products-commodity-derivatives | commodityForward | 4 | 100% |
@@ -120,7 +120,7 @@
 | fpml-5-13-products-fx-derivatives | fxSwap | 3 | 99% |
 | fpml-5-13-products-fx-derivatives | fxVarianceSwap | 1 | 101% |
 | fpml-5-13-products-fx-derivatives | fxVolatilitySwap | 1 | 100% |
-| fpml-5-13-products-inflation-swaps | swap | 13 | 94% |
+| fpml-5-13-products-inflation-swaps | swap | 13 | 95% |
 | fpml-5-13-products-interest-rate-derivatives | bulletPayment | 1 | 71% |
 | fpml-5-13-products-interest-rate-derivatives | capFloor | 3 | 100% |
 | fpml-5-13-products-interest-rate-derivatives | fra | 2 | 100% |

--- a/tests/src/test/resources/ingest/diagnostics/test_pack_product_diagnostics.md
+++ b/tests/src/test/resources/ingest/diagnostics/test_pack_product_diagnostics.md
@@ -35,9 +35,9 @@
 | fpml-5-10-invalid-products | swap | 12 | 100% |
 | fpml-5-10-processes | creditDefaultSwap | 9 | 110% |
 | fpml-5-10-processes | fxSingleLeg | 1 | 102% |
-| fpml-5-10-processes | swap | 5 | 99% |
+| fpml-5-10-processes | swap | 5 | 100% |
 | fpml-5-10-products-commodity | commodityBasketOption | 1 | 100% |
-| fpml-5-10-products-commodity | commodityOption | 7 | 93% |
+| fpml-5-10-products-commodity | commodityOption | 7 | 95% |
 | fpml-5-10-products-commodity | commoditySwap | 6 | 103% |
 | fpml-5-10-products-correlation-swaps | correlationSwap | 4 | 97% |
 | fpml-5-10-products-credit | creditDefaultSwap | 20 | 97% |
@@ -104,7 +104,7 @@
 | fpml-5-13-processes-execution-advice | creditDefaultSwap | 6 | 101% |
 | fpml-5-13-processes-execution-advice | swap | 2 | 103% |
 | fpml-5-13-products-bond-options | bondOption | 4 | 99% |
-| fpml-5-13-products-commodity-derivatives | commodityOption | 11 | 94% |
+| fpml-5-13-products-commodity-derivatives | commodityOption | 11 | 95% |
 | fpml-5-13-products-commodity-derivatives | commoditySwap | 5 | 103% |
 | fpml-5-13-products-commodity-derivatives | swap | 2 | 102% |
 | fpml-5-13-products-correlation-swaps | correlationSwap | 3 | 98% |

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex09-oil-put-option-american.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-10-products-commodity/com-ex09-oil-put-option-american.diff
@@ -19,46 +19,26 @@
 -                    }
 -                  }
 -                }
-@@ -62,19 +44,0 @@
--              "commencementDate" : {
--                "adjustableDate" : {
--                  "unadjustedDate" : "2008-10-27",
--                  "dateAdjustments" : {
--                    "businessDayConvention" : "NotApplicable"
--                  }
--                }
--              },
--              "expirationDate" : [ {
--                "adjustableDate" : {
--                  "unadjustedDate" : "2009-01-12",
--                  "dateAdjustments" : {
--                    "businessDayConvention" : "NotApplicable"
--                  }
--                },
--                "meta" : {
--                  "externalKey" : "expirationDate"
--                }
--              } ],
-@@ -86,0 +49,3 @@
+@@ -86,0 +68,3 @@
 +              },
 +              "meta" : {
 +                "externalKey" : "exerciseDate"
-@@ -103,4 +69,1 @@
+@@ -103,4 +88,1 @@
 -        } ],
 -        "calculationAgent" : {
 -          "calculationAgentPartyEnum" : "AsSpecifiedInMasterAgreement"
 -        }
 +        } ]
-@@ -155,6 +118,0 @@
+@@ -155,6 +137,0 @@
 -                "isExchangeListed" : true,
 -                "exchange" : {
 -                  "name" : {
 -                    "value" : "IFEU"
 -                  }
 -                },
-@@ -164,0 +121,1 @@
+@@ -164,0 +140,1 @@
 +                    "periodMultiplier" : 2,
-@@ -165,5 +123,0 @@
+@@ -165,5 +142,0 @@
 -                  },
 -                  "deliveryDateRollConvention" : {
 -                    "periodMultiplier" : 1,

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-Vanilla-multiple-accounts.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-10-products-rates/EUR-Vanilla-multiple-accounts.diff
@@ -14,3 +14,7 @@
 +              "value" : "quantity-2"
 @@ -314,0 +314,1 @@
 +                    "assetClass" : "InterestRate",
+@@ -456,3 +457,0 @@
+-      "partyReference" : {
+-        "externalReference" : "p1"
+-      },

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex32-zero-coupon-swap-normal-rate.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-12-products-rates/ird-ex32-zero-coupon-swap-normal-rate.diff
@@ -18,23 +18,7 @@
 +              "value" : "quantity-2"
 @@ -314,0 +311,1 @@
 +                    "assetClass" : "InterestRate",
-@@ -358,7 +356,0 @@
--          "value" : "1-2",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
--          }
--        }
--      }, {
--        "identifier" : {
-@@ -389,7 +380,0 @@
--          "value" : "LCH00000000001",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
--          }
--        }
--      }, {
--        "identifier" : {
-@@ -500,0 +484,7 @@
+@@ -500,0 +498,7 @@
 +        "externalReference" : "clearingBroker1"
 +      },
 +      "ownershipPartyReference" : {

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex9-oil-put-option-american.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-13-products-commodity-derivatives/com-ex9-oil-put-option-american.diff
@@ -19,46 +19,26 @@
 -                    }
 -                  }
 -                }
-@@ -62,19 +44,0 @@
--              "commencementDate" : {
--                "adjustableDate" : {
--                  "unadjustedDate" : "2008-10-27",
--                  "dateAdjustments" : {
--                    "businessDayConvention" : "NotApplicable"
--                  }
--                }
--              },
--              "expirationDate" : [ {
--                "adjustableDate" : {
--                  "unadjustedDate" : "2009-01-12",
--                  "dateAdjustments" : {
--                    "businessDayConvention" : "NotApplicable"
--                  }
--                },
--                "meta" : {
--                  "externalKey" : "expirationDate"
--                }
--              } ],
-@@ -86,0 +49,3 @@
+@@ -86,0 +68,3 @@
 +              },
 +              "meta" : {
 +                "externalKey" : "exerciseDate"
-@@ -103,4 +69,1 @@
+@@ -103,4 +88,1 @@
 -        } ],
 -        "calculationAgent" : {
 -          "calculationAgentPartyEnum" : "AsSpecifiedInMasterAgreement"
 -        }
 +        } ]
-@@ -155,6 +118,0 @@
+@@ -155,6 +137,0 @@
 -                "isExchangeListed" : true,
 -                "exchange" : {
 -                  "name" : {
 -                    "value" : "IFEU"
 -                  }
 -                },
-@@ -164,0 +121,1 @@
+@@ -164,0 +140,1 @@
 +                    "periodMultiplier" : 2,
-@@ -165,5 +123,0 @@
+@@ -165,5 +142,0 @@
 -                  },
 -                  "deliveryDateRollConvention" : {
 -                    "periodMultiplier" : 1,

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex06-zc.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-13-products-inflation-swaps/inflation-swap-ex06-zc.diff
@@ -34,44 +34,7 @@
 -                      },
 -                      "identifierType" : "Other"
 -                    } ],
-@@ -310,7 +292,0 @@
--          "value" : "1",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
--          }
--        }
--      }, {
--        "identifier" : {
-@@ -353,28 +328,0 @@
--          "value" : "LCH00000000001",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
--          }
--        }
--      }, {
--        "identifier" : {
--          "value" : "11111111",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/group-id"
--          }
--        }
--      }, {
--        "identifier" : {
--          "value" : "12",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/group-size"
--          }
--        }
--      }, {
--        "identifier" : {
--          "value" : "1111111",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/link-id"
--          }
--        }
--      }, {
--        "identifier" : {
-@@ -485,0 +432,7 @@
+@@ -485,0 +467,7 @@
 +        "externalReference" : "clearingBroker1"
 +      },
 +      "ownershipPartyReference" : {

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex32-zero-coupon-swap-normal-rate.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex32-zero-coupon-swap-normal-rate.diff
@@ -18,23 +18,7 @@
 +              "value" : "quantity-2"
 @@ -314,0 +311,1 @@
 +                    "assetClass" : "InterestRate",
-@@ -358,7 +356,0 @@
--          "value" : "1-2",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
--          }
--        }
--      }, {
--        "identifier" : {
-@@ -389,7 +380,0 @@
--          "value" : "LCH00000000001",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
--          }
--        }
--      }, {
--        "identifier" : {
-@@ -500,0 +484,7 @@
+@@ -500,0 +498,7 @@
 +        "externalReference" : "clearingBroker1"
 +      },
 +      "ownershipPartyReference" : {

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex37-zero-coupon-swap-known-amount-schedule.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-trade-state/fpml-5-13-products-interest-rate-derivatives/ird-ex37-zero-coupon-swap-known-amount-schedule.diff
@@ -47,23 +47,7 @@
 -      }, {
 @@ -306,0 +290,1 @@
 +                    "assetClass" : "InterestRate",
-@@ -350,7 +335,0 @@
--          "value" : "1-2",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
--          }
--        }
--      }, {
--        "identifier" : {
-@@ -393,7 +371,0 @@
--          "value" : "LCH00000000001",
--          "meta" : {
--            "scheme" : "http://www.lchclearnet.com/clearlink/coding-scheme/trade-id"
--          }
--        }
--      }, {
--        "identifier" : {
-@@ -504,0 +475,7 @@
+@@ -504,0 +489,7 @@
 +        "externalReference" : "clearingBroker1"
 +      },
 +      "ownershipPartyReference" : {

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.diff
@@ -22,16 +22,11 @@
 +    "intent" : "Clearing",
 @@ -274,0 +258,1 @@
 +                            "assetClass" : "InterestRate",
-@@ -464,12 +449,0 @@
--                },
--                "price" : {
--                  "value" : 123567,
--                  "unit" : {
--                    "currency" : {
--                      "value" : "USD"
--                    }
--                  },
--                  "perUnitOf" : {
+@@ -473,1 +458,3 @@
 -                    "financialUnit" : "Contract"
--                  },
++                    "currency" : {
++                      "value" : "USD"
++                    }
+@@ -475,1 +462,1 @@
 -                  "priceType" : "CashPrice"
++                  "priceType" : "AssetPrice"

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.diff
@@ -27,6 +27,3 @@
 +                    "currency" : {
 +                      "value" : "USD"
 +                    }
-@@ -475,1 +462,1 @@
--                  "priceType" : "CashPrice"
-+                  "priceType" : "AssetPrice"

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.diff
@@ -31,25 +31,3 @@
 +    "intent" : "Clearing",
 @@ -283,0 +258,1 @@
 +                            "assetClass" : "InterestRate",
-@@ -473,21 +449,0 @@
--                },
--                "price" : {
--                  "value" : 0.05,
--                  "unit" : {
--                    "currency" : {
--                      "value" : "USD",
--                      "meta" : {
--                        "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
--                      }
--                    }
--                  },
--                  "perUnitOf" : {
--                    "currency" : {
--                      "value" : "USD",
--                      "meta" : {
--                        "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
--                      }
--                    }
--                  },
--                  "priceType" : "InterestRate",
--                  "arithmeticOperator" : "Add"

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex68-execution-advice-warrant.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex68-execution-advice-warrant.diff
@@ -2,16 +2,7 @@
 +++ rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-13-incomplete-processes-execution-advice/msg-ex68-execution-advice-warrant.json
 @@ -4,0 +4,1 @@
 +    "eventDate" : "2016-08-25",
-@@ -14,8 +15,0 @@
--                  "value" : "1234512345",
--                  "meta" : {
--                    "scheme" : "http://www.abcbank.com/coding-scheme/front-office/trade-id"
--                  }
--                },
--                "version" : 1
--              }, {
--                "identifier" : {
-@@ -42,35 +35,0 @@
+@@ -42,35 +43,0 @@
 -              "businessUnit" : [ {
 -                "identifier" : {
 -                  "assignedIdentifier" : [ {
@@ -47,7 +38,7 @@
 -                  "externalKey" : "BACKOFFICE"
 -                }
 -              } ],
-@@ -106,0 +64,15 @@
+@@ -106,0 +72,15 @@
 +              "personRole" : [ {
 +                "personReference" : {
 +                  "externalReference" : "person1"
@@ -63,7 +54,7 @@
 +                  "value" : "Broker"
 +                } ]
 +              } ],
-@@ -152,1 +125,4 @@
+@@ -152,1 +133,4 @@
 -      "value" : "FRONTSYSTEM"
 +      "value" : "FRONTSYSTEM",
 +      "meta" : {


### PR DESCRIPTION
# _Infrastructure - Dependency Update_

Version updates include:

- `Bundle` `11.121.2` - Fixes deserialization of ambiguous XML elements.
- `FpML as Rune` `2.0.0` - Flattened model. See FpML as Rune release notes: [2.0.0](https://github.com/rosetta-models/rune-fpml/releases/tag/2.0.0)
- `FpML as Rune` `2.1.1` - Deserialization disambiguation support. See FpML as Rune release notes: [2.1.1](https://github.com/rosetta-models/rune-fpml/releases/tag/2.1.1)

# _FpML Confirmation Ingestion - Flattened FpML Model_

_What is being released?_

This release introduces an updated version of the generated `FpML as Rune` model, incorporating the structural flattening approach described in issue #4666. The flattened model more closely reflects the structure and hierarchy of the source FpML XML documents, rather than the underlying XSD schema structure.

A number of functions that contain filters on the meta type `reference` have had their filter clause commented out as the syntax is not yet supported by the Python code generator. This is currently being addressed in issue #4781, the filters can be uncommented after this issue is addressed.

The release includes:

- Updates to FpML ingestion mapping functions to operate against the revised input model structure.
- Refactoring of ingestion logic and supporting functions impacted by the new model layout.
- Regression and ingestion expectation updates required to support the updated FpML model version.

_Review Directions_

Changes can be reviewed in PR: https://github.com/finos/common-domain-model/pull/4776