### PR TITLE
Add backward compatibility section to the serialization docs, and add example

### DIFF
--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -67,7 +67,7 @@ It is possible to convert between the two formats without any loss of data. The 
 
 To convert from Rune JSON to Legacy JSON:
 
-```java
+``` Java
 // Deserialize from Rune JSON
 RuneJsonObjectMapper runeMapper = new RuneJsonObjectMapper();
 TradeState tradeState = runeMapper.readValue(runeJsonString, TradeState.class);
@@ -79,7 +79,7 @@ String legacyJson = legacyMapper.writeValueAsString(tradeState);
 
 To convert from Legacy JSON to Rune JSON:
 
-```java
+``` Java
 // Deserialize from Legacy JSON
 ObjectMapper legacyMapper = RosettaObjectMapper.getNewMinimalRosettaObjectMapper();
 TradeState tradeState = legacyMapper.readValue(legacyJsonString, TradeState.class);

--- a/docs/serialization.md
+++ b/docs/serialization.md
@@ -54,6 +54,43 @@ For example, `Trade`'s `tradeDate` attribute, which is annotated with `[metadata
     }
 ```
 
+## Backward compatibility and format conversion
+
+**Both the new Rune JSON format and the Legacy JSON format (used in CDM v6 and earlier) are supported.** Implementors can choose to continue using the Legacy JSON format or adopt the new Rune JSON format based on their requirements.
+
+It is possible to convert between the two formats without any loss of data. The CDM provides two object mappers:
+
+- **`RuneJsonObjectMapper`** — for the new Rune JSON format (default in CDM v7 onwards)
+- **`RosettaObjectMapper`** — for the Legacy JSON format (default in CDM v6 and earlier)
+
+### Converting between formats
+
+To convert from Rune JSON to Legacy JSON:
+
+```java
+// Deserialize from Rune JSON
+RuneJsonObjectMapper runeMapper = new RuneJsonObjectMapper();
+TradeState tradeState = runeMapper.readValue(runeJsonString, TradeState.class);
+
+// Serialize to Legacy JSON
+ObjectMapper legacyMapper = RosettaObjectMapper.getNewMinimalRosettaObjectMapper();
+String legacyJson = legacyMapper.writeValueAsString(tradeState);
+```
+
+To convert from Legacy JSON to Rune JSON:
+
+```java
+// Deserialize from Legacy JSON
+ObjectMapper legacyMapper = RosettaObjectMapper.getNewMinimalRosettaObjectMapper();
+TradeState tradeState = legacyMapper.readValue(legacyJsonString, TradeState.class);
+
+// Serialize to Rune JSON
+RuneJsonObjectMapper runeMapper = new RuneJsonObjectMapper();
+String runeJson = runeMapper.writeValueAsString(tradeState);
+```
+
+A complete working example demonstrating bidirectional conversion between formats can be found in the [SerialisationTest.java](../examples/src/test/java/org/finos/cdm/example/SerialisationTest.java) test case (see the `shouldConvertSampleBetweenJsonFormats` test method).
+
 ## Full specification
 
 The serialization standard is defined by the Rune DSL and applies to all Rune-based models, including the CDM. The full specification — covering the design principles, the complete set of special attributes, generation, ingestion and validation behaviour, and worked examples — is documented on the Rune DSL website:

--- a/examples/src/test/java/org/finos/cdm/example/SerialisationTest.java
+++ b/examples/src/test/java/org/finos/cdm/example/SerialisationTest.java
@@ -8,15 +8,17 @@ import com.google.common.io.Resources;
 import com.regnosys.rosetta.common.serialisation.RosettaObjectMapper;
 import com.regnosys.rosetta.common.util.ClassPathUtils;
 import com.rosetta.model.lib.records.Date;
+import org.finos.cdm.example.util.ResourcesUtils;
 import org.finos.rune.mapper.RuneJsonObjectMapper;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.net.URL;
 import java.nio.file.Path;
 
-import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
@@ -28,8 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
  */
 public class SerialisationTest {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(SerialisationTest.class);
+    
     @Test
-    void shouldDeserialiseCdmSampleFileWithClassLoader() throws IOException {
+    void shouldDeserialiseCdmSampleFileWithClassLoader_RuneJsonFormat() throws IOException {
         // Get the classLoader from any class in CDM
         ClassLoader classLoader = TradeState.class.getClassLoader();
         Path sampleFilePath = ClassPathUtils
@@ -46,7 +50,7 @@ public class SerialisationTest {
     }
 
     @Test
-    void shouldDeserialiseCdmSampleFileWithResources() throws IOException {
+    void shouldDeserialiseCdmSampleFileWithResources_RuneJsonFormat() throws IOException {
         // Get the classLoader from any class in CDM
         URL sampleFilePath = Resources.getResource("ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex01-single-underlyer-execution-long-form.json");
         assertNotNull(sampleFilePath);
@@ -58,7 +62,7 @@ public class SerialisationTest {
     }
 
     @Test
-    void shouldSerialiseCdmObjectThenDeserialise() throws JsonProcessingException {
+    void shouldSerialiseCdmObjectThenDeserialise_LegacyJsonFormat() throws JsonProcessingException {
         // Instantiate the pre-configured Rosetta ObjectMapper
         ObjectMapper rosettaObjectMapper = RosettaObjectMapper.getNewRosettaObjectMapper();
 
@@ -72,5 +76,53 @@ public class SerialisationTest {
         // Deserialize back to Java
         InterestRatePayout deserializedObject = rosettaObjectMapper.readValue(json, fixedRatePayout.getClass());
         assertNotNull(deserializedObject);
+    }
+
+    @Test
+    void shouldConvertSampleBetweenJsonFormats() throws IOException {
+        String sampleInRuneJson = ResourcesUtils.getJson("ingest/output/fpml-confirmation-to-trade-state/fpml-5-10-products-equity/eqs-ex01-single-underlyer-execution-long-form.json");
+        
+        LOGGER.info("Sample serialized in Rune JSON : {}", sampleInRuneJson);
+
+        String sampleInLegacyJson = convertFromRuneJsonToLegacyJson(sampleInRuneJson);
+
+        LOGGER.info("Sample serialized in Legacy JSON : {}", sampleInLegacyJson);
+
+        String sampleInRuneJson2 = convertFromLegacyJsonToRuneJson(sampleInLegacyJson);
+        
+        // This shows that there is no loss of data when converting between old and new JSON formats
+        assertEquals(sampleInRuneJson, sampleInRuneJson2);
+    }
+
+    private static String convertFromRuneJsonToLegacyJson(String sampleInRuneJson) throws JsonProcessingException {
+        // Create a RuneJsonObjectMapper to deserialize the sample from Rune JSON  (default format in CDM v7)
+        RuneJsonObjectMapper runeJsonObjectMapper = new RuneJsonObjectMapper();
+
+        // Deserialize sample
+        TradeState tradeStateDeserializedFromRuneJson =
+                runeJsonObjectMapper.readValue(sampleInRuneJson, TradeState.class);
+        assertNotNull(tradeStateDeserializedFromRuneJson);
+
+        // Create a RosettaObjectMapper to serialize the sample to Legacy JSON  (default format in CDM v6 and v5)
+        ObjectMapper legacyJsonObjectMapper = RosettaObjectMapper.getNewMinimalRosettaObjectMapper();
+
+        // Serialize sample
+        return legacyJsonObjectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(tradeStateDeserializedFromRuneJson);
+    }
+
+    private static String convertFromLegacyJsonToRuneJson(String sampleInLegacyJson) throws JsonProcessingException {
+        // Create a RosettaObjectMapper to deserialize the sample from Legacy JSON  (default format in CDM v6 and v5)
+        ObjectMapper legacyJsonObjectMapper = RosettaObjectMapper.getNewMinimalRosettaObjectMapper();
+       
+        // Deserialize sample
+        TradeState tradeStateDeserializedFromRuneJson =
+                legacyJsonObjectMapper.readValue(sampleInLegacyJson, TradeState.class);
+        assertNotNull(tradeStateDeserializedFromRuneJson);
+
+        // Create a RuneJsonObjectMapper to serialize the sample to Rune JSON  (default format in CDM v7)
+        RuneJsonObjectMapper runeJsonObjectMapper = new RuneJsonObjectMapper();
+
+        // Serialize sample
+        return runeJsonObjectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(tradeStateDeserializedFromRuneJson);
     }
 }


### PR DESCRIPTION
# *Documentation - Rune JSON Serialization Backwards Compatibility Guide*

_Background_

Rune JSON serialisation was enabled in version [7.0.0-dev.121,](https://github.com/finos/common-domain-model/releases/tag/7.0.0-dev.121) and documentation was added in version [7.0.0-dev.132](https://github.com/finos/common-domain-model/releases/tag/7.0.0-dev.132).  For further details, see GitHub issue: [#4746](https://github.com/finos/common-domain-model/issues/4746).

_What is being released_

- Documentation added to explain the new Rune JSON serialization format and the legacy JSON serialization format are both supported in CDM version 7.
- Examples added to show how implementors can read samples in one format and write out another, or vice versa.

_Review Directions_

Changes can be reviewed in PR:  https://github.com/finos/common-domain-model/pull/4949

----

See preview:
https://deploy-preview-4949--finos-cdm.netlify.app/docs/next/serialization#backward-compatibility-and-format-conversion