### PR TITLE
Instruction Composition Reset Step 3: Adjust the period

### DIFF
--- a/rosetta-source/src/main/rosetta/base-datetime-func.rosetta
+++ b/rosetta-source/src/main/rosetta/base-datetime-func.rosetta
@@ -394,3 +394,69 @@ func AdjustableDatesResolution: <"Prioritization of unadjustedDate over adjusted
         if adjustableDates -> unadjustedDate exists
         then adjustableDates -> unadjustedDate
         else adjustableDates -> adjustedDate
+
+func AdjustDateToBusinessDayConvention: <"Applies a specific business day convention to a single date if it's a non-business day and adjusts it. Note: Currently, only FOLLOWING, PRECEDING, and MODFOLLOWING conventions are implemented. Other conventions will raise an error indicating they are not yet supported.">
+    inputs:
+        unadjustedDate date (1..1)
+        nonBusinessDates date (0..*)
+        businessConvention BusinessDayConventionEnum (1..1)
+    output:
+        adjustedDate date (1..1)
+
+    condition SupportedConvention: <"Only FOLLOWING, PRECEDING, MODFOLLOWING, and NONE are currently implemented. Unsupported conventions are blocked to prevent returning silently unadjusted dates.">
+        businessConvention = BusinessDayConventionEnum -> FOLLOWING
+            or businessConvention = BusinessDayConventionEnum -> PRECEDING
+            or businessConvention = BusinessDayConventionEnum -> MODFOLLOWING
+            or businessConvention = BusinessDayConventionEnum -> NONE
+
+    set adjustedDate:
+        if (nonBusinessDates contains unadjustedDate) = False
+        then unadjustedDate
+        else businessConvention switch
+            FOLLOWING then
+                AdjustDateToFollowingBusinessDay(unadjustedDate, nonBusinessDates),
+            PRECEDING then
+                AdjustDateToPrecedingBusinessDay(unadjustedDate, nonBusinessDates),
+            MODFOLLOWING then
+                AdjustDateToModfollowingBusinessDay(unadjustedDate, nonBusinessDates),
+            default unadjustedDate
+
+func AdjustDateToFollowingBusinessDay: <"Finds the next available business day by moving forward in time.">
+    inputs:
+        unadjustedDate date (1..1)
+        nonBusinessDates date (0..*)
+    output:
+        nextBusinessDay date (1..1)
+
+    set nextBusinessDay:
+        if (nonBusinessDates contains unadjustedDate) = False
+        then unadjustedDate
+        else AdjustDateToFollowingBusinessDay(AddDays(unadjustedDate, 1), nonBusinessDates)
+
+func AdjustDateToPrecedingBusinessDay: <"Finds the previous available business day by moving backward in time.">
+    inputs:
+        unadjustedDate date (1..1)
+        nonBusinessDates date (0..*)
+    output:
+        previousBusinessDay date (1..1)
+
+    set previousBusinessDay:
+        if (nonBusinessDates contains unadjustedDate) = False
+        then unadjustedDate
+        else AdjustDateToPrecedingBusinessDay(AddDays(unadjustedDate, -1), nonBusinessDates)
+
+func AdjustDateToModfollowingBusinessDay: <"Applies the 'Following' convention, but reverts to 'Preceding' if the adjustment crosses a month boundary.">
+    inputs:
+        unadjustedDate date (1..1)
+        nonBusinessDates date (0..*)
+    output:
+        adjustedDate date (1..1)
+
+    alias followingDate: AdjustDateToFollowingBusinessDay(unadjustedDate, nonBusinessDates)
+
+    alias IsDifferentMonth: (followingDate -> month) <> (unadjustedDate -> month)
+
+    set adjustedDate:
+        if IsDifferentMonth
+        then AdjustDateToPrecedingBusinessDay(unadjustedDate, nonBusinessDates)
+        else followingDate

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-func.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-func.rosetta
@@ -1,6 +1,8 @@
 namespace cdm.event.instructioncomposition.reset
 version "${project.version}"
 
+import cdm.base.datetime.*
+import cdm.base.staticdata.codelist.*
 import cdm.event.instructioncomposition.*
 import cdm.product.asset.*
 import cdm.product.common.schedule.*
@@ -46,6 +48,54 @@ func Create_DetermineUnadjustedCalculationPeriodInstruction: <"This function gen
     set determineUnadjustedCalculationPeriodInstruction -> unadjustedResetDate: <"Sets the unadjusted reset date to the output.">
         unadjustedResetDate
 
+// Code Implementation Function - External call to fetch the list of non business dates
+func GetNonBusinessDates: <"This function, given the list of business centers applicable and a period or a list of dates, extracts the list of non business dates for the given period or list of dates and returns the corresponding list of non business dates. The function should receive as input a list of dates or a period, but not both at the same time. That is, given either a list of periods or a period (start date + end date), the function will return their non business days.">
+    [codeImplementation]
+    inputs:
+        businessCenters BusinessCenter (0..*) <"The business centers related to a period or a list of one or more dates.">
+        period CalculationPeriodBase (0..1) <"The period from which the list of non business dates are generated.">
+        dates date (0..*) <"The list of dates from which the list of non business dates are generated.">
+    output:
+        nonBusinessDates date (1..*) <"The list of non business dates.">
+
+    condition PeriodOrDates: <"There can only be a period or a list of dates specified as input to this function. The function then fetches the non business dates of the given period OR list of dates and returns them.">
+        if period is absent
+        then dates exists
+        else if dates is absent
+        then period exists
+
+// Instruction Composition STEP 3 - Adjust Calculation Period
+func Create_AdjustPeriodInstruction: <"This function generates the Instruction Composition step instruction necessary to adjust the unadjusted period, and adding it to the AdjustPeriodInstruction. Supported business day conventions in this version are: {Following, Preceding, ModFollowing}. Other conventions (e.g., ModPreceding, Nearest) are currently out-of-scope.">
+    inputs:
+        unadjustedPeriod CalculationPeriodBase (1..1) <"The Unadjusted Period.">
+        nonBusinessDates date (0..*) <"The list of non business dates applicable to the Period.">
+        businessConvention BusinessDayConventionEnum (1..1) <"The business day convention to apply to adjust the Unadjusted Period (e.g., FOLLOWING, PRECEDING).">
+    output:
+        adjustPeriodInstruction AdjustPeriodInstruction (1..1) <"The Adjusted Calculation Period.">
+
+    alias adjustedCalculationPeriodStart: <"The adjusted starting date of the calculation period.">
+        AdjustDateToBusinessDayConvention(
+                unadjustedPeriod -> adjustedStartDate,
+                nonBusinessDates,
+                businessConvention
+            )
+
+    alias adjustedCalculationPeriodEnd: <"The adjusted ending date of the calculation period.">
+        AdjustDateToBusinessDayConvention(
+                unadjustedPeriod -> adjustedEndDate,
+                nonBusinessDates,
+                businessConvention
+            )
+
+    set adjustPeriodInstruction:
+        AdjustPeriodInstruction {
+            adjustedPeriod:
+                CalculationPeriodBase {
+                    adjustedStartDate: adjustedCalculationPeriodStart,
+                    adjustedEndDate: adjustedCalculationPeriodEnd
+        }}
+
+// COMPOSITION STATE CHANGES FOR RESET
 func UpdateResetCompositionState: <"Handles the field-by-field overlay for the Reset process state.">
     inputs:
         currentResetCompositionState ResetInstructionState (0..1)
@@ -68,12 +118,18 @@ func UpdateResetCompositionState: <"Handles the field-by-field overlay for the R
         if nextStepToAdd -> determineUnadjustedCalculationPeriod exists
         then nextStepToAdd -> determineUnadjustedCalculationPeriod -> unadjustedCalculationPeriod
         else currentResetCompositionState -> unadjustedCalculationPeriod
-
     set updatedResetCompositionState -> unadjustedResetDate:
         if nextStepToAdd -> determineUnadjustedCalculationPeriod exists
         then nextStepToAdd -> determineUnadjustedCalculationPeriod -> unadjustedResetDate
         else currentResetCompositionState -> unadjustedResetDate
 
+    // Step 3: Adjusted Period
+    set updatedResetCompositionState -> adjustedCalculationPeriod:
+        if nextStepToAdd -> adjustPeriod exists
+        then nextStepToAdd -> adjustPeriod -> adjustedPeriod
+        else currentResetCompositionState -> adjustedCalculationPeriod
+
+// NEXT STEP FOR RESET
 func ResetInstructionNextStep: <"A state-machine evaluator for the Reset process that identifies the next required instruction by checking for the presence of mandatory data fields across the seven-step lifecycle.">
     inputs:
         resetInstructionState ResetInstructionState (0..1)

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-type.rosetta
@@ -12,6 +12,9 @@ type DetermineUnadjustedCalculationPeriodInstruction: <"Instruction that contain
     unadjustedCalculationPeriod CalculationPeriodBase (1..1)
     unadjustedResetDate date (1..1)
 
+type AdjustPeriodInstruction: <"Instruction that holds the adjusted period.">
+    adjustedPeriod CalculationPeriodBase (1..1)
+
 type ResetInstructionState: <"The definitive state object for the Reset process. It acts as a cumulative 'Golden Record,' storing every data point captured from Step 1 (Index Collection) through Step 7 (Final Calculation) to ensure deterministic processing.">
 
     // Step 1 - CollectFloatingRateOptionInstruction
@@ -20,6 +23,8 @@ type ResetInstructionState: <"The definitive state object for the Reset process.
     // Step 2 - DetermineUnadjustedCalculationPeriodInstruction
     unadjustedCalculationPeriod CalculationPeriodBase (0..1) <"The raw start and end dates of the period before any business day adjustments are applied.">
     unadjustedResetDate date (0..1) <"The theoretical reset date before applying business day conventions.">
+    // Step 3 - AdjustPeriodInstruction
+    adjustedCalculationPeriod CalculationPeriodBase (0..1) <"The calculation period after adjusting for non-business days and relevant financial calendars.">
 
 type ResetInstructionSteps: <"A wrapper that encapsulates the specific ResetInstructionCompositionStepsEnum, allowing the engine to identify the exact phase of the Reset lifecycle currently being processed.">
     resetInstructionCompositionSteps ResetInstructionCompositionStepsEnum (1..1)

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-type.rosetta
@@ -42,6 +42,7 @@ type CompositionStepInstruction: <"Set of instructions defining the steps of eac
 type CompositionStepInstructions: <"Container for all instruction steps that can be used within an InstructionComposition.">
     collectFloatingRateOption CollectFloatingRateOptionInstruction (0..1) <"Data needed to execute the extraction of the Floating Rate Option index name.">
     determineUnadjustedCalculationPeriod DetermineUnadjustedCalculationPeriodInstruction (0..1) <"Data needed to determine the Unadjusted Calculation Period.">
+    adjustPeriod AdjustPeriodInstruction (0..1) <"Data needed to adjust the Calculation Period.">
 
     condition NonEmptyInstruction:
         one-of

--- a/rosetta-source/src/test/java/cdm/base/datetime/functions/AdjustDateToBusinessDayConventionTest.java
+++ b/rosetta-source/src/test/java/cdm/base/datetime/functions/AdjustDateToBusinessDayConventionTest.java
@@ -1,0 +1,82 @@
+package cdm.base.datetime.functions;
+
+import cdm.base.datetime.BusinessDayConventionEnum;
+import javax.inject.Inject;
+import com.rosetta.model.lib.records.Date;
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import com.rosetta.model.lib.functions.ConditionValidator;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class AdjustDateToBusinessDayConventionTest extends AbstractFunctionTest {
+
+    @Inject
+    private AdjustDateToBusinessDayConvention func;
+
+    private static final List<Date> NONBUSINESSDAYS = Arrays.asList(Date.of(2024, 1, 15));
+
+    // --- date is not adjusted ---
+
+    @ParameterizedTest
+    @EnumSource(value = BusinessDayConventionEnum.class, names = {"FOLLOWING", "PRECEDING", "MODFOLLOWING"})
+    void shouldReturnDateUnchangedWhenDateIsABusinessDay(BusinessDayConventionEnum convention) {
+        Date input = Date.of(2024, 1, 14);
+        assertEquals(input, func.evaluate(input, NONBUSINESSDAYS, convention));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BusinessDayConventionEnum.class, names = {"FOLLOWING", "PRECEDING", "MODFOLLOWING"})
+    void shouldReturnDateUnchangedWhenNonBusinessDaysListIsEmpty(BusinessDayConventionEnum convention) {
+        Date input = Date.of(2024, 1, 15);
+        assertEquals(input, func.evaluate(input, Collections.emptyList(), convention));
+    }
+
+    @Test
+    void shouldReturnDateUnchangedForNoneConvention() {
+        Date input = Date.of(2024, 1, 15);
+        assertEquals(input, func.evaluate(input, NONBUSINESSDAYS, BusinessDayConventionEnum.NONE));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = BusinessDayConventionEnum.class, names = {"FRN", "MODPRECEDING", "NEAREST", "NOT_APPLICABLE"})
+    void shouldThrowForUnimplementedConventions(BusinessDayConventionEnum convention) {
+        Date input = Date.of(2024, 1, 15);
+        ConditionValidator.ConditionException exception = assertThrows(ConditionValidator.ConditionException.class,
+                () -> func.evaluate(input, NONBUSINESSDAYS, convention));
+        assertEquals("Only FOLLOWING, PRECEDING, MODFOLLOWING, and NONE are currently implemented. " +
+                "Unsupported conventions are blocked to prevent returning silently unadjusted dates.",
+                exception.getMessage());
+    }
+
+    // --- date is a non-business day, adjusts to the correct convention ---
+
+    @Test
+    void shouldAdjustToFollowing() {
+        Date result = func.evaluate(Date.of(2024, 1, 15), NONBUSINESSDAYS, BusinessDayConventionEnum.FOLLOWING);
+        assertEquals(Date.of(2024, 1, 16), result);
+    }
+
+    @Test
+    void shouldAdjustToPreceding() {
+        Date result = func.evaluate(Date.of(2024, 1, 15), NONBUSINESSDAYS, BusinessDayConventionEnum.PRECEDING);
+        assertEquals(Date.of(2024, 1, 14), result);
+    }
+
+    @Test
+    void shouldAdjustToModFollowing() {
+        Date result = func.evaluate(Date.of(2024, 1, 15), NONBUSINESSDAYS, BusinessDayConventionEnum.MODFOLLOWING);
+        assertEquals(Date.of(2024, 1, 16), result);
+    }
+}
+
+
+

--- a/rosetta-source/src/test/java/cdm/base/datetime/functions/AdjustDateToFollowingBusinessDayTest.java
+++ b/rosetta-source/src/test/java/cdm/base/datetime/functions/AdjustDateToFollowingBusinessDayTest.java
@@ -1,0 +1,45 @@
+package cdm.base.datetime.functions;
+
+import javax.inject.Inject;
+import com.rosetta.model.lib.records.Date;
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AdjustDateToFollowingBusinessDayTest extends AbstractFunctionTest {
+
+    @Inject
+    private AdjustDateToFollowingBusinessDay func;
+
+    @Test
+    void shouldReturnSameDateWhenDateIsABusinessDay() {
+        List<Date> nonBusinessDays = Arrays.asList(Date.of(2024, 1, 15));
+        Date result = func.evaluate(Date.of(2024, 1, 14), nonBusinessDays);
+        assertEquals(Date.of(2024, 1, 14), result);
+    }
+
+    @Test
+    void shouldReturnNextDayWhenDateIsNotABusinessDay() {
+        List<Date> nonBusinessDays = Arrays.asList(Date.of(2024, 1, 15));
+        Date result = func.evaluate(Date.of(2024, 1, 15), nonBusinessDays);
+        assertEquals(Date.of(2024, 1, 16), result);
+    }
+
+    @Test
+    void shouldSkipMultipleConsecutiveNonBusinessDays() {
+        List<Date> nonBusinessDays = Arrays.asList(Date.of(2024, 1, 15), Date.of(2024, 1, 16));
+        Date result = func.evaluate(Date.of(2024, 1, 15), nonBusinessDays);
+        assertEquals(Date.of(2024, 1, 17), result);
+    }
+
+    @Test
+    void shouldReturnSameDateWhenNonBusinessDayListIsEmpty() {
+        Date result = func.evaluate(Date.of(2024, 1, 15), Collections.emptyList());
+        assertEquals(Date.of(2024, 1, 15), result);
+    }
+}

--- a/rosetta-source/src/test/java/cdm/base/datetime/functions/AdjustDateToModfollowingBusinessDayTest.java
+++ b/rosetta-source/src/test/java/cdm/base/datetime/functions/AdjustDateToModfollowingBusinessDayTest.java
@@ -1,0 +1,54 @@
+package cdm.base.datetime.functions;
+
+import javax.inject.Inject;
+import com.rosetta.model.lib.records.Date;
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AdjustDateToModfollowingBusinessDayTest extends AbstractFunctionTest {
+
+    @Inject
+    private AdjustDateToModfollowingBusinessDay func;
+
+    @Test
+    void shouldReturnSameDateWhenDateIsABusinessDay() {
+        List<Date> nonBusinessDays = Arrays.asList(Date.of(2024, 1, 15));
+        Date result = func.evaluate(Date.of(2024, 1, 14), nonBusinessDays);
+        assertEquals(Date.of(2024, 1, 14), result);
+    }
+
+    @Test
+    void shouldApplyFollowingWhenNextDayIsInSameMonth() {
+        List<Date> nonBusinessDays = Arrays.asList(Date.of(2024, 1, 15));
+        Date result = func.evaluate(Date.of(2024, 1, 15), nonBusinessDays);
+        assertEquals(Date.of(2024, 1, 16), result);
+    }
+
+    @Test
+    void shouldRevertToPrecedingWhenFollowingCrossesMonthBoundary() {
+        // Jan 31 is a non-business day; following = Feb 1 (different month) → revert to preceding = Jan 30
+        List<Date> nonBusinessDays = Arrays.asList(Date.of(2024, 1, 31));
+        Date result = func.evaluate(Date.of(2024, 1, 31), nonBusinessDays);
+        assertEquals(Date.of(2024, 1, 30), result);
+    }
+
+    @Test
+    void shouldSkipMultipleNonBusinessDaysAndRevertToPrecedingAtMonthEnd() {
+        // Jan 30 and Jan 31 are non-business days; following of Jan 30 = Feb 1 → revert to preceding = Jan 29
+        List<Date> nonBusinessDays = Arrays.asList(Date.of(2024, 1, 30), Date.of(2024, 1, 31));
+        Date result = func.evaluate(Date.of(2024, 1, 30), nonBusinessDays);
+        assertEquals(Date.of(2024, 1, 29), result);
+    }
+
+    @Test
+    void shouldReturnSameDateWhenNonBusinessDayListIsEmpty() {
+        Date result = func.evaluate(Date.of(2024, 1, 31), Collections.emptyList());
+        assertEquals(Date.of(2024, 1, 31), result);
+    }
+}

--- a/rosetta-source/src/test/java/cdm/base/datetime/functions/AdjustDateToPrecedingBusinessDayTest.java
+++ b/rosetta-source/src/test/java/cdm/base/datetime/functions/AdjustDateToPrecedingBusinessDayTest.java
@@ -1,0 +1,45 @@
+package cdm.base.datetime.functions;
+
+import javax.inject.Inject;
+import com.rosetta.model.lib.records.Date;
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AdjustDateToPrecedingBusinessDayTest extends AbstractFunctionTest {
+
+    @Inject
+    private AdjustDateToPrecedingBusinessDay func;
+
+    @Test
+    void shouldReturnSameDateWhenDateIsABusinessDay() {
+        List<Date> nonBusinessDays = Arrays.asList(Date.of(2024, 1, 15));
+        Date result = func.evaluate(Date.of(2024, 1, 16), nonBusinessDays);
+        assertEquals(Date.of(2024, 1, 16), result);
+    }
+
+    @Test
+    void shouldReturnPreviousDayWhenDateIsNonBusinessDay() {
+        List<Date> nonBusinessDays = Arrays.asList(Date.of(2024, 1, 15));
+        Date result = func.evaluate(Date.of(2024, 1, 15), nonBusinessDays);
+        assertEquals(Date.of(2024, 1, 14), result);
+    }
+
+    @Test
+    void shouldSkipMultipleConsecutiveNonBusinessDays() {
+        List<Date> nonBusinessDays = Arrays.asList(Date.of(2024, 1, 15), Date.of(2024, 1, 16));
+        Date result = func.evaluate(Date.of(2024, 1, 16), nonBusinessDays);
+        assertEquals(Date.of(2024, 1, 14), result);
+    }
+
+    @Test
+    void shouldReturnSameDateWhenNonBusinessDayListIsEmpty() {
+        Date result = func.evaluate(Date.of(2024, 1, 15), Collections.emptyList());
+        assertEquals(Date.of(2024, 1, 15), result);
+    }
+}

--- a/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/Create_AdjustPeriodInstructionTest.java
+++ b/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/Create_AdjustPeriodInstructionTest.java
@@ -1,0 +1,125 @@
+package cdm.event.instructioncomposition.reset.functions;
+
+import cdm.base.datetime.BusinessDayConventionEnum;
+import cdm.event.instructioncomposition.reset.AdjustPeriodInstruction;
+import cdm.product.common.schedule.CalculationPeriodBase;
+import com.rosetta.model.lib.records.Date;
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class Create_AdjustPeriodInstructionTest extends AbstractFunctionTest {
+
+    @Inject
+    private Create_AdjustPeriodInstruction createAdjustPeriodInstruction;
+
+    static Stream<Arguments> adjustmentScenarios() {
+        return Stream.of(
+                // --- No-op cases ---
+                Arguments.of(
+                        "Returns unadjusted dates when neither date is a holiday",
+                        buildPeriod(Date.of(2024, 1, 10), Date.of(2024, 1, 30)),
+                        Arrays.asList(Date.of(2024, 1, 15)),
+                        BusinessDayConventionEnum.FOLLOWING,
+                        Date.of(2024, 1, 10),
+                        Date.of(2024, 1, 30)
+                ),
+                Arguments.of(
+                        "Returns unadjusted dates when holiday list is empty",
+                        buildPeriod(Date.of(2024, 1, 15), Date.of(2024, 1, 31)),
+                        Collections.emptyList(),
+                        BusinessDayConventionEnum.FOLLOWING,
+                        Date.of(2024, 1, 15),
+                        Date.of(2024, 1, 31)
+                ),
+                // --- Independent adjustment of each date ---
+                Arguments.of(
+                        "Only adjusts start date when only start date falls on a holiday",
+                        buildPeriod(Date.of(2024, 1, 15), Date.of(2024, 1, 30)),
+                        Arrays.asList(Date.of(2024, 1, 15)),
+                        BusinessDayConventionEnum.FOLLOWING,
+                        Date.of(2024, 1, 16),
+                        Date.of(2024, 1, 30)
+                ),
+                Arguments.of(
+                        "Only adjusts end date when only end date falls on a holiday",
+                        buildPeriod(Date.of(2024, 1, 10), Date.of(2024, 1, 15)),
+                        Arrays.asList(Date.of(2024, 1, 15)),
+                        BusinessDayConventionEnum.FOLLOWING,
+                        Date.of(2024, 1, 10),
+                        Date.of(2024, 1, 16)
+                ),
+                // --- Convention is threaded through to both dates ---
+                Arguments.of(
+                        "FOLLOWING: both dates moved forward to next business day",
+                        buildPeriod(Date.of(2024, 1, 15), Date.of(2024, 1, 31)),
+                        Arrays.asList(Date.of(2024, 1, 15), Date.of(2024, 1, 31)),
+                        BusinessDayConventionEnum.FOLLOWING,
+                        Date.of(2024, 1, 16),
+                        Date.of(2024, 2, 1)
+                ),
+                Arguments.of(
+                        "PRECEDING: both dates moved backward to previous business day",
+                        buildPeriod(Date.of(2024, 1, 15), Date.of(2024, 1, 31)),
+                        Arrays.asList(Date.of(2024, 1, 15), Date.of(2024, 1, 31)),
+                        BusinessDayConventionEnum.PRECEDING,
+                        Date.of(2024, 1, 14),
+                        Date.of(2024, 1, 30)
+                ),
+                Arguments.of(
+                        "MODFOLLOWING: both dates adjusted using modified following convention",
+                        buildPeriod(Date.of(2024, 1, 15), Date.of(2024, 1, 29)),
+                        Arrays.asList(Date.of(2024, 1, 15), Date.of(2024, 1, 29)),
+                        BusinessDayConventionEnum.MODFOLLOWING,
+                        Date.of(2024, 1, 16),
+                        Date.of(2024, 1, 30)
+                ),
+                Arguments.of(
+                        "NONE: both dates returned unadjusted even when they fall on holidays",
+                        buildPeriod(Date.of(2024, 1, 15), Date.of(2024, 1, 31)),
+                        Arrays.asList(Date.of(2024, 1, 15), Date.of(2024, 1, 31)),
+                        BusinessDayConventionEnum.NONE,
+                        Date.of(2024, 1, 15),
+                        Date.of(2024, 1, 31)
+                )
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("adjustmentScenarios")
+    void shouldAdjustPeriodDatesAccordingToConvention(
+            String description,
+            CalculationPeriodBase unadjustedPeriod,
+            List<Date> holidays,
+            BusinessDayConventionEnum convention,
+            Date expectedStart,
+            Date expectedEnd) {
+
+        AdjustPeriodInstruction result = createAdjustPeriodInstruction.evaluate(
+                unadjustedPeriod, holidays, convention);
+
+        assertEquals(expectedStart, result.getAdjustedPeriod().getAdjustedStartDate(),
+                description + ": unexpected adjusted start date");
+        assertEquals(expectedEnd, result.getAdjustedPeriod().getAdjustedEndDate(),
+                description + ": unexpected adjusted end date");
+    }
+
+
+    // -------- Helper methods -----------
+
+    private static CalculationPeriodBase buildPeriod(Date startDate, Date endDate) {
+        return CalculationPeriodBase.builder()
+                .setAdjustedStartDate(startDate)
+                .setAdjustedEndDate(endDate)
+                .build();
+    }
+}

--- a/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/UpdateResetCompositionStateTest.java
+++ b/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/UpdateResetCompositionStateTest.java
@@ -2,6 +2,7 @@ package cdm.event.instructioncomposition.reset.functions;
 
 import cdm.base.staticdata.asset.rates.FloatingRateIndexEnum;
 import cdm.event.instructioncomposition.CompositionStepInstructions;
+import cdm.event.instructioncomposition.reset.AdjustPeriodInstruction;
 import cdm.event.instructioncomposition.reset.CollectFloatingRateOptionInstruction;
 import cdm.event.instructioncomposition.reset.DetermineUnadjustedCalculationPeriodInstruction;
 import cdm.event.instructioncomposition.reset.ResetInstructionState;
@@ -130,6 +131,63 @@ class UpdateResetCompositionStateTest extends AbstractFunctionTest {
 
             assertNull(result.getUnadjustedCalculationPeriod());
             assertNull(result.getUnadjustedResetDate());
+        }
+    }
+
+    @Nested
+    @DisplayName("Step 3 - Adjusted Calculation Period")
+    class AdjustPeriodTest {
+
+        @Test
+        @DisplayName("Sets adjustedCalculationPeriod from the step instruction when adjustPeriod is present")
+        void shouldSetAdjustedCalculationPeriodFromStepWhenAdjustPeriodIsPresent() {
+            CalculationPeriodBase adjustedPeriod = CalculationPeriodBase.builder()
+                    .setAdjustedStartDate(Date.of(2024, 1, 1))
+                    .setAdjustedEndDate(Date.of(2024, 3, 31))
+                    .build();
+            CompositionStepInstructions nextStep = CompositionStepInstructions.builder()
+                    .setAdjustPeriod(AdjustPeriodInstruction.builder()
+                            .setAdjustedPeriod(adjustedPeriod)
+                            .build())
+                    .build();
+
+            ResetInstructionState result = updateResetCompositionState.evaluate(null, nextStep);
+
+            assertEquals(Date.of(2024, 1, 1), result.getAdjustedCalculationPeriod().getAdjustedStartDate(),
+                    "adjustedStartDate must be taken from the step instruction");
+            assertEquals(Date.of(2024, 3, 31), result.getAdjustedCalculationPeriod().getAdjustedEndDate(),
+                    "adjustedEndDate must be taken from the step instruction");
+        }
+
+        @Test
+        @DisplayName("Carries forward adjustedCalculationPeriod from the current state when adjustPeriod is absent")
+        void shouldCarryForwardAdjustedCalculationPeriodFromCurrentStateWhenAdjustPeriodIsAbsent() {
+            CalculationPeriodBase existingPeriod = CalculationPeriodBase.builder()
+                    .setAdjustedStartDate(Date.of(2024, 4, 1))
+                    .setAdjustedEndDate(Date.of(2024, 6, 30))
+                    .build();
+            ResetInstructionState currentState = ResetInstructionState.builder()
+                    .setAdjustedCalculationPeriod(existingPeriod)
+                    .build();
+            CompositionStepInstructions nextStepWithoutAdjustPeriod = CompositionStepInstructions.builder().build();
+
+            ResetInstructionState result = updateResetCompositionState.evaluate(currentState, nextStepWithoutAdjustPeriod);
+
+            assertEquals(Date.of(2024, 4, 1), result.getAdjustedCalculationPeriod().getAdjustedStartDate(),
+                    "adjustedStartDate must be carried forward from the current state");
+            assertEquals(Date.of(2024, 6, 30), result.getAdjustedCalculationPeriod().getAdjustedEndDate(),
+                    "adjustedEndDate must be carried forward from the current state");
+        }
+
+        @Test
+        @DisplayName("Produces null adjustedCalculationPeriod when adjustPeriod is absent and current state is absent")
+        void shouldProduceNullAdjustedCalculationPeriodWhenAdjustPeriodAndCurrentStateAreBothAbsent() {
+            CompositionStepInstructions nextStepWithoutAdjustPeriod = CompositionStepInstructions.builder().build();
+
+            ResetInstructionState result = updateResetCompositionState.evaluate(null, nextStepWithoutAdjustPeriod);
+
+            assertNull(result.getAdjustedCalculationPeriod(),
+                    "adjustedCalculationPeriod must be null when both current state and step instruction are absent");
         }
     }
 }


### PR DESCRIPTION
# _Instruction Composition Reset Step 3: Adjust the period_


_Background_

Building upon the functional milestones introduced in the previous release for Step 2 (#4379), the CDM Smart Contract Taskforce is advancing the state-machine execution capabilities within the Instruction Composition Framework. This release delivers the components required to execute Step 3 (Adjust Calculation Period) of the 8-step Interest Rate Reset processing workflow. By introducing this phase, the model can now deterministically apply calendar adjustments and financial business day conventions to unadjusted schedules. For further information, see issue #4389.

_What is being released?_

This release provides the core business day alignment logic, holiday calendar resolution hooks, and state accumulator mutations necessary to transition an unadjusted calculation period into its adjusted lifecycle state. It incorporates payload bindings for Step 3 into the reusable instruction containers and expands the historical overlay tracking mechanisms to capture the final adjusted period bounds.

_Functions_

Changes in the cdm.base.datetime namespace:
- `AdjustDateToBusinessDayConvention`: Core mapping function that routes an unadjusted date through a selected business day convention matrix when a calendar clash is detected.
- `ApplyFollowing`: Recursive utility evaluating calendar forward-shifts to find the next valid business day.
- `ApplyPreceding`: Recursive utility evaluating calendar backward-shifts to find the previous valid business day.
- `ApplyModFollowing`: Evaluation function ensuring forward-shifted dates do not cross month boundaries, defaulting to preceding lookbacks where necessary.

Changes in the cdm.event.instructioncomposition.reset namespace:
- `Create_AdjustPeriodInstruction`: An operational mapping function that compiles adjusted starting and ending coordinates for a calculation period using defined business conventions and holiday datasets.
- `GetNonBusinessDates`: An externalized code-implementation hook to query and extract non-business dates from financial calendar providers using either distinct date vectors or defined boundary periods.

Changes in the cdm.event.instructioncomposition namespace:
- `UpdateResetCompositionState`: (Updated) Expanded to implement "Step 3" overlay logic. It conditionally captures the incoming adjustPeriod payload to update the active adjustedCalculationPeriod parameter.

_Types and Choices_

Changes in the cdm.event.instructioncomposition namespace:
- `CompositionStepInstructions` (Updated): Expanded to include adjustPeriod, allowing the global step orchestrator to wrap period adjustment data structures.

Changes in the cdm.event.instructioncomposition.reset namespace:
- `AdjustPeriodInstruction`: Introduced as the official type for Step 3.
- `ResetInstructionState` (Updated): Expanded to hold its third phase state variable (adjustedCalculationPeriod), allowing the cumulative workflow to track adjusted parameters over its lifecycle.

_Review Directions_

Navigate to the following paths to inspect the new models:
- rosetta-source/src/main/rosetta/instructionComposition-type.rosetta: Review the updated CompositionStepInstructions container to verify the inclusion of the Step 3 instruction payload mapping.
- rosetta-source/src/main/rosetta/instructionComposition-func.rosetta: Examine the updated field overlay logic inside UpdateResetCompositionState handling adjusted period state tracking.
- rosetta-source/src/main/rosetta/instructionComposition-reset-type.rosetta: Inspect the new AdjustPeriodInstruction type structure and the updated tracking properties embedded within ResetInstructionState.
- rosetta-source/src/main/rosetta/instructionComposition-reset-func.rosetta: Inspect the schedule compilation logic inside Create_AdjustPeriodInstruction and the GetNonBusinessDates interface.