### PR TITLE
Use live NVD data for CVE scanning

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -2,6 +2,8 @@ name: CVE Scanning for Maven
 
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * *'
   push:
     branches:
       - master
@@ -25,26 +27,40 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: ./.github/actions/maven-build
-      with:
-        run-tests: false
-    - name: CVE scanning
-      uses: dependency-check/Dependency-Check_Action@main
-      env:
-        JAVA_HOME: /opt/jdk
-      with:
-        project: 'Common Domain Model'
-        path: '.'
-        format: 'HTML'
-        out: 'reports'
-        args: >
-          --suppression allow-list.xml
-          --failOnCVSS 7
-          --disableOssIndex
-          --centralUrl https://central.sonatype.com/solrsearch/select # remove when https://search.maven.org/solrsearch/select is back online
-    - name: Upload results
-      uses: actions/upload-artifact@v4
-      with:
-        name: CVE Scan Report ${{ strategy.job-index }}
-        path: ${{github.workspace}}/reports
+      - uses: actions/checkout@v7.0.1
+      - uses: ./.github/actions/maven-build
+        with:
+          run-tests: false
+      - name: Cache dependency-check data
+        uses: actions/cache@v6.1.0
+        with:
+          path: ~/.m2/dependency-check-data
+          key: dependency-check-data-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            dependency-check-data-${{ runner.os }}-
+      - name: CVE scanning
+        env:
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+        shell: bash
+        run: |
+          args=(
+            -B dependency-check:aggregate
+            "-DdataDirectory=${HOME}/.m2/dependency-check-data"
+            -DsuppressionFile=allow-list.xml
+            -Dformat=HTML
+            -Dodc.outputDirectory=reports
+            -DfailBuildOnCVSS=7
+            -DossIndexAnalyzerEnabled=false
+          )
+
+          if [ -n "${NVD_API_KEY:-}" ]; then
+            args+=(-DnvdApiKeyEnvironmentVariable=NVD_API_KEY)
+          fi
+
+          mvn "${args[@]}"
+      - name: Upload results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: CVE Scan Report
+          path: ${{github.workspace}}/reports

--- a/allow-list.xml
+++ b/allow-list.xml
@@ -22,17 +22,21 @@
     </suppress>
     <suppress>
         <notes><![CDATA[
-        This CVE refers to Xtext & Xtend versions prior to 2.18.0, we use Xtext & Xtend version 2.27.0.
-        The dependency org.eclipse.emf.ecore.xcore.lib has separate versioning (latest version is 1.7.0); false alarm. More info on https://nvd.nist.gov/vuln/detail/CVE-2019-10249
+        CVE-2019-10249 applies to Xtext and Xtend versions prior to 2.18.0.
+        This project uses Xtext 2.38.0. org.eclipse.emf.ecore.xcore.lib has
+        separate versioning and is a false positive for this CVE.
+        See https://nvd.nist.gov/vuln/detail/CVE-2019-10249.
         ]]></notes>
         <gav>org.eclipse.emf:org.eclipse.emf.ecore.xcore.lib:1.6.0</gav>
         <cve>CVE-2019-10249</cve>
     </suppress>
     <suppress>
         <notes><![CDATA[
-	   This CVE is not about org.junit.platform.commons. It seems the check is
-	   too loose.  See https://nvd.nist.gov/vuln/detail/CVE-2020-27225
-	   ]]></notes>
+        CVE-2020-27225 applies to Eclipse Platform 4.18 and earlier. Dependency
+        Check reports this through broad Eclipse CPE matching, but the CDM build
+        does not ship or run the vulnerable Eclipse Help subsystem.
+        See https://nvd.nist.gov/vuln/detail/CVE-2020-27225.
+        ]]></notes>
         <cve>CVE-2020-27225</cve>
     </suppress>
     <suppress>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,8 @@
         <jaxb.version>2.3.1</jaxb.version>
         <slf4j-api.version>2.0.7</slf4j-api.version>
         <guava.version>33.3.1-jre</guava.version>
-        <jackson.version>2.17.1</jackson.version>
+        <jackson.version>2.18.8</jackson.version>
+        <plexus-utils.version>4.0.3</plexus-utils.version>
 
         <!-- org.finos.cdm.CodeListTransformer -->
         <saxon.version>10.6</saxon.version>
@@ -122,6 +123,7 @@
         <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
         <maven-enforcer-plugin.version>3.3.0</maven-enforcer-plugin.version>
         <maven-checkstyle-plugin.version>3.4.0</maven-checkstyle-plugin.version>
+        <dependency-check-maven.version>12.2.2</dependency-check-maven.version>
 
         <!-- This property is only necessary when building with Java 12 or lower versions. It is set in a Maven profile. -->
         <maven-javadoc-plugin.option></maven-javadoc-plugin.option>
@@ -279,6 +281,11 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>build-helper-maven-plugin</artifactId>
                     <version>${build-helper-maven-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.owasp</groupId>
+                    <artifactId>dependency-check-maven</artifactId>
+                    <version>${dependency-check-maven.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -467,6 +474,11 @@
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
                 <version>${guava.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>${plexus-utils.version}</version>
             </dependency>
             <!-- org.finos.cdm.CodeListTransformer dependency -->
             <dependency>


### PR DESCRIPTION
## Pull Request Summary

This PR replaces the Dependency-Check Docker action with the official Maven plugin so the CVE scan can refresh from NVD during the workflow run. It also adds a daily scheduled scan, caches the Dependency-Check data directory, and uploads the HTML report even when the scan fails.

The workflow uses `NVD_API_KEY` when the repository secret is available, but still runs without that secret so forked pull requests are not blocked by missing secret access. The dependency updates address the current findings from the issue: Jackson is moved to the fixed 2.18.x line, `plexus-utils` is pinned to 4.0.3 through dependency management, and `logback-core` is left unchanged because current `master` already resolves it to 1.5.25. Existing Eclipse/Xtext false-positive suppressions are kept and documented more precisely.

Resolves #4966

## Content

- [x] A link to an Issue describing the work, background and any associated documentation
- [ ] Been reviewed by one of the following Working Groups:
  - [ ] Contribution Review Working Group (CRWG)
  - [ ] Steering Working Group (SWG)
  - [ ] Technology Architecture Working Group (TAWG)
  - [ ] A CDM Domain Working Group maintained by FINOS
  - [ ] An External Industry Association CDM Working Group e.g. run by ISLA, ISDA, ICMA
- [x] Been assessed for compliance with CDM Design Principles (where applicable)
- [ ] A Release Note that describes the changes

This is a CI/dependency security change, so Working Group review and a model release note may not be needed unless maintainers prefer otherwise.

## Supporting Documentation

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/cve-scanning.yml"); puts "yaml_ok"'`
- `actionlint .github/workflows/cve-scanning.yml`
- `xmllint --noout pom.xml allow-list.xml`
- `git diff --check origin/master...HEAD`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home mvn -B -DskipTests validate`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home mvn -B org.owasp:dependency-check-maven:12.2.2:help -Ddetail -Dgoal=aggregate`
- `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home mvn -B dependency:tree -Dincludes=com.fasterxml.jackson.core:jackson-databind,ch.qos.logback:logback-core,org.codehaus.plexus:plexus-utils -DskipTests`
- `gitleaks detect --no-banner --redact --source . --log-opts origin/master..HEAD`
