### PR TITLE
[6.x.x] Add the read-only namespace verification workflow

### DIFF
--- a/.github/workflows/verify-readonly-namespaces.yml
+++ b/.github/workflows/verify-readonly-namespaces.yml
@@ -1,0 +1,18 @@
+name: Verify read-only namespaces
+
+# Fails when a pull request changes a read-only Rune namespace by hand.
+# For more info, see https://rune-docs.netlify.app/developers/read-only-namespaces
+
+on:
+  pull_request:
+    paths:
+      - "**/*.rosetta"
+      - "rosetta-source/src/main/resources/rosetta-config.yml"
+      - ".github/workflows/verify-readonly-namespaces.yml"
+
+jobs:
+  readonly-namespaces:
+    uses: finos/rune-dsl/.github/workflows/verify-readonly-namespaces.yml@main
+    with:
+      config-path: rosetta-source/src/main/resources/rosetta-config.yml
+      root: rosetta-source/src/main/rosetta


### PR DESCRIPTION
Adds the `verify-readonly-namespaces` CI check, which most of our models already have. It calls the reusable workflow in `finos/rune-dsl`, so a pull request that hand-edits a `.rosetta` file in a namespace marked `readOnly: true` fails CI.

Docs: https://rune-docs.netlify.app/developers/read-only-namespaces

Notes:

- The workflow points at the existing `rosetta-source/src/main/resources/rosetta-config.yml`. This branch is on DSL 9.84.0, which predates the `runeConfig` maven-plugin parameter (added in 9.85.0), so the `rosetta-config.yml` → `rune-config.yml` rename that accompanied this workflow in the other models is deliberately left out — it should ride along with the next DSL/bundle bump.
- The config currently declares no `namespaceConfig` entries, so the check passes as a no-op until read-only namespaces are configured. It is wired up now so the protection is in place the moment they are.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
