### PR TITLE
SettlementBase Refactor

### DIFF
--- a/docs/product-model.md
+++ b/docs/product-model.md
@@ -1121,6 +1121,8 @@ type SettlementBase:
   settlementCurrency string (0..1)
     [metadata scheme]
   settlementDate SettlementDate (0..1)
+  settlementCentre SettlementCentreEnum (0..1)
+    [deprecated]
   settlementProvision SettlementProvision (0..1)
   standardSettlementStyle StandardSettlementStyleEnum (0..1)
   securitySettlementCentre AssetAncillaryPartyRoleEnum (0..1)

--- a/docs/product-model.md
+++ b/docs/product-model.md
@@ -1121,9 +1121,10 @@ type SettlementBase:
   settlementCurrency string (0..1)
     [metadata scheme]
   settlementDate SettlementDate (0..1)
-  settlementCentre SettlementCentreEnum (0..1)
   settlementProvision SettlementProvision (0..1)
   standardSettlementStyle StandardSettlementStyleEnum (0..1)
+  securitySettlementCentre AssetAncillaryPartyRoleEnum (0..1)
+  cashSettlementCentre AssetAncillaryPartyRoleEnum (0..1)
 ```
 
 ### BuyerSeller

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-input.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-input.json
@@ -3,11 +3,11 @@
     "primitiveInstruction" : {
       "execution" : {
         "product" : {
-          "@key" : "b7919021",
+          "@key" : "3b6a16ce",
           "economicTerms" : {
             "payout" : [ {
               "@type" : "cdm.product.template.SettlementPayout",
-              "@key" : "b7919021",
+              "@key" : "3b6a16ce",
               "payerReceiver" : {
                 "payer" : "Party1",
                 "receiver" : "Party2"
@@ -37,8 +37,7 @@
                 "@ref:scoped" : "observable-1"
               }
             } ]
-          },
-          "productPartyRole" : "Party1"
+          }
         },
         "priceQuantity" : [ {
           "@key" : "4062b7ba",

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-input.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-input.json
@@ -3,11 +3,11 @@
     "primitiveInstruction" : {
       "execution" : {
         "product" : {
-          "@key" : "a314fba4",
+          "@key" : "b7919021",
           "economicTerms" : {
             "payout" : [ {
               "@type" : "cdm.product.template.SettlementPayout",
-              "@key" : "a314fba4",
+              "@key" : "b7919021",
               "payerReceiver" : {
                 "payer" : "Party1",
                 "receiver" : "Party2"
@@ -28,8 +28,7 @@
                       "@data" : "2020-09-24"
                     }
                   }
-                },
-                "settlementCentre" : "EuroclearBank"
+                }
               },
               "underlier" : {
                 "@type" : "cdm.observable.asset.Observable",

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-input.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-input.json
@@ -28,14 +28,17 @@
                       "@data" : "2020-09-24"
                     }
                   }
-                }
+                },
+                "securitySettlementCentre" : "SecuritySettlementCentre",
+                "cashSettlementCentre" : "CashSettlementCentre"
               },
               "underlier" : {
                 "@type" : "cdm.observable.asset.Observable",
                 "@ref:scoped" : "observable-1"
               }
             } ]
-          }
+          },
+          "productPartyRole" : "Party1"
         },
         "priceQuantity" : [ {
           "@key" : "4062b7ba",

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-output.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "c7015e9d",
+  "@key" : "36471667",
   "eventDate" : "2020-09-22",
   "instruction" : [ {
     "primitiveInstruction" : {
@@ -40,8 +40,7 @@
                       "@data" : "2020-09-24"
                     }
                   }
-                },
-                "settlementCentre" : "EuroclearBank"
+                }
               },
               "underlier" : {
                 "@type" : "cdm.observable.asset.Observable",
@@ -186,8 +185,7 @@
                     "@data" : "2020-09-24"
                   }
                 }
-              },
-              "settlementCentre" : "EuroclearBank"
+              }
             },
             "underlier" : {
               "@type" : "cdm.observable.asset.Observable",

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-output.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-output.json
@@ -43,7 +43,7 @@
                 },
                 "securitySettlementCentre" : "SecuritySettlementCentre",
                 "cashSettlementCentre" : "CashSettlementCentre"
-            },
+              },
               "underlier" : {
                 "@type" : "cdm.observable.asset.Observable",
                 "@ref:scoped" : "observable-1"
@@ -190,7 +190,7 @@
               },
               "securitySettlementCentre" : "SecuritySettlementCentre",
               "cashSettlementCentre" : "CashSettlementCentre"
-          },
+            },
             "underlier" : {
               "@type" : "cdm.observable.asset.Observable",
               "@ref:scoped" : "observable-1"

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-output.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "36471667",
+  "@key" : "b9558ac1",
   "eventDate" : "2020-09-22",
   "instruction" : [ {
     "primitiveInstruction" : {
@@ -40,8 +40,10 @@
                       "@data" : "2020-09-24"
                     }
                   }
-                }
-              },
+                },
+                "securitySettlementCentre" : "SecuritySettlementCentre",
+                "cashSettlementCentre" : "CashSettlementCentre"
+            },
               "underlier" : {
                 "@type" : "cdm.observable.asset.Observable",
                 "@ref:scoped" : "observable-1"
@@ -185,8 +187,10 @@
                     "@data" : "2020-09-24"
                   }
                 }
-              }
-            },
+              },
+              "securitySettlementCentre" : "SecuritySettlementCentre",
+              "cashSettlementCentre" : "CashSettlementCentre"
+          },
             "underlier" : {
               "@type" : "cdm.observable.asset.Observable",
               "@ref:scoped" : "observable-1"

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-with-bond-details-func-input.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-with-bond-details-func-input.json
@@ -26,8 +26,7 @@
                       "@data" : "2020-09-24"
                     }
                   }
-                },
-                "settlementCentre" : "EuroclearBank"
+                }
               },
               "underlier" : {
                 "@type" : "cdm.observable.asset.Observable",

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-with-bond-details-func-input.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-with-bond-details-func-input.json
@@ -26,8 +26,10 @@
                       "@data" : "2020-09-24"
                     }
                   }
-                }
-              },
+                },
+                "securitySettlementCentre" : "SecuritySettlementCentre",
+                "cashSettlementCentre" : "CashSettlementCentre"
+            },
               "underlier" : {
                 "@type" : "cdm.observable.asset.Observable",
                 "@ref:scoped" : "observable-1"

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-with-bond-details-func-output.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-with-bond-details-func-output.json
@@ -34,7 +34,7 @@
                 },
                 "securitySettlementCentre" : "SecuritySettlementCentre",
                 "cashSettlementCentre" : "CashSettlementCentre"
-            },
+              },
               "underlier" : {
                 "@type" : "cdm.observable.asset.Observable",
                 "@ref:scoped" : "observable-1"
@@ -171,7 +171,7 @@
               },
               "securitySettlementCentre" : "SecuritySettlementCentre",
               "cashSettlementCentre" : "CashSettlementCentre"
-          },
+            },
             "underlier" : {
               "@type" : "cdm.observable.asset.Observable",
               "@ref:scoped" : "observable-1"

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-with-bond-details-func-output.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-with-bond-details-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "e221765d",
+  "@key" : "8245158d",
   "eventDate" : "2020-09-22",
   "instruction" : [ {
     "primitiveInstruction" : {
@@ -31,8 +31,7 @@
                       "@data" : "2020-09-24"
                     }
                   }
-                },
-                "settlementCentre" : "EuroclearBank"
+                }
               },
               "underlier" : {
                 "@type" : "cdm.observable.asset.Observable",
@@ -167,8 +166,7 @@
                     "@data" : "2020-09-24"
                   }
                 }
-              },
-              "settlementCentre" : "EuroclearBank"
+              }
             },
             "underlier" : {
               "@type" : "cdm.observable.asset.Observable",

--- a/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-with-bond-details-func-output.json
+++ b/rosetta-source/src/main/resources/functions/repo-and-bond/bond-execution-with-bond-details-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "8245158d",
+  "@key" : "d1ad41ad",
   "eventDate" : "2020-09-22",
   "instruction" : [ {
     "primitiveInstruction" : {
@@ -31,8 +31,10 @@
                       "@data" : "2020-09-24"
                     }
                   }
-                }
-              },
+                },
+                "securitySettlementCentre" : "SecuritySettlementCentre",
+                "cashSettlementCentre" : "CashSettlementCentre"
+            },
               "underlier" : {
                 "@type" : "cdm.observable.asset.Observable",
                 "@ref:scoped" : "observable-1"
@@ -166,8 +168,10 @@
                     "@data" : "2020-09-24"
                   }
                 }
-              }
-            },
+              },
+              "securitySettlementCentre" : "SecuritySettlementCentre",
+              "cashSettlementCentre" : "CashSettlementCentre"
+          },
             "underlier" : {
               "@type" : "cdm.observable.asset.Observable",
               "@ref:scoped" : "observable-1"

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-bond-options.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-bond-options.json
@@ -10,7 +10,7 @@
     "assertions" : {
       "inputPathCount" : 63,
       "outputPathCount" : 69,
-      "modelValidationFailures" : 2,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {
@@ -21,7 +21,7 @@
     "assertions" : {
       "inputPathCount" : 76,
       "outputPathCount" : 70,
-      "modelValidationFailures" : 2,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {
@@ -32,7 +32,7 @@
     "assertions" : {
       "inputPathCount" : 70,
       "outputPathCount" : 66,
-      "modelValidationFailures" : 3,
+      "modelValidationFailures" : 4,
       "runtimeError" : false
     }
   } ]

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-equity-options.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-incomplete-products-equity-options.json
@@ -10,7 +10,7 @@
     "assertions" : {
       "inputPathCount" : 86,
       "outputPathCount" : 91,
-      "modelValidationFailures" : 7,
+      "modelValidationFailures" : 8,
       "runtimeError" : false
     }
   }, {
@@ -21,7 +21,7 @@
     "assertions" : {
       "inputPathCount" : 65,
       "outputPathCount" : 87,
-      "modelValidationFailures" : 10,
+      "modelValidationFailures" : 11,
       "runtimeError" : false
     }
   }, {
@@ -32,7 +32,7 @@
     "assertions" : {
       "inputPathCount" : 65,
       "outputPathCount" : 87,
-      "modelValidationFailures" : 10,
+      "modelValidationFailures" : 11,
       "runtimeError" : false
     }
   }, {
@@ -98,7 +98,7 @@
     "assertions" : {
       "inputPathCount" : 89,
       "outputPathCount" : 102,
-      "modelValidationFailures" : 9,
+      "modelValidationFailures" : 10,
       "runtimeError" : false
     }
   }, {
@@ -120,7 +120,7 @@
     "assertions" : {
       "inputPathCount" : 82,
       "outputPathCount" : 89,
-      "modelValidationFailures" : 7,
+      "modelValidationFailures" : 8,
       "runtimeError" : false
     }
   }, {
@@ -131,7 +131,7 @@
     "assertions" : {
       "inputPathCount" : 63,
       "outputPathCount" : 87,
-      "modelValidationFailures" : 10,
+      "modelValidationFailures" : 11,
       "runtimeError" : false
     }
   }, {
@@ -142,7 +142,7 @@
     "assertions" : {
       "inputPathCount" : 60,
       "outputPathCount" : 94,
-      "modelValidationFailures" : 8,
+      "modelValidationFailures" : 9,
       "runtimeError" : false
     }
   }, {
@@ -153,7 +153,7 @@
     "assertions" : {
       "inputPathCount" : 91,
       "outputPathCount" : 91,
-      "modelValidationFailures" : 7,
+      "modelValidationFailures" : 8,
       "runtimeError" : false
     }
   }, {
@@ -175,7 +175,7 @@
     "assertions" : {
       "inputPathCount" : 50,
       "outputPathCount" : 86,
-      "modelValidationFailures" : 11,
+      "modelValidationFailures" : 12,
       "runtimeError" : false
     }
   }, {
@@ -186,7 +186,7 @@
     "assertions" : {
       "inputPathCount" : 58,
       "outputPathCount" : 86,
-      "modelValidationFailures" : 4,
+      "modelValidationFailures" : 5,
       "runtimeError" : false
     }
   }, {
@@ -208,7 +208,7 @@
     "assertions" : {
       "inputPathCount" : 100,
       "outputPathCount" : 89,
-      "modelValidationFailures" : 7,
+      "modelValidationFailures" : 8,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-equity.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-equity.json
@@ -10,7 +10,7 @@
     "assertions" : {
       "inputPathCount" : 77,
       "outputPathCount" : 91,
-      "modelValidationFailures" : 7,
+      "modelValidationFailures" : 8,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-rates.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-10-products-rates.json
@@ -10,7 +10,7 @@
     "assertions" : {
       "inputPathCount" : 132,
       "outputPathCount" : 86,
-      "modelValidationFailures" : 16,
+      "modelValidationFailures" : 17,
       "runtimeError" : false
     }
   }, {
@@ -21,7 +21,7 @@
     "assertions" : {
       "inputPathCount" : 134,
       "outputPathCount" : 86,
-      "modelValidationFailures" : 16,
+      "modelValidationFailures" : 17,
       "runtimeError" : false
     }
   }, {
@@ -32,7 +32,7 @@
     "assertions" : {
       "inputPathCount" : 54,
       "outputPathCount" : 78,
-      "modelValidationFailures" : 2,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {
@@ -54,7 +54,7 @@
     "assertions" : {
       "inputPathCount" : 58,
       "outputPathCount" : 74,
-      "modelValidationFailures" : 2,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-equity.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-equity.json
@@ -10,7 +10,7 @@
     "assertions" : {
       "inputPathCount" : 86,
       "outputPathCount" : 91,
-      "modelValidationFailures" : 7,
+      "modelValidationFailures" : 8,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-rates.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-12-products-rates.json
@@ -10,7 +10,7 @@
     "assertions" : {
       "inputPathCount" : 63,
       "outputPathCount" : 69,
-      "modelValidationFailures" : 2,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {
@@ -21,7 +21,7 @@
     "assertions" : {
       "inputPathCount" : 76,
       "outputPathCount" : 70,
-      "modelValidationFailures" : 2,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {
@@ -32,7 +32,7 @@
     "assertions" : {
       "inputPathCount" : 70,
       "outputPathCount" : 66,
-      "modelValidationFailures" : 3,
+      "modelValidationFailures" : 4,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-equity-options.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-incomplete-products-equity-options.json
@@ -21,7 +21,7 @@
     "assertions" : {
       "inputPathCount" : 86,
       "outputPathCount" : 91,
-      "modelValidationFailures" : 7,
+      "modelValidationFailures" : 8,
       "runtimeError" : false
     }
   }, {
@@ -76,7 +76,7 @@
     "assertions" : {
       "inputPathCount" : 89,
       "outputPathCount" : 102,
-      "modelValidationFailures" : 9,
+      "modelValidationFailures" : 10,
       "runtimeError" : false
     }
   }, {
@@ -87,7 +87,7 @@
     "assertions" : {
       "inputPathCount" : 82,
       "outputPathCount" : 89,
-      "modelValidationFailures" : 7,
+      "modelValidationFailures" : 8,
       "runtimeError" : false
     }
   }, {
@@ -98,7 +98,7 @@
     "assertions" : {
       "inputPathCount" : 91,
       "outputPathCount" : 91,
-      "modelValidationFailures" : 7,
+      "modelValidationFailures" : 8,
       "runtimeError" : false
     }
   }, {
@@ -120,7 +120,7 @@
     "assertions" : {
       "inputPathCount" : 50,
       "outputPathCount" : 86,
-      "modelValidationFailures" : 11,
+      "modelValidationFailures" : 12,
       "runtimeError" : false
     }
   }, {
@@ -131,7 +131,7 @@
     "assertions" : {
       "inputPathCount" : 58,
       "outputPathCount" : 86,
-      "modelValidationFailures" : 4,
+      "modelValidationFailures" : 5,
       "runtimeError" : false
     }
   }, {
@@ -153,7 +153,7 @@
     "assertions" : {
       "inputPathCount" : 100,
       "outputPathCount" : 89,
-      "modelValidationFailures" : 7,
+      "modelValidationFailures" : 8,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-bond-options.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-bond-options.json
@@ -10,7 +10,7 @@
     "assertions" : {
       "inputPathCount" : 63,
       "outputPathCount" : 69,
-      "modelValidationFailures" : 2,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {
@@ -21,7 +21,7 @@
     "assertions" : {
       "inputPathCount" : 76,
       "outputPathCount" : 70,
-      "modelValidationFailures" : 2,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {
@@ -32,7 +32,7 @@
     "assertions" : {
       "inputPathCount" : 70,
       "outputPathCount" : 66,
-      "modelValidationFailures" : 3,
+      "modelValidationFailures" : 4,
       "runtimeError" : false
     }
   }, {
@@ -43,7 +43,7 @@
     "assertions" : {
       "inputPathCount" : 77,
       "outputPathCount" : 73,
-      "modelValidationFailures" : 4,
+      "modelValidationFailures" : 5,
       "runtimeError" : false
     }
   } ]

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-equity-options.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-equity-options.json
@@ -10,7 +10,7 @@
     "assertions" : {
       "inputPathCount" : 65,
       "outputPathCount" : 87,
-      "modelValidationFailures" : 10,
+      "modelValidationFailures" : 11,
       "runtimeError" : false
     }
   }, {
@@ -21,7 +21,7 @@
     "assertions" : {
       "inputPathCount" : 65,
       "outputPathCount" : 87,
-      "modelValidationFailures" : 10,
+      "modelValidationFailures" : 11,
       "runtimeError" : false
     }
   }, {
@@ -54,7 +54,7 @@
     "assertions" : {
       "inputPathCount" : 63,
       "outputPathCount" : 87,
-      "modelValidationFailures" : 10,
+      "modelValidationFailures" : 11,
       "runtimeError" : false
     }
   }, {
@@ -65,7 +65,7 @@
     "assertions" : {
       "inputPathCount" : 60,
       "outputPathCount" : 94,
-      "modelValidationFailures" : 8,
+      "modelValidationFailures" : 9,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/rosetta/base-staticdata-party-enum.rosetta
+++ b/rosetta-source/src/main/rosetta/base-staticdata-party-enum.rosetta
@@ -128,6 +128,10 @@ enum AssetAncillaryPartyRoleEnum: <"The enumerated values that specify the role 
     TransferAgent <"The party responsible for maintaining records of owners and processing changes in ownership.">
     Exchange <"The exchange or platform where the security has been issued and the exchange has an indirect role.">
     RelatedExchange <"An exchange or platform other than the primary exchange where the security has been issued and the exchange has an indirect role.">
+    SecuritySettlementCentre <"Specifies the party that processes the transfer and delivery of securities between issuers, counterparties, agents and other service providers.">
+    CashSettlementCentre <"Specifies the party that processes the transfer and delivery of cash between issuers, counterparties, agents and other service providers.">
+    PlaceOfDeposit <"Specifies the party responsible for recording securities ownership, holding physical certificates and facilitating securities transfers.">
+    Custodian <"Specifies the party responsible for safekeeping securities and performing securities lifecycle events.">
 
 enum AncillaryRoleEnum: <"Defines the enumerated values to specify the ancillary roles to the transaction. The product is agnostic to the actual parties involved in the transaction, with the party references abstracted away from the product definition and replaced by the AncillaryRoleEnum. The AncillaryRoleEnum can then be positioned in the product and the AncillaryParty type, which is positioned outside of the product definition, allows the AncillaryRoleEnum to be associated with an actual party reference.">
     DisruptionEventsDeterminingParty <"Specifies the party which determines additional disruption events.">

--- a/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
@@ -372,11 +372,20 @@ type SettlementBase: <"A base class to be extended by the SettlementTerms class.
         [docReference ICMA GMRA namingConvention "Contractual Currency"
             provision "As defined in GMRA paragraph 2(k)/ paragraph 7(a) All the payments made in respect of the Purchase Price or the Repurchase Price of any Transaction shall be made in the currency of the Purchase Price (the Contractual Currency) save as provided in paragraph 10(d)(ii). Notwithstanding the foregoing, the payee of any money may, at its option, accept tender thereof in any other currency, provided, however, that, to the extent permitted by applicable law, the obligation of the payer to pay such money will be discharged only to the extent of the amount of the Contractual Currency that such payee may, consistent with normal banking procedures, purchase with such other currency (after deduction of any premium and costs of exchange) for delivery within the customary delivery period for spot transactions in respect of the relevant currency."]
     settlementDate SettlementDate (0..1) <"The date on which the settlement amount will be paid, subject to adjustment in accordance with any applicable business day convention. This component would not be present for a mandatory early termination provision where the cash settlement payment date is the mandatory early termination date.">
-    settlementCentre SettlementCentreEnum (0..1) <"Optional settlement centre as an enumerated list: Euroclear, Clearstream.">
     settlementProvision SettlementProvision (0..1) <"Optionally defines the parameters that regulate a settlement.">
     standardSettlementStyle StandardSettlementStyleEnum (0..1) <"Settlement Style.">
+    securitySettlementCentre AssetAncillaryPartyRoleEnum (0..1) <"Specifies the settlement centre of a security.">
+    cashSettlementCentre AssetAncillaryPartyRoleEnum (0..1) <"Specifies the settlement centre of cash.">
 
-//ICMA-P2
+    condition SecuritySettlementCentre:
+        if securitySettlementCentre exists
+          then   securitySettlementCentre = AssetAncillaryPartyRoleEnum -> SecuritySettlementCentre
+
+    condition CashSettlementCentre:
+        if cashSettlementCentre exists
+          then  cashSettlementCentre = AssetAncillaryPartyRoleEnum -> CashSettlementCentre
+
+
 type SettlementProvision: <"Defines parameters that regulate a settlement, for instance whether this settlement should be netted with other ones or broken-down into smaller amounts.">
     shapingProvisions ShapingProvision (0..1) <"Defines the parameters that are necessary to 'shape' a settlement, i.e. break it down into smaller amounts.">
 

--- a/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-common-settlement-type.rosetta
@@ -372,6 +372,8 @@ type SettlementBase: <"A base class to be extended by the SettlementTerms class.
         [docReference ICMA GMRA namingConvention "Contractual Currency"
             provision "As defined in GMRA paragraph 2(k)/ paragraph 7(a) All the payments made in respect of the Purchase Price or the Repurchase Price of any Transaction shall be made in the currency of the Purchase Price (the Contractual Currency) save as provided in paragraph 10(d)(ii). Notwithstanding the foregoing, the payee of any money may, at its option, accept tender thereof in any other currency, provided, however, that, to the extent permitted by applicable law, the obligation of the payer to pay such money will be discharged only to the extent of the amount of the Contractual Currency that such payee may, consistent with normal banking procedures, purchase with such other currency (after deduction of any premium and costs of exchange) for delivery within the customary delivery period for spot transactions in respect of the relevant currency."]
     settlementDate SettlementDate (0..1) <"The date on which the settlement amount will be paid, subject to adjustment in accordance with any applicable business day convention. This component would not be present for a mandatory early termination provision where the cash settlement payment date is the mandatory early termination date.">
+    settlementCentre SettlementCentreEnum (0..1) <"Optional settlement centre as an enumerated list: Euroclear, Clearstream.">
+        [deprecated]
     settlementProvision SettlementProvision (0..1) <"Optionally defines the parameters that regulate a settlement.">
     standardSettlementStyle StandardSettlementStyleEnum (0..1) <"Settlement Style.">
     securitySettlementCentre AssetAncillaryPartyRoleEnum (0..1) <"Specifies the settlement centre of a security.">
@@ -379,11 +381,11 @@ type SettlementBase: <"A base class to be extended by the SettlementTerms class.
 
     condition SecuritySettlementCentre:
         if securitySettlementCentre exists
-          then   securitySettlementCentre = AssetAncillaryPartyRoleEnum -> SecuritySettlementCentre
+          then   securitySettlementCentre = SecuritySettlementCentre
 
     condition CashSettlementCentre:
         if cashSettlementCentre exists
-          then  cashSettlementCentre = AssetAncillaryPartyRoleEnum -> CashSettlementCentre
+          then  cashSettlementCentre = CashSettlementCentre
 
 
 type SettlementProvision: <"Defines parameters that regulate a settlement, for instance whether this settlement should be netted with other ones or broken-down into smaller amounts.">

--- a/rosetta-source/src/main/rosetta/product-template-type.rosetta
+++ b/rosetta-source/src/main/rosetta/product-template-type.rosetta
@@ -187,6 +187,11 @@ type OptionPayout extends PayoutBase: <" The option payout specification terms. 
         if underlier as NonTransferableProduct is absent
         then optionType exists
 
+    condition SettlementCentreRequired: <"SettlementCentre required where underlier is a security.">
+            if underlier as Security exists
+                then (settlementTerms -> securitySettlementCentre exists
+                 and settlementTerms -> cashSettlementCentre exists)
+
 type ReturnTerms: <"Specifies the type of return of a performance payout.">
 
     priceReturnTerms PriceReturnTerms (0..1) <"Return terms based upon the underlier's observed price.">
@@ -419,6 +424,11 @@ type SettlementPayout extends PayoutBase: <"Represents a forward settling payout
 
     condition SettlementTerms: <"Settlement Terms should be defined except for cash.">
         if underlier as Cash exists then settlementTerms exists
+
+    condition SettlementCentreRequired: <"SettlementCentre required where underlier is a security.">
+            if underlier as Security exists
+                then (settlementTerms -> securitySettlementCentre exists
+                 and settlementTerms -> cashSettlementCentre exists)
 
     condition DeliveryCapacity: <"Checks that only one of the representations of delivery capacity is present simultaneously.">
         if delivery -> deliveryCapacity exists
@@ -865,6 +875,11 @@ type AssetPayout extends PayoutBase: <"Security finance payout specification in 
 
     condition UnderlierNotCash: <"The purchased asset in an assetPayout should not be cash.">
         underlier as Cash is absent
+
+    condition SettlementCentreRequired: <"SettlementCentre required where underlier is a security.">
+            if underlier as Security exists
+                then (settlementTerms -> securitySettlementCentre exists
+                 and settlementTerms -> cashSettlementCentre exists)
 
 type DividendTerms: <"Information related to dividends and payments.">
     manufacturedIncomeRequirement DividendPayoutRatio (1..1) <"Specifies the proportion of the value of the dividend on the borrowed shares that the borrower is legally obligated to return to the lender.">


### PR DESCRIPTION
This is a new PR to replace, https://github.com/finos/common-domain-model/pull/4742. A new PR was required because of problems with the prior merge and unwanted changes.

The last comments on this were:

We don't need a tradableSettlementCentre attribute, only the asset one is relevant
No need for new enum values in AncillaryRoleEnum
4 new enum values in AssetAncillaryPartyRoleEnum:
CashSettlementCentre
SecuritySettlementCentre
PlaceOfDeposit
Custodian
Rather than a multi-cardinality assetSettlementCentre, we need 2 optional attributes of single-cardinality each:
cashSettlementCentre, whose value should be CashSettlementCentre
securitySettlementCentre whose value should be SecuritySettlementCentre
Do not modify the snippets in the documentation for older versions of the model.
Remove the extraneous enum files in /resources