### PR TITLE
Add FpML coding scheme links to codelist aliases

### DIFF
--- a/rosetta-source/src/main/rosetta/base-staticdata-codelist-type.rosetta
+++ b/rosetta-source/src/main/rosetta/base-staticdata-codelist-type.rosetta
@@ -29,33 +29,47 @@ typeAlias FpMLCodingScheme(domain string):
         if item exists
         then ValidateFpMLCodingSchemeDomain(item, domain)
 
-typeAlias BusinessCenter: FpMLCodingScheme(domain: "business-center")
+typeAlias BusinessCenter: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.19">
+    FpMLCodingScheme(domain: "business-center")
 
-typeAlias FloatingRateIndex: FpMLCodingScheme(domain: "floating-rate-index")
+typeAlias FloatingRateIndex: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.114">
+    FpMLCodingScheme(domain: "floating-rate-index")
 
-typeAlias CommodityBusinessCalendar: FpMLCodingScheme(domain: "commodity-business-calendar")
+typeAlias CommodityBusinessCalendar: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.39">
+    FpMLCodingScheme(domain: "commodity-business-calendar")
 
-typeAlias InflationRateIndex: FpMLCodingScheme(domain: "inflation-index-description")
+typeAlias InflationRateIndex: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.123">
+    FpMLCodingScheme(domain: "inflation-index-description")
 
-typeAlias CreditEventType: FpMLCodingScheme(domain: "credit-event-type")
+typeAlias CreditEventType: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.76">
+    FpMLCodingScheme(domain: "credit-event-type")
 
-typeAlias MasterAgreementType: FpMLCodingScheme(domain: "master-agreement-type")
+typeAlias MasterAgreementType: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.149">
+    FpMLCodingScheme(domain: "master-agreement-type")
 
-typeAlias MasterConfirmationAnnexType:
+typeAlias MasterConfirmationAnnexType: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.151">
     FpMLCodingScheme(domain: "master-confirmation-annex-type")
 
-typeAlias MasterConfirmationType: FpMLCodingScheme(domain: "master-confirmation-type")
+typeAlias MasterConfirmationType: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.152">
+    FpMLCodingScheme(domain: "master-confirmation-type")
 
-typeAlias CommodityReferencePrice: FpMLCodingScheme(domain: "commodity-reference-price")
+typeAlias CommodityReferencePrice: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.64">
+    FpMLCodingScheme(domain: "commodity-reference-price")
 
-typeAlias CreditRatingAgency: FpMLCodingScheme(domain: "credit-rating-agency")
+typeAlias CreditRatingAgency: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.80">
+    FpMLCodingScheme(domain: "credit-rating-agency")
 
-typeAlias InformationProvider: FpMLCodingScheme(domain: "information-provider")
+typeAlias InformationProvider: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.127">
+    FpMLCodingScheme(domain: "information-provider")
 
-typeAlias InterpolationMethod: FpMLCodingScheme(domain: "interpolation-method")
+typeAlias InterpolationMethod: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.129">
+    FpMLCodingScheme(domain: "interpolation-method")
 
-typeAlias SettlementRateOption: FpMLCodingScheme(domain: "settlement-rate-option")
+typeAlias SettlementRateOption: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.216">
+    FpMLCodingScheme(domain: "settlement-rate-option")
 
-typeAlias DeterminationMethod: FpMLCodingScheme(domain: "determination-method")
+typeAlias DeterminationMethod: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.95">
+    FpMLCodingScheme(domain: "determination-method")
 
-typeAlias CreditSeniority: FpMLCodingScheme(domain: "credit-seniority")
+typeAlias CreditSeniority: <"FpML coding scheme: https://www.fpml.org/spec/coding-scheme/fpml-schemes.html#s5.81">
+    FpMLCodingScheme(domain: "credit-seniority")


### PR DESCRIPTION
## Pull Request Summary ##

Adds FpML Coding Schemes links to the migrated FpML code-list type aliases in `base-staticdata-codelist-type.rosetta`, so modelers can open the source scheme definitions while the values remain externally managed.

Issue: https://github.com/finos/common-domain-model/issues/3929

## Content ##
**This Pull Request contains (tick each list item once completed):**

- [x] A link to an Issue describing the work, background and any associated documentation
- [ ] Been reviewed by one of the following Working Groups:
  - [ ] Contribution Review Working Group (CRWG)
  - [ ] Steering Working Group (SWG)
  - [ ] Technology Architecture Working Group (TAWG)
  - [ ] A CDM Domain Working Group maintained by FINOS
  - [ ] An External Industry Association CDM Working Group e.g. run by ISLA, ISDA, ICMA
- [ ] Been assessed for compliance with CDM Design Principles (where applicable)
- [ ] A Release Note that describes the changes, which contains:
  - [ ] A section explaining the business or technical reasoning for the change
  - [ ] A section detailing the changes themselves
  - [ ] A section on any changes that break backwards compatibility
  - [ ] A link to this Pull Request as a cross reference

Unchecked items can be completed during review if the working group wants the change tracked as a formal specification update. This PR follows the lightweight visibility improvement suggested by maintainers and does not change validation behavior.

## Supporting Documentation ##

The added comments point to the current FpML Coding Schemes page section anchors for each canonical scheme. `InformationProvider` uses the `information-provider` scheme section, not the separate commodity information provider section.