### PR TITLE
Update CVE failure for npm shell-quote package

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16,6 +16,7 @@
         "image-size": "1.2.1",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
+        "shell-quote": "1.8.4",
         "trim": "0.0.3"
       },
       "engines": {
@@ -17736,9 +17737,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"

--- a/website/package.json
+++ b/website/package.json
@@ -24,6 +24,7 @@
     "image-size": "1.2.1",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
+    "shell-quote": "1.8.4",
     "trim": "0.0.3"
   },
   "overrides": {


### PR DESCRIPTION
# _Infrastructure - Dependency Update_

_What is being released?_

This release updates third-party software libraries to comply with the “Common Vulnerabilities and Exposures” standard (CVE, https://www.cve.org/):

- Update shell-quote to version 1.8.4 - [GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p)

_Review Directions_

The changes can be reviewed in PR: [#4838](https://github.com/finos/common-domain-model/pull/4838)