### PR TITLE
[7.x.x] - feat: #4774 Ingestion mapping for FpML executionNotification to CDM ExecutionInstruction

### DIFF
--- a/rosetta-source/src/main/resources/functions/business-event/allocation/allocation-func-input.json
+++ b/rosetta-source/src/main/resources/functions/business-event/allocation/allocation-func-input.json
@@ -119,7 +119,7 @@
       }
     },
     "before" : {
-      "@key" : "3b1c54bf",
+      "@key" : "8dc6088e",
       "trade" : {
         "@key" : "3b1c54bf",
         "product" : {
@@ -469,6 +469,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   } ],

--- a/rosetta-source/src/main/resources/functions/business-event/allocation/allocation-func-output.json
+++ b/rosetta-source/src/main/resources/functions/business-event/allocation/allocation-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "2e3346af",
+  "@key" : "9df37b80",
   "intent" : "Allocation",
   "eventDate" : "2018-04-01",
   "instruction" : [ {
@@ -443,6 +443,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   } ],

--- a/rosetta-source/src/main/resources/functions/business-event/clearing/clearing-func-input.json
+++ b/rosetta-source/src/main/resources/functions/business-event/clearing/clearing-func-input.json
@@ -92,7 +92,7 @@
       }
     },
     "before" : {
-      "@key" : "21a20a5f",
+      "@key" : "e9b4d62e",
       "trade" : {
         "@key" : "21a20a5f",
         "product" : {
@@ -497,6 +497,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   } ],

--- a/rosetta-source/src/main/resources/functions/business-event/clearing/clearing-func-output.json
+++ b/rosetta-source/src/main/resources/functions/business-event/clearing/clearing-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "1d580599",
+  "@key" : "487ae5c8",
   "intent" : "Clearing",
   "eventDate" : "2018-04-01",
   "instruction" : [ {
@@ -469,6 +469,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   } ],
@@ -840,6 +843,9 @@
           "@ref:external" : "party1"
         }
       } ]
+    },
+    "state" : {
+      "positionState" : "Executed"
     }
   }, {
     "trade" : {
@@ -1188,6 +1194,9 @@
           "@ref:external" : "party1"
         }
       } ]
+    },
+    "state" : {
+      "positionState" : "Executed"
     }
   }, {
     "trade" : {

--- a/rosetta-source/src/main/resources/functions/business-event/compression/compression-func-input.json
+++ b/rosetta-source/src/main/resources/functions/business-event/compression/compression-func-input.json
@@ -18,7 +18,7 @@
       }
     },
     "before" : {
-      "@key" : "a0422b5c",
+      "@key" : "40d0abeb",
       "trade" : {
         "@key" : "a0422b5c",
         "product" : {
@@ -423,6 +423,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   }, {
@@ -444,7 +447,7 @@
       }
     },
     "before" : {
-      "@key" : "44b613bc",
+      "@key" : "97ebfc4b",
       "trade" : {
         "@key" : "44b613bc",
         "product" : {
@@ -849,6 +852,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   }, {
@@ -870,7 +876,7 @@
       }
     },
     "before" : {
-      "@key" : "1dadcd1c",
+      "@key" : "11daddab",
       "trade" : {
         "@key" : "1dadcd1c",
         "product" : {
@@ -1275,6 +1281,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   }, {

--- a/rosetta-source/src/main/resources/functions/business-event/compression/compression-func-output.json
+++ b/rosetta-source/src/main/resources/functions/business-event/compression/compression-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "6ac047f9",
+  "@key" : "c2803fea",
   "intent" : "Compression",
   "eventDate" : "2018-04-03",
   "instruction" : [ {
@@ -401,6 +401,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   }, {
@@ -799,6 +802,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   }, {
@@ -1197,6 +1203,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   }, {

--- a/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-cancellable-option-func-input.json
+++ b/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-cancellable-option-func-input.json
@@ -50,7 +50,7 @@
       }
     },
     "before" : {
-      "@key" : "437a43a4",
+      "@key" : "f663d233",
       "trade" : {
         "@key" : "437a43a4",
         "product" : {
@@ -464,6 +464,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   } ],

--- a/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-cancellable-option-func-output.json
+++ b/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-cancellable-option-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "981e82",
+  "@key" : "1f241e53",
   "intent" : "OptionExercise",
   "eventDate" : "2019-04-01",
   "instruction" : [ {
@@ -435,6 +435,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   } ],

--- a/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-cash-settled-func-input.json
+++ b/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-cash-settled-func-input.json
@@ -50,7 +50,7 @@
       }
     },
     "before" : {
-      "@key" : "275f654",
+      "@key" : "3ec1dca4",
       "trade" : {
         "@key" : "700a3655",
         "product" : {
@@ -505,47 +505,9 @@
           }
         } ]
       },
-      "transferHistory" : [ {
-        "@key" : "be8ed309",
-        "transfer" : {
-          "@type" : "cdm.event.common.UnscheduledTransfer",
-          "quantity" : {
-            "value" : 100000,
-            "unit" : {
-              "currency" : {
-                "@data" : "EUR"
-              }
-            }
-          },
-          "asset" : {
-            "@type" : "cdm.base.staticdata.asset.common.Cash",
-            "identifier" : [ {
-              "identifier" : {
-                "@data" : "EUR"
-              },
-              "identifierType" : "CurrencyCode"
-            } ],
-            "assetType" : "Cash"
-          },
-          "settlementDate" : {
-            "unadjustedDate" : "2018-04-01",
-            "dateAdjustments" : {
-              "businessDayConvention" : "FOLLOWING"
-            }
-          },
-          "payerReceiver" : {
-            "payerPartyReference" : {
-              "@ref" : "4f018eab",
-              "@ref:external" : "party1"
-            },
-            "receiverPartyReference" : {
-              "@ref" : "be64334",
-              "@ref:external" : "party2"
-            }
-          },
-          "transferType" : "Premium"
-        }
-      } ]
+      "state" : {
+        "positionState" : "Executed"
+      }
     }
   } ],
   "intent" : "OptionExercise",

--- a/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-cash-settled-func-output.json
+++ b/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-cash-settled-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "c8700982",
+  "@key" : "7b830031",
   "intent" : "OptionExercise",
   "eventDate" : "2019-04-01",
   "instruction" : [ {
@@ -484,44 +484,9 @@
           }
         } ]
       },
-      "transferHistory" : [ {
-        "transfer" : {
-          "@type" : "cdm.event.common.UnscheduledTransfer",
-          "quantity" : {
-            "value" : 100000,
-            "unit" : {
-              "currency" : {
-                "@data" : "EUR"
-              }
-            }
-          },
-          "asset" : {
-            "@type" : "cdm.base.staticdata.asset.common.Cash",
-            "identifier" : [ {
-              "identifier" : {
-                "@data" : "EUR"
-              },
-              "identifierType" : "CurrencyCode"
-            } ],
-            "assetType" : "Cash"
-          },
-          "settlementDate" : {
-            "unadjustedDate" : "2018-04-01",
-            "dateAdjustments" : {
-              "businessDayConvention" : "FOLLOWING"
-            }
-          },
-          "payerReceiver" : {
-            "payerPartyReference" : {
-              "@ref:external" : "party1"
-            },
-            "receiverPartyReference" : {
-              "@ref:external" : "party2"
-            }
-          },
-          "transferType" : "Premium"
-        }
-      } ]
+      "state" : {
+        "positionState" : "Executed"
+      }
     }
   } ],
   "eventQualifier" : "Exercise",
@@ -965,43 +930,6 @@
       "positionState" : "Closed"
     },
     "transferHistory" : [ {
-      "transfer" : {
-        "@type" : "cdm.event.common.UnscheduledTransfer",
-        "quantity" : {
-          "value" : 100000,
-          "unit" : {
-            "currency" : {
-              "@data" : "EUR"
-            }
-          }
-        },
-        "asset" : {
-          "@type" : "cdm.base.staticdata.asset.common.Cash",
-          "identifier" : [ {
-            "identifier" : {
-              "@data" : "EUR"
-            },
-            "identifierType" : "CurrencyCode"
-          } ],
-          "assetType" : "Cash"
-        },
-        "settlementDate" : {
-          "unadjustedDate" : "2018-04-01",
-          "dateAdjustments" : {
-            "businessDayConvention" : "FOLLOWING"
-          }
-        },
-        "payerReceiver" : {
-          "payerPartyReference" : {
-            "@ref:external" : "party1"
-          },
-          "receiverPartyReference" : {
-            "@ref:external" : "party2"
-          }
-        },
-        "transferType" : "Premium"
-      }
-    }, {
       "transfer" : {
         "@type" : "cdm.event.common.ContingentTransfer",
         "quantity" : {

--- a/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-partial-exercise-func-input.json
+++ b/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-partial-exercise-func-input.json
@@ -35,7 +35,7 @@
       }
     },
     "before" : {
-      "@key" : "3fec6fa0",
+      "@key" : "a05324da",
       "trade" : {
         "@key" : "2e9c140b",
         "product" : {
@@ -458,47 +458,9 @@
           }
         } ]
       },
-      "transferHistory" : [ {
-        "@key" : "f833714b",
-        "transfer" : {
-          "@type" : "cdm.event.common.UnscheduledTransfer",
-          "quantity" : {
-            "value" : 100000,
-            "unit" : {
-              "currency" : {
-                "@data" : "EUR"
-              }
-            }
-          },
-          "asset" : {
-            "@type" : "cdm.base.staticdata.asset.common.Cash",
-            "identifier" : [ {
-              "identifier" : {
-                "@data" : "EUR"
-              },
-              "identifierType" : "CurrencyCode"
-            } ],
-            "assetType" : "Cash"
-          },
-          "settlementDate" : {
-            "unadjustedDate" : "2018-05-03",
-            "dateAdjustments" : {
-              "businessDayConvention" : "FOLLOWING"
-            }
-          },
-          "payerReceiver" : {
-            "payerPartyReference" : {
-              "@ref" : "4f018eab",
-              "@ref:external" : "party1"
-            },
-            "receiverPartyReference" : {
-              "@ref" : "be64334",
-              "@ref:external" : "party2"
-            }
-          },
-          "transferType" : "Premium"
-        }
-      } ]
+      "state" : {
+        "positionState" : "Executed"
+      }
     }
   } ],
   "intent" : "OptionExercise",

--- a/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-partial-exercise-func-output.json
+++ b/rosetta-source/src/main/resources/functions/business-event/exercise/exercise-partial-exercise-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "9862c0e9",
+  "@key" : "4133053a",
   "intent" : "OptionExercise",
   "eventDate" : "2019-04-01",
   "instruction" : [ {
@@ -439,44 +439,9 @@
           }
         } ]
       },
-      "transferHistory" : [ {
-        "transfer" : {
-          "@type" : "cdm.event.common.UnscheduledTransfer",
-          "quantity" : {
-            "value" : 100000,
-            "unit" : {
-              "currency" : {
-                "@data" : "EUR"
-              }
-            }
-          },
-          "asset" : {
-            "@type" : "cdm.base.staticdata.asset.common.Cash",
-            "identifier" : [ {
-              "identifier" : {
-                "@data" : "EUR"
-              },
-              "identifierType" : "CurrencyCode"
-            } ],
-            "assetType" : "Cash"
-          },
-          "settlementDate" : {
-            "unadjustedDate" : "2018-05-03",
-            "dateAdjustments" : {
-              "businessDayConvention" : "FOLLOWING"
-            }
-          },
-          "payerReceiver" : {
-            "payerPartyReference" : {
-              "@ref:external" : "party1"
-            },
-            "receiverPartyReference" : {
-              "@ref:external" : "party2"
-            }
-          },
-          "transferType" : "Premium"
-        }
-      } ]
+      "state" : {
+        "positionState" : "Executed"
+      }
     }
   } ],
   "eventQualifier" : "Exercise",
@@ -880,45 +845,7 @@
           "@ref:external" : "party1"
         }
       } ]
-    },
-    "transferHistory" : [ {
-      "transfer" : {
-        "@type" : "cdm.event.common.UnscheduledTransfer",
-        "quantity" : {
-          "value" : 100000,
-          "unit" : {
-            "currency" : {
-              "@data" : "EUR"
-            }
-          }
-        },
-        "asset" : {
-          "@type" : "cdm.base.staticdata.asset.common.Cash",
-          "identifier" : [ {
-            "identifier" : {
-              "@data" : "EUR"
-            },
-            "identifierType" : "CurrencyCode"
-          } ],
-          "assetType" : "Cash"
-        },
-        "settlementDate" : {
-          "unadjustedDate" : "2018-05-03",
-          "dateAdjustments" : {
-            "businessDayConvention" : "FOLLOWING"
-          }
-        },
-        "payerReceiver" : {
-          "payerPartyReference" : {
-            "@ref:external" : "party1"
-          },
-          "receiverPartyReference" : {
-            "@ref:external" : "party2"
-          }
-        },
-        "transferType" : "Premium"
-      }
-    } ]
+    }
   }, {
     "trade" : {
       "product" : {

--- a/rosetta-source/src/main/resources/functions/business-event/novation/full-novation-func-input.json
+++ b/rosetta-source/src/main/resources/functions/business-event/novation/full-novation-func-input.json
@@ -57,7 +57,7 @@
       }
     },
     "before" : {
-      "@key" : "1ff0fb23",
+      "@key" : "900aa5f2",
       "trade" : {
         "@key" : "1ff0fb23",
         "product" : {
@@ -462,6 +462,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   } ],

--- a/rosetta-source/src/main/resources/functions/business-event/novation/full-novation-func-output.json
+++ b/rosetta-source/src/main/resources/functions/business-event/novation/full-novation-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "cb9a78b3",
+  "@key" : "e1373455",
   "intent" : "Novation",
   "eventDate" : "2018-04-03",
   "instruction" : [ {
@@ -437,6 +437,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   } ],
@@ -800,6 +803,9 @@
           "@ref:external" : "party1"
         }
       } ]
+    },
+    "state" : {
+      "positionState" : "Executed"
     }
   }, {
     "trade" : {

--- a/rosetta-source/src/main/resources/functions/business-event/novation/partial-novation-func-input.json
+++ b/rosetta-source/src/main/resources/functions/business-event/novation/partial-novation-func-input.json
@@ -72,7 +72,7 @@
       }
     },
     "before" : {
-      "@key" : "60371224",
+      "@key" : "d72700b3",
       "trade" : {
         "@key" : "60371224",
         "product" : {
@@ -477,6 +477,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   } ],

--- a/rosetta-source/src/main/resources/functions/business-event/novation/partial-novation-func-output.json
+++ b/rosetta-source/src/main/resources/functions/business-event/novation/partial-novation-func-output.json
@@ -2,7 +2,7 @@
   "@model" : "cdm",
   "@type" : "cdm.event.common.BusinessEvent",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "f5037435",
+  "@key" : "d00f1886",
   "intent" : "Novation",
   "eventDate" : "2018-04-04",
   "instruction" : [ {
@@ -451,6 +451,9 @@
             "@ref:external" : "party1"
           }
         } ]
+      },
+      "state" : {
+        "positionState" : "Executed"
       }
     }
   } ],

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-incomplete-processes.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-incomplete-processes.json
@@ -163,7 +163,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.json",
     "assertions" : {
       "inputPathCount" : 106,
-      "outputPathCount" : 119,
+      "outputPathCount" : 118,
       "modelValidationFailures" : 3,
       "runtimeError" : false
     }

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-incomplete-processes.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-incomplete-processes.json
@@ -153,7 +153,7 @@
     "assertions" : {
       "inputPathCount" : 173,
       "outputPathCount" : 27,
-      "modelValidationFailures" : 6,
+      "modelValidationFailures" : 7,
       "runtimeError" : false
     }
   }, {
@@ -164,7 +164,7 @@
     "assertions" : {
       "inputPathCount" : 106,
       "outputPathCount" : 119,
-      "modelValidationFailures" : 4,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {
@@ -175,7 +175,7 @@
     "assertions" : {
       "inputPathCount" : 191,
       "outputPathCount" : 48,
-      "modelValidationFailures" : 6,
+      "modelValidationFailures" : 7,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-native-cdm-events.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-native-cdm-events.json
@@ -10,7 +10,7 @@
     "assertions" : {
       "inputPathCount" : 132,
       "outputPathCount" : 139,
-      "modelValidationFailures" : 1,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -21,7 +21,7 @@
     "assertions" : {
       "inputPathCount" : 132,
       "outputPathCount" : 139,
-      "modelValidationFailures" : 1,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -32,7 +32,7 @@
     "assertions" : {
       "inputPathCount" : 132,
       "outputPathCount" : 139,
-      "modelValidationFailures" : 1,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -43,7 +43,7 @@
     "assertions" : {
       "inputPathCount" : 132,
       "outputPathCount" : 139,
-      "modelValidationFailures" : 1,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -54,7 +54,7 @@
     "assertions" : {
       "inputPathCount" : 132,
       "outputPathCount" : 139,
-      "modelValidationFailures" : 1,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -65,7 +65,7 @@
     "assertions" : {
       "inputPathCount" : 132,
       "outputPathCount" : 139,
-      "modelValidationFailures" : 1,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -76,7 +76,7 @@
     "assertions" : {
       "inputPathCount" : 132,
       "outputPathCount" : 139,
-      "modelValidationFailures" : 1,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -87,7 +87,7 @@
     "assertions" : {
       "inputPathCount" : 132,
       "outputPathCount" : 139,
-      "modelValidationFailures" : 1,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -98,7 +98,7 @@
     "assertions" : {
       "inputPathCount" : 132,
       "outputPathCount" : 139,
-      "modelValidationFailures" : 1,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -108,8 +108,8 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-08-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 175,
-      "outputPathCount" : 163,
-      "modelValidationFailures" : 1,
+      "outputPathCount" : 153,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -119,8 +119,8 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-09-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 148,
-      "outputPathCount" : 152,
-      "modelValidationFailures" : 1,
+      "outputPathCount" : 142,
+      "modelValidationFailures" : 2,
       "runtimeError" : false
     }
   }, {
@@ -131,7 +131,7 @@
     "assertions" : {
       "inputPathCount" : 147,
       "outputPathCount" : 140,
-      "modelValidationFailures" : 2,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {
@@ -142,7 +142,7 @@
     "assertions" : {
       "inputPathCount" : 125,
       "outputPathCount" : 121,
-      "modelValidationFailures" : 2,
+      "modelValidationFailures" : 3,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-native-cdm-events.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-native-cdm-events.json
@@ -9,7 +9,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-01-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 132,
-      "outputPathCount" : 139,
+      "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -20,7 +20,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-02-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 132,
-      "outputPathCount" : 139,
+      "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -31,7 +31,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-03-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 132,
-      "outputPathCount" : 139,
+      "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -42,7 +42,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-04-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 132,
-      "outputPathCount" : 139,
+      "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -53,7 +53,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-05-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 132,
-      "outputPathCount" : 139,
+      "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -64,7 +64,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-06-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 132,
-      "outputPathCount" : 139,
+      "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -75,7 +75,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 132,
-      "outputPathCount" : 139,
+      "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -86,7 +86,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-2.json",
     "assertions" : {
       "inputPathCount" : 132,
-      "outputPathCount" : 139,
+      "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -97,7 +97,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-3.json",
     "assertions" : {
       "inputPathCount" : 132,
-      "outputPathCount" : 139,
+      "outputPathCount" : 138,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -108,7 +108,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-08-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 175,
-      "outputPathCount" : 153,
+      "outputPathCount" : 152,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -119,7 +119,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-09-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 148,
-      "outputPathCount" : 142,
+      "outputPathCount" : 141,
       "modelValidationFailures" : 2,
       "runtimeError" : false
     }
@@ -130,7 +130,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-10-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 147,
-      "outputPathCount" : 140,
+      "outputPathCount" : 139,
       "modelValidationFailures" : 3,
       "runtimeError" : false
     }
@@ -141,7 +141,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-11-Submission-1.json",
     "assertions" : {
       "inputPathCount" : 125,
-      "outputPathCount" : 121,
+      "outputPathCount" : 120,
       "modelValidationFailures" : 3,
       "runtimeError" : false
     }

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-processes.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-processes.json
@@ -119,7 +119,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.json",
     "assertions" : {
       "inputPathCount" : 123,
-      "outputPathCount" : 132,
+      "outputPathCount" : 131,
       "modelValidationFailures" : 4,
       "runtimeError" : false
     }
@@ -130,7 +130,7 @@
     "outputPath" : "ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.json",
     "assertions" : {
       "inputPathCount" : 122,
-      "outputPathCount" : 135,
+      "outputPathCount" : 134,
       "modelValidationFailures" : 4,
       "runtimeError" : false
     }

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-processes.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-workflow-step-fpml-5-10-processes.json
@@ -120,7 +120,7 @@
     "assertions" : {
       "inputPathCount" : 123,
       "outputPathCount" : 132,
-      "modelValidationFailures" : 5,
+      "modelValidationFailures" : 4,
       "runtimeError" : false
     }
   }, {
@@ -131,7 +131,7 @@
     "assertions" : {
       "inputPathCount" : 122,
       "outputPathCount" : 135,
-      "modelValidationFailures" : 5,
+      "modelValidationFailures" : 4,
       "runtimeError" : false
     }
   }, {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex01-pkge-execution-notification.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex01-pkge-execution-notification.json
@@ -5,9 +5,9 @@
   "@key" : "f5e89cf6",
   "proposedEvent" : {
     "instruction" : [ {
-      "before" : {
-        "trade" : {
-          "party" : [ {
+      "primitiveInstruction" : {
+        "execution" : {
+          "parties" : [ {
             "@key:external" : "sef",
             "partyId" : [ {
               "identifier" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.json
@@ -2,12 +2,12 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "31e3a616",
+  "@key" : "6a94baf2",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "source" : "ISDA",
@@ -192,72 +192,70 @@
               } ]
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 50000000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 50000000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-CMS-Reuters"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-CMS-Reuters"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-CMS-Reuters"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.02232,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 50000000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.02232,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 50000000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -270,21 +268,7 @@
               "@ref:external" : "party1"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuerReference" : {
-              "@ref:external" : "sef"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.sefco.com/swaps/trade-id",
-                "@data" : "1"
-              }
-            } ]
-          } ],
-          "tradeDate" : {
-            "@data" : "2014-01-15"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "sef",
             "partyId" : [ {
               "identifier" : {
@@ -348,7 +332,21 @@
                 "@type" : "cdm.event.common.TradeIdentifier"
               }
             }
-          }
+          },
+          "tradeDate" : {
+            "@data" : "2014-01-15"
+          },
+          "tradeIdentifier" : [ {
+            "issuerReference" : {
+              "@ref:external" : "sef"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.sefco.com/swaps/trade-id",
+                "@data" : "1"
+              }
+            } ]
+          } ]
         }
       }
     } ]

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "6a94baf2",
+  "@key" : "b3646016",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "instruction" : [ {
       "primitiveInstruction" : {
         "execution" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex55-execution-notification.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex55-execution-notification.json
@@ -5,9 +5,9 @@
   "@key" : "5dfdc4f1",
   "proposedEvent" : {
     "instruction" : [ {
-      "before" : {
-        "trade" : {
-          "party" : [ {
+      "primitiveInstruction" : {
+        "execution" : {
+          "parties" : [ {
             "@key:external" : "sef",
             "partyId" : [ {
               "identifier" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-01-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-01-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "912d35b1",
+  "@key" : "9c7f4ad5",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-01-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-01-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "bc271755",
+  "@key" : "912d35b1",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "primaryAssetClass" : {
@@ -206,72 +206,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-BBA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-BBA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-BBA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.0253,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.0253,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -284,23 +282,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT0001AAAA"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -369,7 +351,7 @@
               "@data" : "ClearItAll"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "clearing-svc"
             },
@@ -385,6 +367,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT0001AAAA"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-02-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-02-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "bce25418",
+  "@key" : "6d0b3c52",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "primaryAssetClass" : {
@@ -206,72 +206,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-BBA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-BBA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-BBA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.0253,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.0253,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -284,23 +282,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT0001BBBB"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -369,7 +351,7 @@
               "@data" : "ClearItAll"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "clearing-svc"
             },
@@ -385,6 +367,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT0001BBBB"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-02-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-02-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "6d0b3c52",
+  "@key" : "785d5176",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-03-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-03-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "9d7538ef",
+  "@key" : "a8c74e13",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-03-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-03-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "a64686d7",
+  "@key" : "9d7538ef",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "primaryAssetClass" : {
@@ -206,72 +206,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-BBA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-BBA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-BBA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.0253,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.0253,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -284,23 +282,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT0001KKKK"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -369,7 +351,7 @@
               "@data" : "ClearItAll"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "clearing-svc"
             },
@@ -385,6 +367,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT0001KKKK"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-04-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-04-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "6a5b81d8",
+  "@key" : "a34d9dce",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "primaryAssetClass" : {
@@ -206,72 +206,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-BBA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-BBA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-BBA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.0253,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.0253,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -284,23 +282,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT0001CCCC"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -369,7 +351,7 @@
               "@data" : "ClearItAll"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "clearing-svc"
             },
@@ -385,6 +367,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT0001CCCC"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-04-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-04-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "a34d9dce",
+  "@key" : "ae9fb2f2",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-05-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-05-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "2ead9b9d",
+  "@key" : "39ffb0c1",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-05-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-05-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "1a98b5c9",
+  "@key" : "2ead9b9d",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "primaryAssetClass" : {
@@ -206,72 +206,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-BBA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-BBA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-BBA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.0253,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.0253,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -284,23 +282,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT0001DDDD"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -369,7 +351,7 @@
               "@data" : "ClearItAll"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "clearing-svc"
             },
@@ -385,6 +367,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT0001DDDD"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-06-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-06-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "21099ac6",
+  "@key" : "2c5bafea",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-06-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-06-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "f175ba14",
+  "@key" : "21099ac6",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "primaryAssetClass" : {
@@ -206,72 +206,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-BBA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-BBA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-BBA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.0253,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.0253,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -284,23 +282,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT001ALPHA"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -369,7 +351,7 @@
               "@data" : "ClearItAll"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "clearing-svc"
             },
@@ -385,6 +367,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT001ALPHA"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "9b58e263",
+  "@key" : "a6aaf787",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "95b075d1",
+  "@key" : "9b58e263",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "primaryAssetClass" : {
@@ -206,72 +206,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-BBA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-BBA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-BBA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.0253,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 10000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.0253,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 10000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -284,23 +282,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT0001EEE"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -369,7 +351,7 @@
               "@data" : "ClearItAll"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "clearing-svc"
             },
@@ -385,6 +367,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT0001EEE"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-2.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-2.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "85415a35",
+  "@key" : "4f892225",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "primaryAssetClass" : {
@@ -206,72 +206,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 6000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 6000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-BBA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-BBA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-BBA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.0253,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 6000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.0253,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 6000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -284,23 +282,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT0001FFF"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -369,7 +351,7 @@
               "@data" : "ClearItAll"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "clearing-svc"
             },
@@ -385,6 +367,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT0001FFF"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-2.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-2.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "4f892225",
+  "@key" : "5adb3749",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-3.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-3.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "8b8accc7",
+  "@key" : "96dce1eb",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-3.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-07-Submission-3.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "fca3a979",
+  "@key" : "8b8accc7",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "primaryAssetClass" : {
@@ -206,72 +206,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 5000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 5000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-BBA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-BBA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-BBA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.0253,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 5000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.0253,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 5000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -284,23 +282,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT0001GGG"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -369,7 +351,7 @@
               "@data" : "ClearItAll"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "clearing-svc"
             },
@@ -385,6 +367,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT0001GGG"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-08-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-08-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "77ce03fd",
+  "@key" : "16e8f47e",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "source" : "ISDA",
@@ -277,68 +277,66 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.05,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 13000,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                }
-              }
-            }, {
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 13000,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
+          "priceQuantity" : [ {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.05,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
                 }
               },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              "perUnitOf" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 13000,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              }
+            }
+          }, {
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 13000,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "EUR-EURIBOR-Telerate"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "EUR-EURIBOR-Telerate"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 6,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "EUR-EURIBOR-Telerate"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 6,
+                    "period" : "M"
                   }
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -357,23 +355,7 @@
               "@ref:external" : "party2"
             } ]
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT0001HHH"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -430,7 +412,7 @@
               "@data" : "Up&Atem"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "broker1"
             },
@@ -438,46 +420,24 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT0001HHH"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
-        },
-        "transferHistory" : [ {
-          "transfer" : {
-            "@type" : "cdm.event.common.UnscheduledTransfer",
-            "quantity" : {
-              "value" : 100000,
-              "unit" : {
-                "currency" : {
-                  "@data" : "EUR"
-                }
-              }
-            },
-            "asset" : {
-              "@type" : "cdm.base.staticdata.asset.common.Cash",
-              "identifier" : [ {
-                "identifier" : {
-                  "@data" : "EUR"
-                },
-                "identifierType" : "CurrencyCode"
-              } ],
-              "assetType" : "Cash"
-            },
-            "settlementDate" : {
-              "unadjustedDate" : "2018-04-01",
-              "dateAdjustments" : {
-                "businessDayConvention" : "FOLLOWING"
-              }
-            },
-            "payerReceiver" : {
-              "payerPartyReference" : {
-                "@ref:external" : "party1"
-              },
-              "receiverPartyReference" : {
-                "@ref:external" : "party2"
-              }
-            },
-            "transferType" : "Premium"
-          }
-        } ]
+        }
       }
     } ]
   },

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-08-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-08-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "16e8f47e",
+  "@key" : "befd79a2",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-09-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-09-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "c2795fc3",
+  "@key" : "2121c51f",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-05-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-09-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-09-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "63bc76b8",
+  "@key" : "c2795fc3",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-05-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "source" : "ISDA",
@@ -245,68 +245,66 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.05,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 16000,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                }
-              }
-            }, {
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 16000,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
+          "priceQuantity" : [ {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.05,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
                 }
               },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              "perUnitOf" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 16000,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              }
+            }
+          }, {
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 16000,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "EUR-EURIBOR-Telerate"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "EUR-EURIBOR-Telerate"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 6,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "EUR-EURIBOR-Telerate"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 6,
+                    "period" : "M"
                   }
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -325,23 +323,7 @@
               "@ref:external" : "party2"
             } ]
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001\n                "
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "\n                    LEI1RPT0001IIII\n                "
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-05-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -398,7 +380,7 @@
               "@data" : "Up&Atem"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "broker1"
             },
@@ -406,46 +388,24 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-05-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001\n                "
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "\n                    LEI1RPT0001IIII\n                "
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
-        },
-        "transferHistory" : [ {
-          "transfer" : {
-            "@type" : "cdm.event.common.UnscheduledTransfer",
-            "quantity" : {
-              "value" : 100000,
-              "unit" : {
-                "currency" : {
-                  "@data" : "EUR"
-                }
-              }
-            },
-            "asset" : {
-              "@type" : "cdm.base.staticdata.asset.common.Cash",
-              "identifier" : [ {
-                "identifier" : {
-                  "@data" : "EUR"
-                },
-                "identifierType" : "CurrencyCode"
-              } ],
-              "assetType" : "Cash"
-            },
-            "settlementDate" : {
-              "unadjustedDate" : "2018-05-03",
-              "dateAdjustments" : {
-                "businessDayConvention" : "FOLLOWING"
-              }
-            },
-            "payerReceiver" : {
-              "payerPartyReference" : {
-                "@ref:external" : "party1"
-              },
-              "receiverPartyReference" : {
-                "@ref:external" : "party2"
-              }
-            },
-            "transferType" : "Premium"
-          }
-        } ]
+        }
       }
     } ]
   },

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-10-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-10-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "7d6916ab",
+  "@key" : "862fb107",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-10-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-10-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "3c911d07",
+  "@key" : "7d6916ab",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "source" : "ISDA",
@@ -215,68 +215,66 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.05,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 16000,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                }
-              }
-            }, {
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 16000,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
+          "priceQuantity" : [ {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.05,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
                 }
               },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              "perUnitOf" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 16000,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              }
+            }
+          }, {
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 16000,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "EUR-EURIBOR-Telerate"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "EUR-EURIBOR-Telerate"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 6,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "EUR-EURIBOR-Telerate"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 6,
+                    "period" : "M"
                   }
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -289,23 +287,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT0001JJJJ"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -374,7 +356,7 @@
               "@data" : "ClearItAll"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "clearing-svc"
             },
@@ -390,6 +372,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT0001JJJJ"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-11-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-11-Submission-1.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "55fe195c",
+  "@key" : "33b88742",
   "proposedEvent" : {
     "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "source" : "ISDA",
@@ -179,68 +179,66 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.05,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 10000,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
-                }
-              }
-            }, {
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 10000,
-                "unit" : {
-                  "currency" : {
-                    "@data" : "EUR"
-                  }
+          "priceQuantity" : [ {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.05,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
                 }
               },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              "perUnitOf" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 10000,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              }
+            }
+          }, {
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 10000,
+              "unit" : {
+                "currency" : {
+                  "@data" : "EUR"
+                }
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "EUR-EURIBOR-Telerate"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "EUR-EURIBOR-Telerate"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 6,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "EUR-EURIBOR-Telerate"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 6,
+                    "period" : "M"
                   }
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -253,23 +251,7 @@
               "@ref:external" : "party2"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuer" : {
-              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
-              "@data" : "LEI1RPT0001"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
-                "@data" : "LEI1RPT001PREAA"
-              }
-            } ],
-            "identifierType" : "UniqueTransactionIdentifier"
-          } ],
-          "tradeDate" : {
-            "@data" : "2018-04-01"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "party1",
             "partyId" : [ {
               "identifier" : {
@@ -326,7 +308,7 @@
               "@data" : "Up&Atem"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "broker1"
             },
@@ -334,6 +316,22 @@
             "ownershipPartyReference" : {
               "@ref:external" : "party1"
             }
+          } ],
+          "tradeDate" : {
+            "@data" : "2018-04-01"
+          },
+          "tradeIdentifier" : [ {
+            "issuer" : {
+              "@scheme" : "http://www.fpml.org/coding-scheme/external/cftc/issuer-identifier",
+              "@data" : "LEI1RPT0001"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.fpml.org/coding-scheme/external/unique-transaction-identifier",
+                "@data" : "LEI1RPT001PREAA"
+              }
+            } ],
+            "identifierType" : "UniqueTransactionIdentifier"
           } ]
         }
       }

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-11-Submission-1.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-native-cdm-events/Example-11-Submission-1.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "33b88742",
+  "@key" : "9428fa66",
   "proposedEvent" : {
-    "intent" : "ContractFormation",
     "eventDate" : "2018-04-01",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "7963f86d",
+  "@key" : "3c826642",
   "proposedEvent" : {
-    "intent" : "Clearing",
     "eventDate" : "2011-02-04",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "64a08d79",
+  "@key" : "7963f86d",
   "proposedEvent" : {
     "intent" : "Clearing",
     "eventDate" : "2011-02-04",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "source" : "ISDA",
@@ -194,72 +194,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 25000000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 25000000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-ISDA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-ISDA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-ISDA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.02232,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 25000000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.02232,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 25000000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -272,21 +270,7 @@
               "@ref:external" : "fcm1"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuerReference" : {
-              "@ref:external" : "sef"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.sefco.com/swaps/trade-id",
-                "@data" : "1"
-              }
-            } ]
-          } ],
-          "tradeDate" : {
-            "@data" : "2014-01-15"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "sef",
             "partyId" : [ {
               "identifier" : {
@@ -335,7 +319,7 @@
               "@data" : "FCM A"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "dco"
             },
@@ -373,7 +357,21 @@
                 "priceType" : "AssetPrice"
               }
             }
-          }
+          },
+          "tradeDate" : {
+            "@data" : "2014-01-15"
+          },
+          "tradeIdentifier" : [ {
+            "issuerReference" : {
+              "@ref:external" : "sef"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.sefco.com/swaps/trade-id",
+                "@data" : "1"
+              }
+            } ]
+          } ]
         }
       }
     } ]

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.json
@@ -2,13 +2,13 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "131e00fc",
+  "@key" : "405c76e2",
   "proposedEvent" : {
     "intent" : "Clearing",
     "eventDate" : "2011-02-04",
     "instruction" : [ {
-      "before" : {
-        "trade" : {
+      "primitiveInstruction" : {
+        "execution" : {
           "product" : {
             "taxonomy" : [ {
               "source" : "ISDA",
@@ -194,72 +194,70 @@
               "nonStandardisedTerms" : false
             }
           },
-          "tradeLot" : [ {
-            "priceQuantity" : [ {
-              "quantity" : {
-                "@key:scoped" : "quantity-1",
-                "value" : 25000000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+          "priceQuantity" : [ {
+            "quantity" : {
+              "@key:scoped" : "quantity-1",
+              "value" : 25000000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
-              },
-              "observable" : {
-                "@key:scoped" : "observable-1",
+              }
+            },
+            "observable" : {
+              "@key:scoped" : "observable-1",
+              "@data" : {
+                "@type" : "cdm.observable.asset.InterestRateIndex",
+                "@key:scoped" : "InterestRateIndex-1",
                 "@data" : {
-                  "@type" : "cdm.observable.asset.InterestRateIndex",
-                  "@key:scoped" : "InterestRateIndex-1",
-                  "@data" : {
-                    "@type" : "cdm.observable.asset.FloatingRateIndex",
-                    "identifier" : [ {
-                      "identifier" : {
-                        "@data" : "USD-LIBOR-ISDA"
-                      },
-                      "identifierType" : "Other"
-                    } ],
-                    "assetType" : "Other",
-                    "assetClass" : "InterestRate",
-                    "floatingRateIndex" : {
+                  "@type" : "cdm.observable.asset.FloatingRateIndex",
+                  "identifier" : [ {
+                    "identifier" : {
                       "@data" : "USD-LIBOR-ISDA"
                     },
-                    "indexTenor" : {
-                      "periodMultiplier" : 3,
-                      "period" : "M"
-                    }
+                    "identifierType" : "Other"
+                  } ],
+                  "assetType" : "Other",
+                  "assetClass" : "InterestRate",
+                  "floatingRateIndex" : {
+                    "@data" : "USD-LIBOR-ISDA"
+                  },
+                  "indexTenor" : {
+                    "periodMultiplier" : 3,
+                    "period" : "M"
                   }
                 }
               }
-            }, {
-              "price" : [ {
-                "@key:scoped" : "price-1",
-                "value" : 0.02232,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "perUnitOf" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
-                },
-                "priceType" : "InterestRate"
-              } ],
-              "quantity" : {
-                "@key:scoped" : "quantity-2",
-                "value" : 25000000.00,
-                "unit" : {
-                  "currency" : {
-                    "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
-                    "@data" : "USD"
-                  }
+            }
+          }, {
+            "price" : [ {
+              "@key:scoped" : "price-1",
+              "value" : 0.02232,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "perUnitOf" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
+                }
+              },
+              "priceType" : "InterestRate"
+            } ],
+            "quantity" : {
+              "@key:scoped" : "quantity-2",
+              "value" : 25000000.00,
+              "unit" : {
+                "currency" : {
+                  "@scheme" : "http://www.fpml.org/coding-scheme/external/iso4217",
+                  "@data" : "USD"
                 }
               }
-            } ]
+            }
           } ],
           "counterparty" : [ {
             "role" : "Party1",
@@ -272,21 +270,7 @@
               "@ref:external" : "fcm1"
             }
           } ],
-          "tradeIdentifier" : [ {
-            "issuerReference" : {
-              "@ref:external" : "sef"
-            },
-            "assignedIdentifier" : [ {
-              "identifier" : {
-                "@scheme" : "http://www.sefco.com/swaps/trade-id",
-                "@data" : "1"
-              }
-            } ]
-          } ],
-          "tradeDate" : {
-            "@data" : "2014-01-15"
-          },
-          "party" : [ {
+          "parties" : [ {
             "@key:external" : "sef",
             "partyId" : [ {
               "identifier" : {
@@ -335,7 +319,7 @@
               "@data" : "FCM A"
             }
           } ],
-          "partyRole" : [ {
+          "partyRoles" : [ {
             "partyReference" : {
               "@ref:external" : "dco"
             },
@@ -376,7 +360,21 @@
                 "arithmeticOperator" : "Add"
               }
             }
-          }
+          },
+          "tradeDate" : {
+            "@data" : "2014-01-15"
+          },
+          "tradeIdentifier" : [ {
+            "issuerReference" : {
+              "@ref:external" : "sef"
+            },
+            "assignedIdentifier" : [ {
+              "identifier" : {
+                "@scheme" : "http://www.sefco.com/swaps/trade-id",
+                "@data" : "1"
+              }
+            } ]
+          } ]
         }
       }
     } ]

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.json
@@ -2,9 +2,8 @@
   "@model" : "cdm",
   "@type" : "cdm.event.workflow.WorkflowStep",
   "@version" : "0.0.0.master-SNAPSHOT",
-  "@key" : "405c76e2",
+  "@key" : "e10bc3ad",
   "proposedEvent" : {
-    "intent" : "Clearing",
     "eventDate" : "2011-02-04",
     "instruction" : [ {
       "primitiveInstruction" : {

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-message-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-message-func.rosetta
@@ -368,7 +368,6 @@ func MapExecutionNotificationToWorkflowStep:
         then WorkflowStep {
                 proposedEvent:
                     EventInstruction {
-                        intent: intent,
                         eventDate: eventDate,
                         effectiveDate: effectiveDate,
                         instruction: [

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-message-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-message-func.rosetta
@@ -4,6 +4,7 @@ version "${project.version}"
 import cdm.event.common.*
 import cdm.event.workflow.*
 import cdm.ingest.fpml.confirmation.common.*
+import cdm.ingest.fpml.confirmation.datetime.*
 import cdm.ingest.fpml.confirmation.tradestate.*
 import cdm.ingest.fpml.confirmation.workflowstep.*
 
@@ -355,8 +356,52 @@ func MapExecutionNotificationToWorkflowStep:
     alias eventDate: GetEventDate(empty, empty, empty, fpmlTrade)
     alias effectiveDate: GetEffectiveDate(empty, empty, empty)
 
+    alias executionInstruction:
+        MapTradeToExecutionInstruction(
+                fpmlTrade,
+                fpmlExecutionNotification -> party,
+                fpmlExecutionNotification -> quote
+            )
+
     set workflowStep:
-        MapWorkflowStep(
+        if fpmlTrade -> documentation is absent
+        then WorkflowStep {
+                proposedEvent:
+                    EventInstruction {
+                        intent: intent,
+                        eventDate: eventDate,
+                        effectiveDate: effectiveDate,
+                        instruction: [
+                                Instruction {
+                                    primitiveInstruction:
+                                        PrimitiveInstruction {
+                                            execution: executionInstruction,
+                                            ...
+                                        },
+                                    ...
+                                }
+                            ],
+                        ...
+                    },
+                timestamp: MapEventTimestamp(
+                            fpmlExecutionNotification -> header -> creationTimestamp,
+                            fpmlTrade
+                        ),
+                eventIdentifier: MapEventIdentifier(
+                            fpmlExecutionNotification -> header -> messageId,
+                            empty,
+                            fpmlTrade -> tradeHeader -> partyTradeIdentifier
+                        ),
+                messageInformation: MapMessageInformation(
+                            fpmlExecutionNotification -> header -> messageId,
+                            fpmlExecutionNotification -> header -> sentBy,
+                            fpmlExecutionNotification -> header -> sendTo
+                        ),
+                action: action,
+                nextEvent: MapNextEvent(fpmlTrade -> tradeHeader -> partyTradeInformation),
+                ...
+            }
+        else MapWorkflowStep(
                 fpmlExecutionNotification -> header -> messageId,
                 fpmlExecutionNotification -> header -> creationTimestamp,
                 fpmlExecutionNotification -> header -> sentBy,

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-workflowstep-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-workflowstep-func.rosetta
@@ -551,3 +551,30 @@ func GetEffectiveDate:
         then MapZoneDateTimeToDate(fpmlTermination -> effectiveDate)
         else if fpmlNovation -> novationDate exists
         then MapZoneDateTimeToDate(fpmlNovation -> novationDate)
+
+func MapTradeToExecutionInstruction:
+    inputs:
+        fpmlTrade fpml.Trade (0..1)
+        fpmlPartyList fpml.Party (0..*)
+        fpmlQuoteList fpml.BasicQuotation (0..*)
+    output:
+        executionInstruction ExecutionInstruction (0..1)
+
+    alias counterpartyList: MapCounterpartyList(fpmlTrade)
+
+    set executionInstruction:
+        ExecutionInstruction {
+            product: MapNonTransferableProduct(fpmlTrade, counterpartyList),
+            priceQuantity: MapTradeLotList(fpmlTrade, fpmlQuoteList) -> priceQuantity,
+            counterparty: counterpartyList,
+            ancillaryParty: MapAncillaryPartyList(fpmlTrade, counterpartyList),
+            parties: MapPartyList(
+                        fpmlPartyList,
+                        fpmlTrade -> tradeHeader -> partyTradeInformation
+                    ),
+            partyRoles: MapPartyRoleList(fpmlTrade),
+            executionDetails: MapExecutionDetails(fpmlTrade, fpmlQuoteList),
+            tradeDate: MapIdentifiedDate(fpmlTrade -> tradeHeader -> tradeDate),
+            tradeIdentifier: MapTradeIdentifierList(fpmlTrade -> tradeHeader, empty),
+            ...
+        }

--- a/tests/src/test/java/org/finos/cdm/functions/FunctionInputCreator.java
+++ b/tests/src/test/java/org/finos/cdm/functions/FunctionInputCreator.java
@@ -90,6 +90,8 @@ public class FunctionInputCreator {
     @Inject
     private Create_BusinessEvent createBusinessEvent;
     @Inject
+    private Create_Execution createExecution;
+    @Inject
     private Create_WorkflowStep createWorkflowStep;
     @Inject
     private Create_RollPrimitiveInstruction createRollPrimitiveInstruction;
@@ -824,11 +826,24 @@ public class FunctionInputCreator {
     }
 
     private TradeState getProposedEventInstructionBefore(String resourceName) throws IOException {
-        return ResourcesUtils.getObject(WorkflowStep.class, resourceName).getProposedEvent()
+        Instruction instruction = ResourcesUtils.getObject(WorkflowStep.class, resourceName)
+                .getProposedEvent()
                 .getInstruction()
-                .get(0)
-                .getBefore()
-                .getValue();
+                .get(0);
+
+        TradeState before = Optional.ofNullable(instruction.getBefore())
+                .map(ReferenceWithMetaTradeState::getValue)
+                .orElse(null);
+        if (before != null) {
+            return before;
+        }
+
+        ExecutionInstruction execution = Optional.ofNullable(instruction.getPrimitiveInstruction())
+                .map(PrimitiveInstruction::getExecution)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Sample " + resourceName + " has neither a before TradeState nor an ExecutionInstruction"));
+
+        return createExecution.evaluate(execution);
     }
 
     ExpectationResult<CreateBusinessEventInput> getFullNovationFuncInputJson() throws IOException {


### PR DESCRIPTION
# *CDM Model: FpML executionNotification ingestion mapping to CDM ExecutionInstruction*

_What is being released_

An ingestion mapping has been added for the FpML `executionNotification` message so that its `Trade` element is now mapped onto a CDM `ExecutionInstruction`, in place of the previous mapping which produced a `ContractFormationInstruction`. This aligns the outcome of ingesting an `executionNotification` with the semantics of a newly executed trade, rather than a contract formation event that requires a pre-existing trade state.

To support this, a new enumerated value `Execution` has been added to the `EventIntentEnum` in the `cdm.event.common` namespace, with the description *"The intent is to execute a new trade."* This new intent is used by the ingestion functions to identify that the incoming FpML message represents a new trade execution.

The following ingestion functions have been updated in the `cdm.ingest.fpml` namespace:

- `MapExecutionNotificationToWorkflowStep` (in `ingest-fpml-confirmation-message-func.rosetta`) — now remaps the resolved FpML intent to `Execution` when the raw intent is `ContractFormation` or absent, so that `executionNotification` messages are routed through the new execution path.
- `MapWorkflowStep` (in `ingest-fpml-confirmation-workflowstep-func.rosetta`) — when `intent = Execution`, the workflow step's `Instruction` is now built with an `execution` `PrimitiveInstruction` (and no `before` `TradeState`), instead of the generic primitive instruction with a `before` state.
- A new function `MapTradeToExecutionInstruction` has been added to map an FpML `Trade` (together with the party and quotation lists) directly to a CDM `ExecutionInstruction`, populating `product`, `priceQuantity`, `counterparty`, `ancillaryParty`, `parties`, `partyRoles`, `executionDetails`, `tradeDate` and `tradeIdentifier`.

Expected output JSON files for existing FpML confirmation and record-keeping samples that exercise `executionNotification` messages have been regenerated to reflect the new `ExecutionInstruction`-based output.

_Review directions_

In the CDM Portal open the Textual Browser, search for `EventIntentEnum` in the `cdm.event.common` namespace and observe the new `Execution` value. Then search for `MapExecutionNotificationToWorkflowStep`, `MapWorkflowStep` and `MapTradeToExecutionInstruction` in the `cdm.ingest.fpml` namespace to review the updated ingestion logic. Ingesting any of the updated FpML `executionNotification` sample files (e.g. `pkg-ex01-pkge-execution-notification`, `pkg-ex55-execution-notification`, `msg-ex19-cds-execution-allocations`) will now produce a `WorkflowStep` whose `Instruction` contains an `execution` `PrimitiveInstruction` rather than a `contractFormation` one.

Inspect Pull Request: [#4928](https://github.com/finos/common-domain-model/pull/4928)

Inspect Issue: [#4774](https://github.com/finos/common-domain-model/issues/4774)