### PR TITLE
Instruction composition framework functions

### DIFF
--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-func.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-func.rosetta
@@ -1,0 +1,90 @@
+namespace cdm.event.instructioncomposition
+version "${project.version}"
+
+import cdm.base.datetime.*
+import cdm.event.common.*
+import cdm.event.instructioncomposition.reset.*
+
+func Create_InstructionComposition: <"Creates a new InstructionComposition instance by appending a CompositionStep derived from the provided instruction, updating any previous compositionState, and producing the Instruction Composition Output if at the end of the Instruction Composition process.">
+    inputs:
+        previousInstructionComposition InstructionComposition (0..1) <"The existing Instruction Composition state before this execution step. If absent, this indicates the start of a new Instruction Composition lifecycle.">
+        instructionCompositionIdentifier string (0..1) <"Unique identifier for the Instruction Composition. Must be provided for the first step; in subsequent steps, it should be inherited from the previous Instruction Composition.">
+        tradeId TradeIdentifier (0..1) <"Identifier of the underlying trade associated with this Instruction Composition. If present, should be provided for the first step; in subsequent steps, it should be inherited from the previous Instruction Composition.">
+        instructionCompositionType InstructionCompositionTypeEnum (0..1) <"The type of Instruction Composition being executed (e.g., ResetInstruction). This type must be consistent across all steps. Must be provided for the first step; in subsequent steps, it should be inherited from the previous Instruction Composition.">
+        stepIdentifier string (1..1) <"Identifier of the Instruction Composition Step, used for traceability, debugging, or audit purposes.">
+        compositionStepInstruction CompositionStepInstruction (1..1) <"The Instruction describing the atomic action to be executed in this step. Exactly one instruction must be populated.">
+    output:
+        executedInstructionComposition InstructionComposition (1..1) <"The resulting Instruction Composition after executing the new step, including the updated history, appended step history, and any generated outputs.">
+
+    alias previousCompositionState: previousInstructionComposition -> compositionState
+
+    alias previousCompositionSteps: previousInstructionComposition -> compositionStep
+
+    alias newCompositionState: <"The updated Instruction Composition History produced by overlaying the current instruction on top of the previous history.">
+        AddStepToCompositionState(previousCompositionState, compositionStepInstruction)
+
+    alias newCompositionStep: <"The new Instruction Composition Step representing the execution of the provided instruction at the current point in time.">
+        CompositionStep {
+            identifier: stepIdentifier,
+            timestamp: Now(),
+            compositionStepInstruction: compositionStepInstruction
+        }
+
+    alias instructionCompositionOutput:
+        InstructionCompositionOutput {
+            resetInstruction: empty
+        }
+
+    condition FirstInstructionComposition: <"Validation rule ensuring that for the initial execution (where no previous state exists), both the composition identifier and the composition type must be explicitly defined.">
+        if previousInstructionComposition is absent
+        then instructionCompositionIdentifier exists and instructionCompositionType exists
+
+    set executedInstructionComposition: <"Constructs the final Instruction Composition instance by combining identifiers, updated history, execution history, and outputs.">
+        InstructionComposition {
+            identifier: if previousInstructionComposition is absent
+                    then instructionCompositionIdentifier
+                else previousInstructionComposition -> identifier,
+            tradeId: if previousInstructionComposition is absent
+                    then tradeId
+                else previousInstructionComposition -> tradeId,
+            instructionCompositionType: if previousInstructionComposition is absent
+                    then instructionCompositionType
+                else previousInstructionComposition -> instructionCompositionType,
+            compositionState: newCompositionState,
+            compositionStep: [previousCompositionSteps, newCompositionStep],
+            instructionCompositionOutput: instructionCompositionOutput
+        }
+
+func AddStepToCompositionState: <"Directs the incoming instruction to the appropriate history update logic based on the specific type of Instruction Composition process, ensuring the cumulative state is incrementally updated.">
+    inputs:
+        initialCompositionState CompositionState (0..1)
+        nextStepToAdd CompositionStepInstruction (1..1)
+    output:
+        finalCompositionState CompositionState (1..1)
+
+    set finalCompositionState -> ResetInstructionState:
+        if nextStepToAdd -> instructionCompositionType = ResetInstruction
+        then UpdateResetCompositionState(
+                    initialCompositionState -> ResetInstructionState,
+                    nextStepToAdd -> compositionStepInstructions
+                )
+
+func UpdateResetCompositionState: <"Handles the field-by-field overlay for the Reset process state.">
+    inputs:
+        initialResetCompositionState ResetInstructionState (0..1)
+        nextStepToAdd CompositionStepInstructions (1..1)
+    output:
+        updatedResetCompositionState ResetInstructionState (1..1)
+
+func NextCompositionStepToExecute: <"Determines the next logical execution step for a given Instruction Composition by evaluating its current execution history and process type.">
+    inputs:
+        currentInstructionComposition InstructionComposition (1..1)
+    output:
+        nextCompositionStep InstructionCompositionSteps (0..1)
+
+func ResetInstructionNextStep: <"A state-machine evaluator for the Reset process that identifies the next required instruction by checking for the presence of mandatory data fields across the seven-step lifecycle.">
+    inputs:
+        resetCompositionState ResetInstructionState (0..1)
+        instructionCompositionOutput InstructionCompositionOutput (0..1)
+    output:
+        resetInstructionNextStep ResetInstructionSteps (0..1)

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-func.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-func.rosetta
@@ -10,7 +10,7 @@ func Create_InstructionComposition: <"Creates a new InstructionComposition insta
         previousInstructionComposition InstructionComposition (0..1) <"The existing Instruction Composition state before this execution step. If absent, this indicates the start of a new Instruction Composition lifecycle.">
         instructionCompositionIdentifier string (0..1) <"Unique identifier for the Instruction Composition. Must be provided for the first step; in subsequent steps, it should be inherited from the previous Instruction Composition.">
         tradeId TradeIdentifier (0..1) <"Identifier of the underlying trade associated with this Instruction Composition. If present, should be provided for the first step; in subsequent steps, it should be inherited from the previous Instruction Composition.">
-        instructionCompositionType InstructionCompositionTypeEnum (0..1) <"The type of Instruction Composition being executed (e.g., ResetInstruction). This type must be consistent across all steps. Must be provided for the first step; in subsequent steps, it should be inherited from the previous Instruction Composition.">
+        instructionCompositionType InstructionCompositionTypeEnum (1..1) <"The type of Instruction Composition being executed (e.g., ResetInstruction). This type must be consistent across all steps. Must be provided for the first step; in subsequent steps, it should be inherited from the previous Instruction Composition.">
         stepIdentifier string (1..1) <"Identifier of the Instruction Composition Step, used for traceability, debugging, or audit purposes.">
         compositionStepInstruction CompositionStepInstruction (1..1) <"The Instruction describing the atomic action to be executed in this step. Exactly one instruction must be populated.">
     output:
@@ -57,7 +57,7 @@ func Create_InstructionComposition: <"Creates a new InstructionComposition insta
 
 func AddStepToCompositionState: <"Directs the incoming instruction to the appropriate history update logic based on the specific type of Instruction Composition process, ensuring the cumulative state is incrementally updated.">
     inputs:
-        initialCompositionState CompositionState (0..1)
+        currentCompositionState CompositionState (0..1)
         nextStepToAdd CompositionStepInstruction (1..1)
     output:
         finalCompositionState CompositionState (1..1)
@@ -65,13 +65,14 @@ func AddStepToCompositionState: <"Directs the incoming instruction to the approp
     set finalCompositionState -> ResetInstructionState:
         if nextStepToAdd -> instructionCompositionType = ResetInstruction
         then UpdateResetCompositionState(
-                    initialCompositionState -> ResetInstructionState,
+                    (currentCompositionState switch
+                        ResetInstructionState then item),
                     nextStepToAdd -> compositionStepInstructions
                 )
 
 func UpdateResetCompositionState: <"Handles the field-by-field overlay for the Reset process state.">
     inputs:
-        initialResetCompositionState ResetInstructionState (0..1)
+        currentResetCompositionState ResetInstructionState (0..1)
         nextStepToAdd CompositionStepInstructions (1..1)
     output:
         updatedResetCompositionState ResetInstructionState (1..1)
@@ -84,7 +85,7 @@ func NextCompositionStepToExecute: <"Determines the next logical execution step 
 
 func ResetInstructionNextStep: <"A state-machine evaluator for the Reset process that identifies the next required instruction by checking for the presence of mandatory data fields across the seven-step lifecycle.">
     inputs:
-        resetCompositionState ResetInstructionState (0..1)
+        resetInstructionState ResetInstructionState (0..1)
         instructionCompositionOutput InstructionCompositionOutput (0..1)
     output:
         resetInstructionNextStep ResetInstructionSteps (0..1)

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-enum.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-enum.rosetta
@@ -1,0 +1,12 @@
+namespace cdm.event.instructioncomposition.reset
+version "${project.version}"
+
+enum ResetInstructionCompositionStepsEnum: <"Defines the strictly sequenced lifecycle of a Reset process. Each enum value represents a discrete atomic action required to transition the Instruction Composition from initial trade parameters to the final Reset execution output.">
+    CollectFloatingRateOptionInstruction
+    DetermineUnadjustedCalculationPeriodInstruction
+    AdjustPeriodInstruction
+    AdjustDateInstruction
+    DetermineUnadjustedObservationDatesInstruction
+    AdjustObservationDatesInstruction
+    CalculateResetValueInstruction
+    ResetInstructionOutput

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-type.rosetta
@@ -1,0 +1,6 @@
+namespace cdm.event.instructioncomposition.reset
+version "${project.version}"
+
+type ResetInstructionState: <"The definitive state object for the Reset process. It acts as a cumulative 'Golden Record,' storing every data point captured from Step 1 (Index Collection) through Step 7 (Final Calculation) to ensure deterministic processing.">
+
+type ResetInstructionSteps: <"A wrapper that encapsulates the specific ResetInstructionInstructionCompositionStepsEnum, allowing the engine to identify the exact phase of the Reset lifecycle currently being processed.">

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-type.rosetta
@@ -27,7 +27,8 @@ type InstructionComposition: <"Represents an Instruction Composition orchestrati
 
     condition CompositionStateByType: <"Validates structural integrity by ensuring that the specific InstructionCompositionState type provided (e.g., ResetInstructionState) is strictly aligned with the declared InstructionCompositionType.">
         if instructionCompositionType = ResetInstruction
-        then compositionState -> ResetInstructionState exists
+        then (compositionState switch
+                ResetInstructionState then True) = True
 
 type CompositionStep: <"Represents a single atomic step in the Instruction Composition lifecycle, including its instructions, status, and optional output. Each CompositionStep is defined by an identifier, a timestamp and a single Instruction.">
     identifier string (0..1) <"Identification of the Instruction Composition step.">

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-type.rosetta
@@ -2,11 +2,21 @@ namespace cdm.event.instructioncomposition
 version "${project.version}"
 
 import cdm.event.common.*
+import cdm.event.instructioncomposition.reset.*
 
-type InstructionComposition: <"Represents an instruction composition orchestration, holding data, shared history, and an ordered sequence of CompositionSteps.">
+/*
+ * Architecture for the event Instruction Composition engine.
+
+ * Key Concepts:
+ * - InstructionComposition: The top-level orchestrator holding shared history, trade references, and the execution state
+ * - CompositionSteps: An ordered sequence of 1 or more atomic actions (e.g., an 8-step process for Resets) tracked by identifiers and timestamps
+ * - Reuseable Instructions: Steps decouple 'what' to do by utilizing CompositionStepInstruction, which pairs a process type with a specific executable payload from the global CompositionStepInstructions list
+ * - State & Output: Tracks intermediate progress via CompositionState and records the final outcome (like a ResetInstruction) in the InstructionCompositionOutput
+ */
+type InstructionComposition: <"Represents an Instruction Composition orchestration, holding data, shared history, and an ordered sequence of CompositionSteps. Each InstructionComposition will have one or more CompositionStps.">
     [rootType]
-    compositionStep CompositionStep (1..*) <"Ordered sequence of CompositionSteps that drive the instruction composition process (atomic actions, calculations, validations).">
-    compositionState CompositionState (0..1) <"Shared state accumulated across executed steps, capturing intermediate and final outputs of the instruction composition process.">
+    compositionStep CompositionStep (1..*) <"Ordered sequence of CompositionSteps that drive the Instruction Composition process (atomic actions, calculations, validations).">
+    compositionState CompositionState (0..1) <"Shared state accumulated across executed steps, capturing intermediate and final outputs of the Instruction Composition process.">
     instructionCompositionType InstructionCompositionTypeEnum (1..1) <"Type of Instruction Composition being orchestrated (e.g. ResetInstruction).">
     identifier string (1..1) <"Unique identifier of this InstructionComposition instance.">
     tradeId TradeIdentifier (0..1) <"Identifier of the underlying trade to which this InstructionComposition relates.">
@@ -15,12 +25,16 @@ type InstructionComposition: <"Represents an instruction composition orchestrati
     condition InstructionCompositionType: <"All CompositionSteps within this InstructionComposition must declare the same InstructionCompositionType as the InstructionComposition itself.">
         compositionStep -> compositionStepInstruction -> instructionCompositionType all = instructionCompositionType
 
-type CompositionStep: <"Represents a single atomic step in the instruction composition lifecycle, including its instructions, status, and optional output.">
+    condition CompositionStateByType: <"Validates structural integrity by ensuring that the specific InstructionCompositionState type provided (e.g., ResetInstructionState) is strictly aligned with the declared InstructionCompositionType.">
+        if instructionCompositionType = ResetInstruction
+        then compositionState -> ResetInstructionState exists
+
+type CompositionStep: <"Represents a single atomic step in the Instruction Composition lifecycle, including its instructions, status, and optional output. Each CompositionStep is defined by an identifier, a timestamp and a single Instruction.">
     identifier string (0..1) <"Identification of the Instruction Composition step.">
     timestamp zonedDateTime (0..1) <"Date and time of the execution of the Instruction Composition step after being executed.">
     compositionStepInstruction CompositionStepInstruction (1..1) <"Set of instructions defining the steps of each Instruction Composition process.">
 
-type CompositionStepInstruction: <"Set of instructions defining the steps of each Instruction Composition process.">
+type CompositionStepInstruction: <"Set of instructions defining the steps of each Instruction Composition process. The CompositionStepInstruction is defined by a type (as the same instruction can be reused across different Instruction Composition types), and the selection of one of the list of CompositionStepInstructions (where the information for executing the step is held).">
     instructionCompositionType InstructionCompositionTypeEnum (1..1) <"Definition of the Instruction Composition.">
     compositionStepInstructions CompositionStepInstructions (1..1) <"List of all Instruction CompositionSteps that can be reusable across Instruction Compositions.">
 
@@ -30,3 +44,7 @@ type InstructionCompositionOutput: <"Records the relevant output of each Instruc
     resetInstruction ResetInstruction (0..1) <"Defines the reset value or fixing value produced in cashflow calculations, during the life-cycle of a financial instrument. The reset process defined in Create_Reset function joins product definition details with observations to compute the reset value.">
 
 choice CompositionState: <"A container that holds the cumulative state of an Instruction Composition. It selects the specific history/state schema (e.g., ResetInstructionState) based on the lifecycle process being executed.">
+    ResetInstructionState
+
+choice InstructionCompositionSteps: <"A top-level routing object used to specify which process-specific instruction set is currently active within the execution engine.">
+    ResetInstructionSteps

--- a/rosetta-source/src/test/java/cdm/event/instructioncomposition/functions/AddStepToCompositionStateTest.java
+++ b/rosetta-source/src/test/java/cdm/event/instructioncomposition/functions/AddStepToCompositionStateTest.java
@@ -1,0 +1,123 @@
+package cdm.event.instructioncomposition.functions;
+
+import cdm.event.instructioncomposition.CompositionState;
+import cdm.event.instructioncomposition.CompositionStepInstruction;
+import cdm.event.instructioncomposition.CompositionStepInstructions;
+import cdm.event.instructioncomposition.InstructionCompositionTypeEnum;
+import cdm.event.instructioncomposition.reset.ResetInstructionState;
+import com.google.inject.Binder;
+import javax.inject.Inject;
+
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AddStepToCompositionStateTest extends AbstractFunctionTest {
+
+    @Inject
+    private AddStepToCompositionState addStepToCompositionState;
+
+    private ResetInstructionState capturedInitialResetState;
+    private CompositionStepInstructions capturedNextStep;
+    private boolean resetCompositionStateUpdated;
+
+    @Override
+    protected void bindTestingMocks(Binder binder) {
+        binder.bind(UpdateResetCompositionState.class).toInstance(new UpdateResetCompositionState() {
+            @Override
+            protected ResetInstructionState.ResetInstructionStateBuilder doEvaluate(
+                    ResetInstructionState initialResetCompositionState,
+                    CompositionStepInstructions nextStepToAdd) {
+                capturedInitialResetState = initialResetCompositionState;
+                capturedNextStep = nextStepToAdd;
+                resetCompositionStateUpdated = true;
+                return ResetInstructionState.builder();
+            }
+        });
+    }
+
+    @BeforeEach
+    void resetCapturedArgs() {
+        capturedInitialResetState = null;
+        capturedNextStep = null;
+        resetCompositionStateUpdated = false;
+    }
+
+    @Test
+    @DisplayName("Updates reset composition state when adding a reset instruction without an initial composition state")
+    void shouldUpdateResetCompositionStateWhenTypeIsResetInstructionAndInitialStateIsAbsent() {
+        CompositionStepInstruction nextStep = buildResetStepInstruction();
+
+        CompositionState result = addStepToCompositionState.evaluate(null, nextStep);
+
+        assertNotNull(result, "result must not be null");
+        assertTrue(resetCompositionStateUpdated, "UpdateResetCompositionState must be called");
+        assertNull(capturedInitialResetState,  "UpdateResetCompositionState must receive null when no initial state");
+        assertEquals(nextStep.getCompositionStepInstructions(), capturedNextStep,
+                "UpdateResetCompositionState must receive the CompositionStepInstructions from nextStepToAdd");
+    }
+
+    @Test
+    @DisplayName("Updates reset composition state when adding a reset instruction with the initial composition state with no reset instruction state")
+    void shouldUpdateResetCompositionStateWhenTypeIsResetInstructionAndInitialCompositionStateHasNoResetInstructionState() {
+        CompositionState initialStateWithNoResetState = CompositionState.builder().build();
+        CompositionStepInstruction nextStep = buildResetStepInstruction();
+
+        addStepToCompositionState.evaluate(initialStateWithNoResetState, nextStep);
+
+        assertTrue(resetCompositionStateUpdated, "UpdateResetCompositionState must be called");
+        assertNull(capturedInitialResetState,
+                "UpdateResetCompositionState must receive null when CompositionState has no ResetInstructionState");
+        assertEquals(nextStep.getCompositionStepInstructions(), capturedNextStep,
+                "UpdateResetCompositionState must receive the CompositionStepInstructions from nextStepToAdd");
+    }
+
+    @Test
+    @DisplayName("Updates reset composition state when adding a reset instruction with initial composition state that has reset instruction state")
+    void shouldUpdateResetCompositionStateWhenTypeIsResetInstructionAndInitialCompositionStateHasResetInstructionState() {
+        ResetInstructionState existingResetState = ResetInstructionState.builder().build();
+        CompositionState initialState = CompositionState.builder()
+                .setResetInstructionState(existingResetState)
+                .build();
+        CompositionStepInstruction nextStep = buildResetStepInstruction();
+
+        addStepToCompositionState.evaluate(initialState, nextStep);
+
+        assertTrue(resetCompositionStateUpdated, "UpdateResetCompositionState must be called");
+        assertEquals(capturedInitialResetState, existingResetState,
+                "UpdateResetCompositionState must receive the existing ResetInstructionState from initial CompositionState");
+        assertEquals(nextStep.getCompositionStepInstructions(), capturedNextStep,
+                "UpdateResetCompositionState must receive the CompositionStepInstructions from nextStepToAdd");
+    }
+
+    @Test
+    @DisplayName("Does not update reset composition state when the next step is not a reset instruction")
+    void shouldNotUpdateResetCompositionStateWhenInstructionTypeIsAbsent() {
+        CompositionStepInstruction nextStepWithoutType = CompositionStepInstruction.builder()
+                .setCompositionStepInstructions(CompositionStepInstructions.builder().build())
+                .build();
+
+        addStepToCompositionState.evaluate(null, nextStepWithoutType);
+        assertFalse(resetCompositionStateUpdated,
+                "UpdateResetCompositionState must not be called when type is absent with null initial state");
+
+        CompositionState initialState = CompositionState.builder()
+                .setResetInstructionState(ResetInstructionState.builder().build())
+                .build();
+        addStepToCompositionState.evaluate(initialState, nextStepWithoutType);
+        assertFalse(resetCompositionStateUpdated,
+                "UpdateResetCompositionState must not be called when type is absent, " +
+                        "even with initial state having ResetInstructionState");
+    }
+
+    //-------- Helper methods -----------
+    private static CompositionStepInstruction buildResetStepInstruction() {
+        return CompositionStepInstruction.builder()
+                .setInstructionCompositionType(InstructionCompositionTypeEnum.RESET_INSTRUCTION)
+                .setCompositionStepInstructions(CompositionStepInstructions.builder().build())
+                .build();
+    }
+}

--- a/rosetta-source/src/test/java/cdm/event/instructioncomposition/functions/Create_InstructionCompositionTest.java
+++ b/rosetta-source/src/test/java/cdm/event/instructioncomposition/functions/Create_InstructionCompositionTest.java
@@ -1,0 +1,272 @@
+package cdm.event.instructioncomposition.functions;
+
+import cdm.event.common.TradeIdentifier;
+import cdm.base.staticdata.identifier.TradeIdentifierTypeEnum;
+import cdm.event.instructioncomposition.*;
+
+import javax.inject.Inject;
+
+import com.rosetta.model.lib.functions.ConditionValidator;
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class Create_InstructionCompositionTest extends AbstractFunctionTest {
+
+    @Inject
+    private Create_InstructionComposition createInstructionComposition;
+
+    @Nested
+    @DisplayName("First step scenarios - where no previous InstructionComposition state exists")
+    class FirstStepScenarios {
+
+        @Test
+        @DisplayName("Creates a first step InstructionComposition with the supplied identifier, type, and step instruction")
+        void shouldCreateInstructionCompositionOnFirstStepWithInstructionCompositionIdentifierAndType() {
+            String instructionCompositionId = "IC-001";
+            String stepId = "step-1";
+            CompositionStepInstruction stepInstruction = buildResetStepInstruction();
+
+            InstructionComposition result = createInstructionComposition.evaluate(
+                    null,
+                    instructionCompositionId,
+                    null,
+                    InstructionCompositionTypeEnum.RESET_INSTRUCTION,
+                    stepId,
+                    stepInstruction
+            );
+
+            assertNotNull(result, "InstructionComposition should be created");
+
+            assertEquals(instructionCompositionId, result.getIdentifier(), "identifier must be set on the new InstructionComposition");
+            assertEquals(InstructionCompositionTypeEnum.RESET_INSTRUCTION, result.getInstructionCompositionType());
+            assertNull(result.getTradeId(), "tradeId should be null when not provided on the first step");
+
+            assertEquals(1, result.getCompositionStep().size(), "compositionStep must be stored on the new InstructionComposition");
+            CompositionStep step = result.getCompositionStep().get(0);
+            assertEquals(stepId, step.getIdentifier(), "identifier must be set on the new CompositionStep");
+            assertNotNull(step.getCompositionStepInstruction(),
+                    "compositionStepInstruction must be stored on the new CompositionStep");
+            assertEquals(InstructionCompositionTypeEnum.RESET_INSTRUCTION,
+                    step.getCompositionStepInstruction().getInstructionCompositionType(), "type must be set on the new CompositionStep");
+            assertNotNull(step.getTimestamp(), "timestamp must be set by Now()");
+        }
+
+        @Test
+        @DisplayName("Attaches the supplied trade identifier when present on the first step")
+        void shouldAttachTradeIdOnFirstStepWhenProvided() {
+            TradeIdentifier tradeId = buildTradeIdentifier();
+
+            InstructionComposition result = createInstructionComposition.evaluate(
+                    null,
+                    "IC-001",
+                    tradeId,
+                    InstructionCompositionTypeEnum.RESET_INSTRUCTION,
+                    "step-1",
+                    buildResetStepInstruction()
+            );
+
+            assertNotNull(result.getTradeId(), "tradeId must be set when provided on the first step");
+            assertEquals(tradeId, result.getTradeId(), "tradeId must be set to the one provided on the first step");
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @CsvSource(
+                value = {
+                        "Missing identifier, NULL, RESET_INSTRUCTION",
+                        "Missing type, IC-001, NULL",
+                        "Missing both identifier and type, NULL, NULL"
+                },
+                nullValues = "NULL")
+        @DisplayName("Fails validation when the first step omits required identifier or type values")
+        void shouldFailWhenFirstStepIsMissingRequiredIdentifierOrType(
+                String scenario,
+                String instructionCompositionIdentifier,
+                InstructionCompositionTypeEnum instructionCompositionType) {
+            ConditionValidator.ConditionException exception = assertThrows(ConditionValidator.ConditionException.class, () ->
+                    createInstructionComposition.evaluate(
+                            null,
+                            instructionCompositionIdentifier,
+                            null,
+                            instructionCompositionType,
+                            "step-1",
+                            buildResetStepInstruction()
+                    )
+            );
+            assertEquals("Validation rule ensuring that for the initial execution (where no previous state exists), " +
+                            "both the composition identifier and the composition type must be explicitly defined.",
+                    exception.getMessage());
+        }
+    }
+
+    @Nested
+    @DisplayName("Subsequent step scenarios - where a previous InstructionComposition state exists and should be inherited from")
+    class SubsequentStepScenarios {
+
+        @Test
+        @DisplayName("Creates an InstructionComposition for the subsequent step and inherits identifier and type from the previous one")
+        void shouldInheritIdentifierTypeOnSubsequentStep() {
+            String instructionCompositionId = "IC-001";
+            String step1Id = "step-1";
+            String step2Id = "step-2";
+
+            InstructionComposition first = createInstructionComposition.evaluate(
+                    null,
+                    instructionCompositionId,
+                    null,
+                    InstructionCompositionTypeEnum.RESET_INSTRUCTION,
+                    step1Id,
+                    buildResetStepInstruction());
+
+            InstructionComposition result = createInstructionComposition.evaluate(
+                    first,
+                    null,
+                    null,
+                    null,
+                    step2Id,
+                    buildResetStepInstruction());
+
+            assertNotNull(result, "InstructionComposition should be created");
+
+            assertEquals(instructionCompositionId, result.getIdentifier(),
+                    "identifier must be inherited from previous InstructionComposition");
+            assertEquals(InstructionCompositionTypeEnum.RESET_INSTRUCTION,
+                    result.getInstructionCompositionType(), "type must be inherited");
+            assertNull(result.getTradeId(), "null tradeId must remain null across steps");
+
+            assertEquals(2, result.getCompositionStep().size(),
+                    "compositionStep must be stored on the new InstructionComposition");
+            assertEquals(step1Id, result.getCompositionStep().get(0).getIdentifier(),
+                    "Previous step must be carried forward");
+            assertEquals(step2Id, result.getCompositionStep().get(1).getIdentifier(),
+                    "identifier must be set on the new CompositionStep");
+            result.getCompositionStep().forEach(step ->
+                    assertNotNull(step.getTimestamp(), "every step must have a timestamp set by Now()"));
+        }
+
+        @Test
+        @DisplayName("Carries forward the existing identifier and type and ignores newly supplied ones on later steps")
+        void shouldCarryForwardIdentifierAndTypeAndIgnoreNewlySuppliedOnSubsequentStep() {
+            String instructionCompositionId = "IC-001";
+
+            InstructionComposition first = createInstructionComposition.evaluate(
+                    null,
+                    instructionCompositionId,
+                    null,
+                    InstructionCompositionTypeEnum.RESET_INSTRUCTION,
+                    "step-1",
+                    buildResetStepInstruction());
+
+            InstructionComposition result = createInstructionComposition.evaluate(
+                    first,
+                    "IC-002",
+                    null,
+                    InstructionCompositionTypeEnum.RESET_INSTRUCTION,
+                    "step-2",
+                    buildResetStepInstruction()
+            );
+
+            assertEquals(instructionCompositionId, result.getIdentifier(),
+                    "identifier from previous composition must take precedence over a newly supplied one");
+            assertEquals(InstructionCompositionTypeEnum.RESET_INSTRUCTION,
+                    result.getInstructionCompositionType(),
+                    "type from previous composition must take precedence over a newly supplied one");
+        }
+
+        @Test
+        @DisplayName("Carries forward the existing trade identifier and ignores a newly supplied one on later steps")
+        void shouldCarryForwardTradeIdAndIgnoreNewlySuppliedOnSubsequentStep() {
+            TradeIdentifier originalTradeId = buildTradeIdentifier();
+            TradeIdentifier differentTradeId = TradeIdentifier.builder()
+                    .setIdentifierType(TradeIdentifierTypeEnum.UNIQUE_SWAP_IDENTIFIER)
+                    .build();
+
+            InstructionComposition first = createInstructionComposition.evaluate(
+                    null,
+                    "IC-001",
+                    originalTradeId,
+                    InstructionCompositionTypeEnum.RESET_INSTRUCTION,
+                    "step-1",
+                    buildResetStepInstruction());
+
+            InstructionComposition second = createInstructionComposition.evaluate(
+                    first,
+                    null,
+                    null,
+                    null,
+                    "step-2",
+                    buildResetStepInstruction());
+
+            assertNotNull(second.getTradeId(), "tradeId must be carried forward when not re-supplied");
+            assertEquals(TradeIdentifierTypeEnum.UNIQUE_TRANSACTION_IDENTIFIER,
+                    second.getTradeId().getIdentifierType());
+
+            InstructionComposition third = createInstructionComposition.evaluate(
+                    second,
+                    null,
+                    differentTradeId,
+                    null,
+                    "step-3",
+                    buildResetStepInstruction());
+            assertEquals(TradeIdentifierTypeEnum.UNIQUE_TRANSACTION_IDENTIFIER,
+                    third.getTradeId().getIdentifierType(),
+                    "tradeId from previous composition must take precedence over a newly supplied one");
+        }
+
+        @Test
+        @DisplayName("Accumulates steps in execution order while timestamping each step")
+        void shouldAccumulateStepsWithIdentifiersAndTimestampsAcrossMultipleExecutions() {
+            String step1Id = "step-1";
+            String step2Id = "step-2";
+            String step3Id = "step-3";
+
+            InstructionComposition step1 = createInstructionComposition.evaluate(
+                    null,
+                    "IC-001",
+                    null,
+                    InstructionCompositionTypeEnum.RESET_INSTRUCTION,
+                    step1Id,
+                    buildResetStepInstruction());
+            InstructionComposition step2 = createInstructionComposition.evaluate(
+                    step1,
+                    null,
+                    null,
+                    null,
+                    step2Id,
+                    buildResetStepInstruction());
+            InstructionComposition step3 = createInstructionComposition.evaluate(
+                    step2,
+                    null,
+                    null,
+                    null,
+                    step3Id,
+                    buildResetStepInstruction());
+
+            assertEquals(3, step3.getCompositionStep().size(), "all steps must be accumulated on the new InstructionComposition");
+            assertEquals(step1Id, step3.getCompositionStep().get(0).getIdentifier(), "steps must be stored in the order they were executed");
+            assertEquals(step2Id, step3.getCompositionStep().get(1).getIdentifier(), "steps must be stored in the order they were executed");
+            assertEquals(step3Id, step3.getCompositionStep().get(2).getIdentifier(), "steps must be stored in the order they were executed");
+            step3.getCompositionStep().forEach(step ->
+                    assertNotNull(step.getTimestamp(), "every step must have a timestamp set by Now()"));
+        }
+    }
+
+    //-------- Helper methods -----------
+    private static CompositionStepInstruction buildResetStepInstruction() {
+        return CompositionStepInstruction.builder()
+                .setInstructionCompositionType(InstructionCompositionTypeEnum.RESET_INSTRUCTION)
+                .setCompositionStepInstructions(CompositionStepInstructions.builder().build())
+                .build();
+    }
+
+    private static TradeIdentifier buildTradeIdentifier() {
+        return TradeIdentifier.builder()
+                .setIdentifierType(TradeIdentifierTypeEnum.UNIQUE_TRANSACTION_IDENTIFIER)
+                .build();
+    }
+}


### PR DESCRIPTION
# _Instruction Composition Framework Functions_


_Background_

The CDM Smart Contract Taskforce is introducing the Instruction Composition Model within the Common Domain Model (CDM). While the CDM has traditionally been declarative, defining what a lifecycle event is, it has not always defined how that event is operationally executed. This gap often forces institutions to implement their own procedural logic externally, increasing reconciliation risks and inconsistent interpretations. This release bridges that gap by establishing a modular, stateful, and deterministic framework to execute the sequential steps and intermediate computations of contractual workflows directly within the model. For further information, see issue #4165.


_What is being released?_

This release builds upon the foundational structures of the Instruction Composition Framework within the cdm.event.instructioncomposition namespace by introducing core operational functions, conditional validation constraints, and routing choices to support the state-machine execution logic. For further information, see issue #4593 

_Functions_

Changes that can be found in the cdm.event.instructionComposition namespace:
- `Create_InstructionComposition`: The primary state-transition engine. Appends a new CompositionStep (stamping Now()), triggers the cumulative history state update, and controls structural inheritance (such as tradeId and instructionCompositionIdentifier) across step executions
- `AddStepToCompositionState`: Evaluates the incoming step instruction type and dynamically routes it to update the corresponding state object choice (e.g., directing reset workflows to UpdateResetCompositionState)
- `UpdateResetCompositionState`: Performs the field-by-field cumulative update overlay logic specifically for the Interest Rate Reset state
- `NextCompositionStepToExecute`: Evaluates the total execution timeline to determine what next phase must be targeted by the engine
- `ResetInstructionNextStep`: Serves as a targeted state-machine evaluator specifically for the 8-step Interest Rate Reset lifecycle by analyzing present and missing data points

_Types and Choices_

Changes that can be found in the cdm.event.instructioncomposition namespace:
- `InstructionComposition` (Updated): Includes a new structural condition CompositionStateByType, which verifies that if instructionCompositionType = ResetInstruction, then compositionState -> ResetInstructionState must exist
- `CompositionState` (Updated): Modified to include ResetInstructionState as an active element of the choice routing container
- `InstructionCompositionSteps`: A top-level routing object utilized by the engine to identify and flag the active process-specific instruction sets

Changes that can be found in the cdm.event.instructioncomposition.reset namespace:
- `ResetInstructionState` The state accumulator for the reset lifecycle. Acts as the functional "Golden Record" that aggregates variables compiled across the workflow steps to enable deterministic process replays
- `ResetInstructionSteps`: A dedicated process wrapper encapsulating the underlying execution phases (ResetInstructionInstructionCompositionStepsEnum), mapping directly back to the top-level routing choices


_Review Directions_

Navigate to the following paths to inspect the new models:
- rosetta-source/src/main/rosetta/instructionComposition-type.rosetta to review the primary cdm.event.instructioncomposition structures, including the updated InstructionComposition type, conditional alignment constraints, and the CompositionState / InstructionCompositionSteps top-level routing choices
- rosetta-source/src/main/rosetta/instructionComposition-enum.rosetta to inspect the updated InstructionCompositionTypeEnum process mappings
- rosetta-source/src/main/rosetta/instructionComposition-func.rosetta to examine the core state-machine and lifecycle execution functions (including Create_InstructionComposition, AddStepToCompositionState, and the state evaluators)
- rosetta-source/src/main/rosetta/instructionComposition-reset-type.rosetta to inspect the dedicated cdm.event.instructioncomposition.reset components, including the cumulative ResetInstructionState accumulator and the ResetInstructionSteps process wrapper