### PR TITLE
Scope ExchangeListed condition to non-Security assets

### DIFF
--- a/rosetta-source/src/main/rosetta/base-staticdata-asset-common-type.rosetta
+++ b/rosetta-source/src/main/rosetta/base-staticdata-asset-common-type.rosetta
@@ -25,8 +25,8 @@ type AssetBase: <"The base data type to specify common attributes for all Assets
     condition RoleIsExchange: <"If Exchange is specified, it must be an exchange-listed Instrument.">
         if partyRole -> role = Exchange then isExchangeListed = True
 
-    condition ExchangeListed: <"if isExchangeListed is true then partyRole is Exchange.">
-        if isExchangeListed and partyRole exists
+    condition ExchangeListed: <"If isExchangeListed is true then partyRole, where specified, must be Exchange - except for a Security, whose partyRole is governed by IssuerRole.">
+        if isExchangeListed and partyRole exists and assetType <> Security
         then partyRole -> role = Exchange
 
     condition IssuerRole: <"If the asset type is a security then the role must be issuer.">


### PR DESCRIPTION
Resolves #5022

# Asset Model – Resolve contradictory `AssetBase` conditions for exchange-listed securities

_What is being released_

The `partyRole exists` guards added in #4856 left two `AssetBase` conditions in direct contradiction for an exchange-listed `Security` that carries a `partyRole`: `ExchangeListed` requires the role to be `Exchange`, while `IssuerRole` requires the role of a `Security` to be `Issuer`. No exchange-listed `Security` with a populated `partyRole` can satisfy both, and omitting `partyRole` makes `TransferableProduct.AssetPartyRoleExists` unsatisfiable — so a plain holding of a listed security cannot be expressed via `Position` at all.

This change scopes the `ExchangeListed` condition to `assetType <> Security`, leaving a `Security`'s `partyRole` governed solely by `IssuerRole`. Listed derivatives are unaffected: `ExchangeRole` already requires their `partyRole` to be `Exchange`, and `RoleIsExchange` still forces `isExchangeListed = True` wherever the `Exchange` role appears. The change only relaxes a condition, so any instance that validates today continues to validate; no test pack expectations change.

_Alternatives considered_

- **Relax `IssuerRole` to also permit `Exchange`.** Note that the FpML ingestion mappings currently populate `partyRole` with the exchange (role = `Exchange`) on `Security` instances, so the existing test pack already carries `IssuerRole` violations on 138 exchange-listed securities across ~95 samples. Relaxing `IssuerRole` would clear those failures but requires regenerating `modelValidationFailures` expectations across the test pack, and weakens the issuer semantics of `IssuerRole`.
- **Document that listed securities carry no `partyRole` and relax `TransferableProduct.AssetPartyRoleExists`.** This is a larger behavioural change to `TransferableProduct` and removes the ability to state a listed security's issuer entirely.

The scoping fix here is the minimal, backwards-compatible resolution; the working group may still wish to address the FpML mapping of exchange IDs into `Security.partyRole` separately.

_Review directions_

In `base-staticdata-asset-common-type.rosetta`, inspect the `ExchangeListed` condition on `AssetBase` and observe the added `assetType <> Security` clause and updated description. Confirm that `IssuerRole`, `ExchangeRole` and `RoleIsExchange` are unchanged.
