### PR TITLE
[6.x.x] Fix Ingest diagnostics following PR #4928

### DIFF
--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex01-pkge-execution-notification.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex01-pkge-execution-notification.diff
@@ -1,0 +1,135 @@
+--- rosetta-source/src/main/resources/result-json-files/fpml-5-10/incomplete-processes/pkg-ex01-pkge-execution-notification.json
++++ rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex01-pkge-execution-notification.json
+@@ -4,15 +4,9 @@
+-      "before" : {
+-        "value" : {
+-          "trade" : {
+-            "party" : [ {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "549300RE0FSXJE8G1L65",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "SEF Corp"
++      "primitiveInstruction" : {
++        "execution" : {
++          "parties" : [ {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "549300RE0FSXJE8G1L65",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -20,15 +14,15 @@
+-              "meta" : {
+-                "externalKey" : "sef"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "HWUPKR0MPOU8FGXBT394",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "Megaclient"
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "SEF Corp"
++            },
++            "meta" : {
++              "externalKey" : "sef"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "HWUPKR0MPOU8FGXBT394",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -36,15 +30,15 @@
+-              "meta" : {
+-                "externalKey" : "party1"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "549300Q4B2OQW6FDBA48",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "EBY"
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "Megaclient"
++            },
++            "meta" : {
++              "externalKey" : "party1"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "549300Q4B2OQW6FDBA48",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -52,15 +46,15 @@
+-              "meta" : {
+-                "externalKey" : "party2"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "969500A1DO2476C1ZL52",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "FCM B"
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "EBY"
++            },
++            "meta" : {
++              "externalKey" : "party2"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "969500A1DO2476C1ZL52",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -68,5 +62,9 @@
+-              "meta" : {
+-                "externalKey" : "clearingbroker"
+-              }
+-            } ]
+-          }
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "FCM B"
++            },
++            "meta" : {
++              "externalKey" : "clearingbroker"
++            }
++          } ]

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.diff
@@ -1,4 +1,771 @@
 --- rosetta-source/src/main/resources/result-json-files/fpml-5-10/incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.json
 +++ rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex02-swap-spread-single-trade-execution-notification.json
-@@ -256,0 +256,1 @@
-+                            "assetClass" : "InterestRate",
+@@ -5,17 +5,25 @@
+-      "before" : {
+-        "value" : {
+-          "trade" : {
+-            "product" : {
+-              "taxonomy" : [ {
+-                "source" : "ISDA",
+-                "productQualifier" : "InterestRate_IRSwap_FixedFloat"
+-              } ],
+-              "economicTerms" : {
+-                "payout" : [ {
+-                  "InterestRatePayout" : {
+-                    "payerReceiver" : {
+-                      "payer" : "Party1",
+-                      "receiver" : "Party2"
+-                    },
+-                    "priceQuantity" : {
+-                      "quantitySchedule" : {
++      "primitiveInstruction" : {
++        "execution" : {
++          "product" : {
++            "taxonomy" : [ {
++              "source" : "ISDA",
++              "productQualifier" : "InterestRate_IRSwap_FixedFloat"
++            } ],
++            "economicTerms" : {
++              "payout" : [ {
++                "InterestRatePayout" : {
++                  "payerReceiver" : {
++                    "payer" : "Party1",
++                    "receiver" : "Party2"
++                  },
++                  "priceQuantity" : {
++                    "quantitySchedule" : {
++                      "address" : {
++                        "scope" : "DOCUMENT",
++                        "value" : "quantity-1"
++                      }
++                    }
++                  },
++                  "rateSpecification" : {
++                    "FloatingRateSpecification" : {
++                      "rateOption" : {
+@@ -24,1 +32,1 @@
+-                          "value" : "quantity-1"
++                          "value" : "InterestRateIndex-1"
+@@ -27,8 +35,11 @@
+-                    },
+-                    "rateSpecification" : {
+-                      "FloatingRateSpecification" : {
+-                        "rateOption" : {
+-                          "address" : {
+-                            "scope" : "DOCUMENT",
+-                            "value" : "InterestRateIndex-1"
+-                          }
++                    }
++                  },
++                  "dayCountFraction" : {
++                    "value" : "ACT/365.FIXED"
++                  },
++                  "calculationPeriodDates" : {
++                    "effectiveDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2014-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "NONE"
+@@ -38,24 +49,11 @@
+-                    "dayCountFraction" : {
+-                      "value" : "ACT/365.FIXED"
+-                    },
+-                    "calculationPeriodDates" : {
+-                      "effectiveDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2014-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "NONE"
+-                          }
+-                        }
+-                      },
+-                      "terminationDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2024-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "MODFOLLOWING",
+-                            "businessCenters" : {
+-                              "businessCenter" : [ {
+-                                "value" : "USNY"
+-                              } ],
+-                              "meta" : {
+-                                "externalKey" : "primaryBusinessCenters1"
+-                              }
++                    "terminationDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2024-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "MODFOLLOWING",
++                          "businessCenters" : {
++                            "businessCenter" : [ {
++                              "value" : "USNY"
++                            } ],
++                            "meta" : {
++                              "externalKey" : "primaryBusinessCenters1"
+@@ -65,16 +63,0 @@
+-                      },
+-                      "calculationPeriodDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      },
+-                      "calculationPeriodFrequency" : {
+-                        "periodMultiplier" : 3,
+-                        "period" : "M",
+-                        "rollConvention" : "17"
+-                      },
+-                      "meta" : {
+-                        "externalKey" : "floatingCalcPeriodDates1"
+@@ -83,12 +65,5 @@
+-                    "paymentDates" : {
+-                      "paymentFrequency" : {
+-                        "periodMultiplier" : 3,
+-                        "period" : "M"
+-                      },
+-                      "payRelativeTo" : "CalculationPeriodEndDate",
+-                      "paymentDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
++                    "calculationPeriodDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -98,36 +73,7 @@
+-                    "resetDates" : {
+-                      "calculationPeriodDatesReference" : {
+-                        "externalReference" : "floatingCalcPeriodDates1"
+-                      },
+-                      "resetRelativeTo" : "CalculationPeriodStartDate",
+-                      "fixingDates" : {
+-                        "periodMultiplier" : -2,
+-                        "period" : "D",
+-                        "dayType" : "Business",
+-                        "businessDayConvention" : "NONE",
+-                        "businessCenters" : {
+-                          "businessCenter" : [ {
+-                            "value" : "GBLO"
+-                          }, {
+-                            "value" : "USNY"
+-                          } ]
+-                        },
+-                        "dateRelativeTo" : {
+-                          "externalReference" : "resetDates1"
+-                        }
+-                      },
+-                      "resetFrequency" : {
+-                        "periodMultiplier" : 3,
+-                        "period" : "M"
+-                      },
+-                      "resetDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      },
+-                      "meta" : {
+-                        "externalKey" : "resetDates1"
+-                      }
++                    "calculationPeriodFrequency" : {
++                      "periodMultiplier" : 3,
++                      "period" : "M",
++                      "rollConvention" : "17"
++                    },
++                    "meta" : {
++                      "externalKey" : "floatingCalcPeriodDates1"
+@@ -135,6 +81,5 @@
+-                  }
+-                }, {
+-                  "InterestRatePayout" : {
+-                    "payerReceiver" : {
+-                      "payer" : "Party2",
+-                      "receiver" : "Party1"
++                  },
++                  "paymentDates" : {
++                    "paymentFrequency" : {
++                      "periodMultiplier" : 3,
++                      "period" : "M"
+@@ -142,5 +87,6 @@
+-                    "priceQuantity" : {
+-                      "quantitySchedule" : {
+-                        "address" : {
+-                          "scope" : "DOCUMENT",
+-                          "value" : "quantity-2"
++                    "payRelativeTo" : "CalculationPeriodEndDate",
++                    "paymentDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -149,0 +95,5 @@
++                    }
++                  },
++                  "resetDates" : {
++                    "calculationPeriodDatesReference" : {
++                      "externalReference" : "floatingCalcPeriodDates1"
+@@ -150,10 +101,15 @@
+-                    "rateSpecification" : {
+-                      "FixedRateSpecification" : {
+-                        "rateSchedule" : {
+-                          "price" : {
+-                            "address" : {
+-                              "scope" : "DOCUMENT",
+-                              "value" : "price-1"
+-                            }
+-                          }
+-                        }
++                    "resetRelativeTo" : "CalculationPeriodStartDate",
++                    "fixingDates" : {
++                      "periodMultiplier" : -2,
++                      "period" : "D",
++                      "dayType" : "Business",
++                      "businessDayConvention" : "NONE",
++                      "businessCenters" : {
++                        "businessCenter" : [ {
++                          "value" : "GBLO"
++                        }, {
++                          "value" : "USNY"
++                        } ]
++                      },
++                      "dateRelativeTo" : {
++                        "externalReference" : "resetDates1"
+@@ -162,2 +118,3 @@
+-                    "dayCountFraction" : {
+-                      "value" : "30E/360"
++                    "resetFrequency" : {
++                      "periodMultiplier" : 3,
++                      "period" : "M"
+@@ -165,7 +122,5 @@
+-                    "calculationPeriodDates" : {
+-                      "effectiveDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2014-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "NONE"
+-                          }
++                    "resetDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -173,29 +128,0 @@
+-                      },
+-                      "terminationDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2019-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "MODFOLLOWING",
+-                            "businessCenters" : {
+-                              "businessCentersReference" : {
+-                                "externalReference" : "primaryBusinessCenters1"
+-                              }
+-                            }
+-                          }
+-                        }
+-                      },
+-                      "calculationPeriodDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      },
+-                      "calculationPeriodFrequency" : {
+-                        "periodMultiplier" : 6,
+-                        "period" : "M",
+-                        "rollConvention" : "17"
+-                      },
+-                      "meta" : {
+-                        "externalKey" : "fixedCalcPeriodDates1"
+@@ -204,14 +130,2 @@
+-                    "paymentDates" : {
+-                      "paymentFrequency" : {
+-                        "periodMultiplier" : 6,
+-                        "period" : "M"
+-                      },
+-                      "payRelativeTo" : "CalculationPeriodEndDate",
+-                      "paymentDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      }
++                    "meta" : {
++                      "externalKey" : "resetDates1"
+@@ -220,14 +134,12 @@
+-                } ]
+-              }
+-            },
+-            "tradeLot" : [ {
+-              "priceQuantity" : [ {
+-                "quantity" : [ {
+-                  "value" : {
+-                    "value" : 50000000.00,
+-                    "unit" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
+-                        }
++                }
++              }, {
++                "InterestRatePayout" : {
++                  "payerReceiver" : {
++                    "payer" : "Party2",
++                    "receiver" : "Party1"
++                  },
++                  "priceQuantity" : {
++                    "quantitySchedule" : {
++                      "address" : {
++                        "scope" : "DOCUMENT",
++                        "value" : "quantity-2"
+@@ -237,30 +149,5 @@
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "quantity-1"
+-                    } ]
+-                  }
+-                } ],
+-                "observable" : {
+-                  "value" : {
+-                    "Index" : {
+-                      "InterestRateIndex" : {
+-                        "value" : {
+-                          "FloatingRateIndex" : {
+-                            "identifier" : [ {
+-                              "identifier" : {
+-                                "value" : "USD-CMS-Reuters"
+-                              },
+-                              "identifierType" : "Other"
+-                            } ],
+-                            "floatingRateIndex" : {
+-                              "value" : "USD-CMS-Reuters"
+-                            },
+-                            "indexTenor" : {
+-                              "periodMultiplier" : 3,
+-                              "period" : "M"
+-                            }
+-                          }
+-                        },
+-                        "meta" : {
+-                          "location" : [ {
++                  "rateSpecification" : {
++                    "FixedRateSpecification" : {
++                      "rateSchedule" : {
++                        "price" : {
++                          "address" : {
+@@ -268,2 +155,2 @@
+-                            "value" : "InterestRateIndex-1"
+-                          } ]
++                            "value" : "price-1"
++                          }
+@@ -274,16 +161,9 @@
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "observable-1"
+-                    } ]
+-                  }
+-                }
+-              }, {
+-                "price" : [ {
+-                  "value" : {
+-                    "value" : 0.02232,
+-                    "unit" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                  "dayCountFraction" : {
++                    "value" : "30E/360"
++                  },
++                  "calculationPeriodDates" : {
++                    "effectiveDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2014-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "NONE"
+@@ -293,5 +173,10 @@
+-                    "perUnitOf" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    "terminationDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2019-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "MODFOLLOWING",
++                          "businessCenters" : {
++                            "businessCentersReference" : {
++                              "externalReference" : "primaryBusinessCenters1"
++                            }
++                          }
+@@ -301,17 +186,5 @@
+-                    "priceType" : "InterestRate"
+-                  },
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "price-1"
+-                    } ]
+-                  }
+-                } ],
+-                "quantity" : [ {
+-                  "value" : {
+-                    "value" : 50000000.00,
+-                    "unit" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    "calculationPeriodDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -320,0 +193,8 @@
++                    },
++                    "calculationPeriodFrequency" : {
++                      "periodMultiplier" : 6,
++                      "period" : "M",
++                      "rollConvention" : "17"
++                    },
++                    "meta" : {
++                      "externalKey" : "fixedCalcPeriodDates1"
+@@ -322,5 +203,14 @@
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "quantity-2"
+-                    } ]
++                  "paymentDates" : {
++                    "paymentFrequency" : {
++                      "periodMultiplier" : 6,
++                      "period" : "M"
++                    },
++                    "payRelativeTo" : "CalculationPeriodEndDate",
++                    "paymentDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
++                        }
++                      }
++                    }
+@@ -328,24 +218,0 @@
+-                } ]
+-              } ]
+-            } ],
+-            "counterparty" : [ {
+-              "role" : "Party1",
+-              "partyReference" : {
+-                "externalReference" : "party2"
+-              }
+-            }, {
+-              "role" : "Party2",
+-              "partyReference" : {
+-                "externalReference" : "party1"
+-              }
+-            } ],
+-            "tradeIdentifier" : [ {
+-              "issuerReference" : {
+-                "externalReference" : "sef"
+-              },
+-              "assignedIdentifier" : [ {
+-                "identifier" : {
+-                  "value" : "1",
+-                  "meta" : {
+-                    "scheme" : "http://www.sefco.com/swaps/trade-id"
+-                  }
+@@ -354,10 +220,12 @@
+-            } ],
+-            "tradeDate" : {
+-              "value" : "2014-01-15"
+-            },
+-            "party" : [ {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "549300RE0FSXJE8G1L65",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++            }
++          },
++          "priceQuantity" : [ {
++            "quantity" : [ {
++              "value" : {
++                "value" : 50000000.00,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
+@@ -365,5 +233,1 @@
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "SEF Corp"
++                }
+@@ -372,1 +236,4 @@
+-                "externalKey" : "sef"
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "quantity-1"
++                } ]
+@@ -374,6 +241,29 @@
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "HWUPKR0MPOU8FGXBT394",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++            } ],
++            "observable" : {
++              "value" : {
++                "Index" : {
++                  "InterestRateIndex" : {
++                    "value" : {
++                      "FloatingRateIndex" : {
++                        "identifier" : [ {
++                          "identifier" : {
++                            "value" : "USD-CMS-Reuters"
++                          },
++                          "identifierType" : "Other"
++                        } ],
++                        "assetClass" : "InterestRate",
++                        "floatingRateIndex" : {
++                          "value" : "USD-CMS-Reuters"
++                        },
++                        "indexTenor" : {
++                          "periodMultiplier" : 3,
++                          "period" : "M"
++                        }
++                      }
++                    },
++                    "meta" : {
++                      "location" : [ {
++                        "scope" : "DOCUMENT",
++                        "value" : "InterestRateIndex-1"
++                      } ]
++                    }
+@@ -381,5 +271,1 @@
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "Megaclient"
++                }
+@@ -388,1 +274,4 @@
+-                "externalKey" : "party1"
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "observable-1"
++                } ]
+@@ -390,6 +279,11 @@
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "549300Q4B2OQW6FDBA48",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++            }
++          }, {
++            "price" : [ {
++              "value" : {
++                "value" : 0.02232,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
+@@ -398,4 +292,9 @@
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "EBY"
++                "perUnitOf" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
++                  }
++                },
++                "priceType" : "InterestRate"
+@@ -404,1 +303,4 @@
+-                "externalKey" : "party2"
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "price-1"
++                } ]
+@@ -406,6 +308,10 @@
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "969500A1DO2476C1ZL52",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++            } ],
++            "quantity" : [ {
++              "value" : {
++                "value" : 50000000.00,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
+@@ -413,5 +319,1 @@
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "FCM B"
++                }
+@@ -420,1 +322,4 @@
+-                "externalKey" : "clearingbroker"
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "quantity-2"
++                } ]
+@@ -422,0 +327,22 @@
++            } ]
++          } ],
++          "counterparty" : [ {
++            "role" : "Party1",
++            "partyReference" : {
++              "externalReference" : "party2"
++            }
++          }, {
++            "role" : "Party2",
++            "partyReference" : {
++              "externalReference" : "party1"
++            }
++          } ],
++          "parties" : [ {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "549300RE0FSXJE8G1L65",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
++              },
++              "identifierType" : "LEI"
+@@ -423,14 +350,12 @@
+-            "executionDetails" : {
+-              "packageReference" : {
+-                "listId" : {
+-                  "issuer" : {
+-                    "value" : "SEF123"
+-                  },
+-                  "assignedIdentifier" : [ {
+-                    "identifier" : {
+-                      "value" : "123",
+-                      "meta" : {
+-                        "scheme" : "http://www.sefco.com/packages/package-id"
+-                      }
+-                    }
+-                  } ]
++            "name" : {
++              "value" : "SEF Corp"
++            },
++            "meta" : {
++              "externalKey" : "sef"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "HWUPKR0MPOU8FGXBT394",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+@@ -438,0 +363,56 @@
++              },
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "Megaclient"
++            },
++            "meta" : {
++              "externalKey" : "party1"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "549300Q4B2OQW6FDBA48",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
++              },
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "EBY"
++            },
++            "meta" : {
++              "externalKey" : "party2"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "969500A1DO2476C1ZL52",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
++              },
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "FCM B"
++            },
++            "meta" : {
++              "externalKey" : "clearingbroker"
++            }
++          } ],
++          "executionDetails" : {
++            "packageReference" : {
++              "listId" : {
++                "issuer" : {
++                  "value" : "SEF123"
++                },
++                "assignedIdentifier" : [ {
++                  "identifier" : {
++                    "value" : "123",
++                    "meta" : {
++                      "scheme" : "http://www.sefco.com/packages/package-id"
++                    }
++                  }
++                } ]
+@@ -440,1 +421,17 @@
+-          }
++          },
++          "tradeDate" : {
++            "value" : "2014-01-15"
++          },
++          "tradeIdentifier" : [ {
++            "issuerReference" : {
++              "externalReference" : "sef"
++            },
++            "assignedIdentifier" : [ {
++              "identifier" : {
++                "value" : "1",
++                "meta" : {
++                  "scheme" : "http://www.sefco.com/swaps/trade-id"
++                }
++              }
++            } ]
++          } ]

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex55-execution-notification.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex55-execution-notification.diff
@@ -1,0 +1,285 @@
+--- rosetta-source/src/main/resources/result-json-files/fpml-5-10/incomplete-processes/pkg-ex55-execution-notification.json
++++ rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-workflow-step/fpml-5-10-incomplete-processes/pkg-ex55-execution-notification.json
+@@ -4,15 +4,9 @@
+-      "before" : {
+-        "value" : {
+-          "trade" : {
+-            "party" : [ {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "549300RE0FSXJE8G1L65",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "SEF Corp"
++      "primitiveInstruction" : {
++        "execution" : {
++          "parties" : [ {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "549300RE0FSXJE8G1L65",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -20,15 +14,15 @@
+-              "meta" : {
+-                "externalKey" : "sef"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "FB0QLOLRQ9EUQ13C5P60",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "Dealer, N.A."
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "SEF Corp"
++            },
++            "meta" : {
++              "externalKey" : "sef"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "FB0QLOLRQ9EUQ13C5P60",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -36,15 +30,15 @@
+-              "meta" : {
+-                "externalKey" : "dealer"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "969500EBDH6VO20UN688",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "InvestmentManager, Inc."
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "Dealer, N.A."
++            },
++            "meta" : {
++              "externalKey" : "dealer"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "969500EBDH6VO20UN688",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -52,15 +46,15 @@
+-              "meta" : {
+-                "externalKey" : "im"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "HWUPKR0MPOU8FGXBT394",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "Megaclient"
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "InvestmentManager, Inc."
++            },
++            "meta" : {
++              "externalKey" : "im"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "HWUPKR0MPOU8FGXBT394",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -68,15 +62,15 @@
+-              "meta" : {
+-                "externalKey" : "party1"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "549300Q4B2OQW6FDBA48",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "EBY"
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "Megaclient"
++            },
++            "meta" : {
++              "externalKey" : "party1"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "549300Q4B2OQW6FDBA48",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -84,15 +78,15 @@
+-              "meta" : {
+-                "externalKey" : "party2"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "BROKER1",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso9362"
+-                  }
+-                },
+-                "identifierType" : "BIC"
+-              } ],
+-              "name" : {
+-                "value" : "Broker Corp."
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "EBY"
++            },
++            "meta" : {
++              "externalKey" : "party2"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "BROKER1",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso9362"
++                }
+@@ -100,15 +94,15 @@
+-              "meta" : {
+-                "externalKey" : "broker1"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "969500A1DO2476C1ZL52",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "FCM A"
++              "identifierType" : "BIC"
++            } ],
++            "name" : {
++              "value" : "Broker Corp."
++            },
++            "meta" : {
++              "externalKey" : "broker1"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "969500A1DO2476C1ZL52",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -116,19 +110,1 @@
+-              "meta" : {
+-                "externalKey" : "fcm1"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "969500X8N10IIFS92509",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "FCM B"
+-              },
+-              "meta" : {
+-                "externalKey" : "fcm2"
+-              }
++              "identifierType" : "LEI"
+@@ -136,3 +112,13 @@
+-            "account" : [ {
+-              "accountNumber" : {
+-                "value" : "1111"
++            "name" : {
++              "value" : "FCM A"
++            },
++            "meta" : {
++              "externalKey" : "fcm1"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "969500X8N10IIFS92509",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -140,24 +126,9 @@
+-              "accountBeneficiary" : {
+-                "externalReference" : "party1"
+-              },
+-              "servicingParty" : {
+-                "externalReference" : "fcm1"
+-              },
+-              "meta" : {
+-                "externalKey" : "party1acct"
+-              }
+-            }, {
+-              "accountNumber" : {
+-                "value" : "2222"
+-              },
+-              "accountBeneficiary" : {
+-                "externalReference" : "party2"
+-              },
+-              "servicingParty" : {
+-                "externalReference" : "fcm2"
+-              },
+-              "meta" : {
+-                "externalKey" : "party2acct"
+-              }
+-            } ]
+-          }
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "FCM B"
++            },
++            "meta" : {
++              "externalKey" : "fcm2"
++            }
++          } ]

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-price.diff
@@ -20,10 +20,831 @@
 @@ -19,1 +3,1 @@
 -    "intent" : "ContractFormation",
 +    "intent" : "Clearing",
-@@ -274,0 +258,1 @@
-+                            "assetClass" : "InterestRate",
-@@ -473,1 +458,3 @@
--                    "financialUnit" : "Contract"
-+                    "currency" : {
-+                      "value" : "USD"
+@@ -22,17 +6,25 @@
+-      "before" : {
+-        "value" : {
+-          "trade" : {
+-            "product" : {
+-              "taxonomy" : [ {
+-                "source" : "ISDA",
+-                "productQualifier" : "InterestRate_IRSwap_FixedFloat"
+-              } ],
+-              "economicTerms" : {
+-                "payout" : [ {
+-                  "InterestRatePayout" : {
+-                    "payerReceiver" : {
+-                      "payer" : "Party1",
+-                      "receiver" : "Party2"
+-                    },
+-                    "priceQuantity" : {
+-                      "quantitySchedule" : {
++      "primitiveInstruction" : {
++        "execution" : {
++          "product" : {
++            "taxonomy" : [ {
++              "source" : "ISDA",
++              "productQualifier" : "InterestRate_IRSwap_FixedFloat"
++            } ],
++            "economicTerms" : {
++              "payout" : [ {
++                "InterestRatePayout" : {
++                  "payerReceiver" : {
++                    "payer" : "Party1",
++                    "receiver" : "Party2"
++                  },
++                  "priceQuantity" : {
++                    "quantitySchedule" : {
++                      "address" : {
++                        "scope" : "DOCUMENT",
++                        "value" : "quantity-1"
++                      }
 +                    }
++                  },
++                  "rateSpecification" : {
++                    "FloatingRateSpecification" : {
++                      "rateOption" : {
+@@ -41,1 +33,1 @@
+-                          "value" : "quantity-1"
++                          "value" : "InterestRateIndex-1"
+@@ -44,8 +36,11 @@
+-                    },
+-                    "rateSpecification" : {
+-                      "FloatingRateSpecification" : {
+-                        "rateOption" : {
+-                          "address" : {
+-                            "scope" : "DOCUMENT",
+-                            "value" : "InterestRateIndex-1"
+-                          }
++                    }
++                  },
++                  "dayCountFraction" : {
++                    "value" : "ACT/365.FIXED"
++                  },
++                  "calculationPeriodDates" : {
++                    "effectiveDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2014-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "NONE"
+@@ -55,24 +50,11 @@
+-                    "dayCountFraction" : {
+-                      "value" : "ACT/365.FIXED"
+-                    },
+-                    "calculationPeriodDates" : {
+-                      "effectiveDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2014-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "NONE"
+-                          }
+-                        }
+-                      },
+-                      "terminationDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2024-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "MODFOLLOWING",
+-                            "businessCenters" : {
+-                              "businessCenter" : [ {
+-                                "value" : "USNY"
+-                              } ],
+-                              "meta" : {
+-                                "externalKey" : "primaryBusinessCenters1"
+-                              }
++                    "terminationDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2024-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "MODFOLLOWING",
++                          "businessCenters" : {
++                            "businessCenter" : [ {
++                              "value" : "USNY"
++                            } ],
++                            "meta" : {
++                              "externalKey" : "primaryBusinessCenters1"
+@@ -82,16 +64,0 @@
+-                      },
+-                      "calculationPeriodDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      },
+-                      "calculationPeriodFrequency" : {
+-                        "periodMultiplier" : 3,
+-                        "period" : "M",
+-                        "rollConvention" : "17"
+-                      },
+-                      "meta" : {
+-                        "externalKey" : "floatingCalcPeriodDates1"
+@@ -100,12 +66,5 @@
+-                    "paymentDates" : {
+-                      "paymentFrequency" : {
+-                        "periodMultiplier" : 3,
+-                        "period" : "M"
+-                      },
+-                      "payRelativeTo" : "CalculationPeriodEndDate",
+-                      "paymentDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
++                    "calculationPeriodDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -115,36 +74,7 @@
+-                    "resetDates" : {
+-                      "calculationPeriodDatesReference" : {
+-                        "externalReference" : "floatingCalcPeriodDates1"
+-                      },
+-                      "resetRelativeTo" : "CalculationPeriodStartDate",
+-                      "fixingDates" : {
+-                        "periodMultiplier" : -2,
+-                        "period" : "D",
+-                        "dayType" : "Business",
+-                        "businessDayConvention" : "NONE",
+-                        "businessCenters" : {
+-                          "businessCenter" : [ {
+-                            "value" : "GBLO"
+-                          }, {
+-                            "value" : "USNY"
+-                          } ]
+-                        },
+-                        "dateRelativeTo" : {
+-                          "externalReference" : "resetDates1"
+-                        }
+-                      },
+-                      "resetFrequency" : {
+-                        "periodMultiplier" : 3,
+-                        "period" : "M"
+-                      },
+-                      "resetDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      },
+-                      "meta" : {
+-                        "externalKey" : "resetDates1"
+-                      }
++                    "calculationPeriodFrequency" : {
++                      "periodMultiplier" : 3,
++                      "period" : "M",
++                      "rollConvention" : "17"
++                    },
++                    "meta" : {
++                      "externalKey" : "floatingCalcPeriodDates1"
+@@ -152,6 +82,5 @@
+-                  }
+-                }, {
+-                  "InterestRatePayout" : {
+-                    "payerReceiver" : {
+-                      "payer" : "Party2",
+-                      "receiver" : "Party1"
++                  },
++                  "paymentDates" : {
++                    "paymentFrequency" : {
++                      "periodMultiplier" : 3,
++                      "period" : "M"
+@@ -159,5 +88,6 @@
+-                    "priceQuantity" : {
+-                      "quantitySchedule" : {
+-                        "address" : {
+-                          "scope" : "DOCUMENT",
+-                          "value" : "quantity-2"
++                    "payRelativeTo" : "CalculationPeriodEndDate",
++                    "paymentDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -166,0 +96,5 @@
++                    }
++                  },
++                  "resetDates" : {
++                    "calculationPeriodDatesReference" : {
++                      "externalReference" : "floatingCalcPeriodDates1"
+@@ -167,10 +102,15 @@
+-                    "rateSpecification" : {
+-                      "FixedRateSpecification" : {
+-                        "rateSchedule" : {
+-                          "price" : {
+-                            "address" : {
+-                              "scope" : "DOCUMENT",
+-                              "value" : "price-1"
+-                            }
+-                          }
+-                        }
++                    "resetRelativeTo" : "CalculationPeriodStartDate",
++                    "fixingDates" : {
++                      "periodMultiplier" : -2,
++                      "period" : "D",
++                      "dayType" : "Business",
++                      "businessDayConvention" : "NONE",
++                      "businessCenters" : {
++                        "businessCenter" : [ {
++                          "value" : "GBLO"
++                        }, {
++                          "value" : "USNY"
++                        } ]
++                      },
++                      "dateRelativeTo" : {
++                        "externalReference" : "resetDates1"
+@@ -179,2 +119,3 @@
+-                    "dayCountFraction" : {
+-                      "value" : "30E/360"
++                    "resetFrequency" : {
++                      "periodMultiplier" : 3,
++                      "period" : "M"
+@@ -182,7 +123,5 @@
+-                    "calculationPeriodDates" : {
+-                      "effectiveDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2014-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "NONE"
+-                          }
++                    "resetDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -190,29 +129,0 @@
+-                      },
+-                      "terminationDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2019-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "MODFOLLOWING",
+-                            "businessCenters" : {
+-                              "businessCentersReference" : {
+-                                "externalReference" : "primaryBusinessCenters1"
+-                              }
+-                            }
+-                          }
+-                        }
+-                      },
+-                      "calculationPeriodDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      },
+-                      "calculationPeriodFrequency" : {
+-                        "periodMultiplier" : 6,
+-                        "period" : "M",
+-                        "rollConvention" : "17"
+-                      },
+-                      "meta" : {
+-                        "externalKey" : "fixedCalcPeriodDates1"
+@@ -221,14 +131,2 @@
+-                    "paymentDates" : {
+-                      "paymentFrequency" : {
+-                        "periodMultiplier" : 6,
+-                        "period" : "M"
+-                      },
+-                      "payRelativeTo" : "CalculationPeriodEndDate",
+-                      "paymentDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      }
++                    "meta" : {
++                      "externalKey" : "resetDates1"
+@@ -237,15 +135,12 @@
+-                } ],
+-                "nonStandardisedTerms" : false
+-              }
+-            },
+-            "tradeLot" : [ {
+-              "priceQuantity" : [ {
+-                "quantity" : [ {
+-                  "value" : {
+-                    "value" : 25000000.00,
+-                    "unit" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
+-                        }
++                }
++              }, {
++                "InterestRatePayout" : {
++                  "payerReceiver" : {
++                    "payer" : "Party2",
++                    "receiver" : "Party1"
++                  },
++                  "priceQuantity" : {
++                    "quantitySchedule" : {
++                      "address" : {
++                        "scope" : "DOCUMENT",
++                        "value" : "quantity-2"
+@@ -255,30 +150,5 @@
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "quantity-1"
+-                    } ]
+-                  }
+-                } ],
+-                "observable" : {
+-                  "value" : {
+-                    "Index" : {
+-                      "InterestRateIndex" : {
+-                        "value" : {
+-                          "FloatingRateIndex" : {
+-                            "identifier" : [ {
+-                              "identifier" : {
+-                                "value" : "USD-LIBOR-ISDA"
+-                              },
+-                              "identifierType" : "Other"
+-                            } ],
+-                            "floatingRateIndex" : {
+-                              "value" : "USD-LIBOR-ISDA"
+-                            },
+-                            "indexTenor" : {
+-                              "periodMultiplier" : 3,
+-                              "period" : "M"
+-                            }
+-                          }
+-                        },
+-                        "meta" : {
+-                          "location" : [ {
++                  "rateSpecification" : {
++                    "FixedRateSpecification" : {
++                      "rateSchedule" : {
++                        "price" : {
++                          "address" : {
+@@ -286,2 +156,2 @@
+-                            "value" : "InterestRateIndex-1"
+-                          } ]
++                            "value" : "price-1"
++                          }
+@@ -292,16 +162,9 @@
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "observable-1"
+-                    } ]
+-                  }
+-                }
+-              }, {
+-                "price" : [ {
+-                  "value" : {
+-                    "value" : 0.02232,
+-                    "unit" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                  "dayCountFraction" : {
++                    "value" : "30E/360"
++                  },
++                  "calculationPeriodDates" : {
++                    "effectiveDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2014-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "NONE"
+@@ -311,5 +174,10 @@
+-                    "perUnitOf" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    "terminationDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2019-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "MODFOLLOWING",
++                          "businessCenters" : {
++                            "businessCentersReference" : {
++                              "externalReference" : "primaryBusinessCenters1"
++                            }
++                          }
+@@ -319,17 +187,5 @@
+-                    "priceType" : "InterestRate"
+-                  },
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "price-1"
+-                    } ]
+-                  }
+-                } ],
+-                "quantity" : [ {
+-                  "value" : {
+-                    "value" : 25000000.00,
+-                    "unit" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    "calculationPeriodDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -338,0 +194,8 @@
++                    },
++                    "calculationPeriodFrequency" : {
++                      "periodMultiplier" : 6,
++                      "period" : "M",
++                      "rollConvention" : "17"
++                    },
++                    "meta" : {
++                      "externalKey" : "fixedCalcPeriodDates1"
+@@ -340,5 +204,14 @@
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "quantity-2"
+-                    } ]
++                  "paymentDates" : {
++                    "paymentFrequency" : {
++                      "periodMultiplier" : 6,
++                      "period" : "M"
++                    },
++                    "payRelativeTo" : "CalculationPeriodEndDate",
++                    "paymentDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
++                        }
++                      }
++                    }
+@@ -346,0 +219,22 @@
++                }
++              } ],
++              "nonStandardisedTerms" : false
++            }
++          },
++          "priceQuantity" : [ {
++            "quantity" : [ {
++              "value" : {
++                "value" : 25000000.00,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
++                  }
++                }
++              },
++              "meta" : {
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "quantity-1"
+@@ -347,6 +242,0 @@
+-              } ]
+-            } ],
+-            "counterparty" : [ {
+-              "role" : "Party1",
+-              "partyReference" : {
+-                "externalReference" : "dco"
+@@ -354,5 +243,0 @@
+-            }, {
+-              "role" : "Party2",
+-              "partyReference" : {
+-                "externalReference" : "fcm1"
+-              }
+@@ -360,9 +244,28 @@
+-            "tradeIdentifier" : [ {
+-              "issuerReference" : {
+-                "externalReference" : "sef"
+-              },
+-              "assignedIdentifier" : [ {
+-                "identifier" : {
+-                  "value" : "1",
+-                  "meta" : {
+-                    "scheme" : "http://www.sefco.com/swaps/trade-id"
++            "observable" : {
++              "value" : {
++                "Index" : {
++                  "InterestRateIndex" : {
++                    "value" : {
++                      "FloatingRateIndex" : {
++                        "identifier" : [ {
++                          "identifier" : {
++                            "value" : "USD-LIBOR-ISDA"
++                          },
++                          "identifierType" : "Other"
++                        } ],
++                        "assetClass" : "InterestRate",
++                        "floatingRateIndex" : {
++                          "value" : "USD-LIBOR-ISDA"
++                        },
++                        "indexTenor" : {
++                          "periodMultiplier" : 3,
++                          "period" : "M"
++                        }
++                      }
++                    },
++                    "meta" : {
++                      "location" : [ {
++                        "scope" : "DOCUMENT",
++                        "value" : "InterestRateIndex-1"
++                      } ]
++                    }
+@@ -371,17 +274,0 @@
+-              } ]
+-            } ],
+-            "tradeDate" : {
+-              "value" : "2014-01-15"
+-            },
+-            "party" : [ {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "549300RE0FSXJE8G1L65",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "SEF Corp"
+@@ -390,1 +276,4 @@
+-                "externalKey" : "sef"
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "observable-1"
++                } ]
+@@ -392,6 +281,11 @@
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "CCP123",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso9362"
++            }
++          }, {
++            "price" : [ {
++              "value" : {
++                "value" : 0.02232,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
+@@ -400,14 +294,6 @@
+-                "identifierType" : "BIC"
+-              } ],
+-              "name" : {
+-                "value" : "Clearco."
+-              },
+-              "meta" : {
+-                "externalKey" : "dco"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "HWUPKR0MPOU8FGXBT394",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                "perUnitOf" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
+@@ -416,4 +302,1 @@
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "Megaclient"
++                "priceType" : "InterestRate"
+@@ -422,1 +305,4 @@
+-                "externalKey" : "party1"
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "price-1"
++                } ]
+@@ -424,6 +310,10 @@
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "969500A1DO2476C1ZL52",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++            } ],
++            "quantity" : [ {
++              "value" : {
++                "value" : 25000000.00,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
+@@ -431,5 +321,1 @@
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "FCM A"
++                }
+@@ -438,1 +324,4 @@
+-                "externalKey" : "fcm1"
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "quantity-2"
++                } ]
+@@ -440,0 +329,22 @@
++            } ]
++          } ],
++          "counterparty" : [ {
++            "role" : "Party1",
++            "partyReference" : {
++              "externalReference" : "dco"
++            }
++          }, {
++            "role" : "Party2",
++            "partyReference" : {
++              "externalReference" : "fcm1"
++            }
++          } ],
++          "parties" : [ {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "549300RE0FSXJE8G1L65",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
++              },
++              "identifierType" : "LEI"
+@@ -441,3 +352,13 @@
+-            "partyRole" : [ {
+-              "partyReference" : {
+-                "externalReference" : "dco"
++            "name" : {
++              "value" : "SEF Corp"
++            },
++            "meta" : {
++              "externalKey" : "sef"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "CCP123",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso9362"
++                }
+@@ -445,4 +366,1 @@
+-              "role" : "ClearingOrganization",
+-              "ownershipPartyReference" : {
+-                "externalReference" : "fcm1"
+-              }
++              "identifierType" : "BIC"
+@@ -450,26 +368,12 @@
+-            "executionDetails" : {
+-              "packageReference" : {
+-                "listId" : {
+-                  "issuer" : {
+-                    "value" : "SEF123"
+-                  },
+-                  "assignedIdentifier" : [ {
+-                    "identifier" : {
+-                      "value" : "123",
+-                      "meta" : {
+-                        "scheme" : "http://sefco.com/package_id"
+-                      }
+-                    }
+-                  } ]
+-                },
+-                "price" : {
+-                  "value" : 123567,
+-                  "unit" : {
+-                    "currency" : {
+-                      "value" : "USD"
+-                    }
+-                  },
+-                  "perUnitOf" : {
+-                    "financialUnit" : "Contract"
+-                  },
+-                  "priceType" : "CashPrice"
++            "name" : {
++              "value" : "Clearco."
++            },
++            "meta" : {
++              "externalKey" : "dco"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "HWUPKR0MPOU8FGXBT394",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+@@ -477,1 +381,5 @@
+-              }
++              },
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "Megaclient"
+@@ -479,3 +387,10 @@
+-            "account" : [ {
+-              "partyReference" : {
+-                "externalReference" : "fcm1"
++            "meta" : {
++              "externalKey" : "party1"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "969500A1DO2476C1ZL52",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
+@@ -483,2 +398,32 @@
+-              "accountNumber" : {
+-                "value" : "1111"
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "FCM A"
++            },
++            "meta" : {
++              "externalKey" : "fcm1"
++            }
++          } ],
++          "partyRoles" : [ {
++            "partyReference" : {
++              "externalReference" : "dco"
++            },
++            "role" : "ClearingOrganization",
++            "ownershipPartyReference" : {
++              "externalReference" : "fcm1"
++            }
++          } ],
++          "executionDetails" : {
++            "packageReference" : {
++              "listId" : {
++                "issuer" : {
++                  "value" : "SEF123"
++                },
++                "assignedIdentifier" : [ {
++                  "identifier" : {
++                    "value" : "123",
++                    "meta" : {
++                      "scheme" : "http://sefco.com/package_id"
++                    }
++                  }
++                } ]
+@@ -486,8 +431,13 @@
+-              "accountBeneficiary" : {
+-                "externalReference" : "party1"
+-              },
+-              "servicingParty" : {
+-                "externalReference" : "fcm1"
+-              },
+-              "meta" : {
+-                "externalKey" : "party1acct"
++              "price" : {
++                "value" : 123567,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD"
++                  }
++                },
++                "perUnitOf" : {
++                  "currency" : {
++                    "value" : "USD"
++                  }
++                },
++                "priceType" : "CashPrice"
+@@ -495,0 +445,16 @@
++            }
++          },
++          "tradeDate" : {
++            "value" : "2014-01-15"
++          },
++          "tradeIdentifier" : [ {
++            "issuerReference" : {
++              "externalReference" : "sef"
++            },
++            "assignedIdentifier" : [ {
++              "identifier" : {
++                "value" : "1",
++                "meta" : {
++                  "scheme" : "http://www.sefco.com/swaps/trade-id"
++                }
++              }
+@@ -496,1 +462,1 @@
+-          }
++          } ]

--- a/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.diff
+++ b/tests/src/test/resources/ingest/expected-output/fpml-confirmation-to-workflow-step/fpml-5-10-processes/msg-package-spread.diff
@@ -29,5 +29,845 @@
 @@ -28,1 +3,1 @@
 -    "intent" : "ContractFormation",
 +    "intent" : "Clearing",
-@@ -283,0 +258,1 @@
-+                            "assetClass" : "InterestRate",
+@@ -31,17 +6,25 @@
+-      "before" : {
+-        "value" : {
+-          "trade" : {
+-            "product" : {
+-              "taxonomy" : [ {
+-                "source" : "ISDA",
+-                "productQualifier" : "InterestRate_IRSwap_FixedFloat"
+-              } ],
+-              "economicTerms" : {
+-                "payout" : [ {
+-                  "InterestRatePayout" : {
+-                    "payerReceiver" : {
+-                      "payer" : "Party1",
+-                      "receiver" : "Party2"
+-                    },
+-                    "priceQuantity" : {
+-                      "quantitySchedule" : {
++      "primitiveInstruction" : {
++        "execution" : {
++          "product" : {
++            "taxonomy" : [ {
++              "source" : "ISDA",
++              "productQualifier" : "InterestRate_IRSwap_FixedFloat"
++            } ],
++            "economicTerms" : {
++              "payout" : [ {
++                "InterestRatePayout" : {
++                  "payerReceiver" : {
++                    "payer" : "Party1",
++                    "receiver" : "Party2"
++                  },
++                  "priceQuantity" : {
++                    "quantitySchedule" : {
++                      "address" : {
++                        "scope" : "DOCUMENT",
++                        "value" : "quantity-1"
++                      }
++                    }
++                  },
++                  "rateSpecification" : {
++                    "FloatingRateSpecification" : {
++                      "rateOption" : {
+@@ -50,1 +33,1 @@
+-                          "value" : "quantity-1"
++                          "value" : "InterestRateIndex-1"
+@@ -53,8 +36,11 @@
+-                    },
+-                    "rateSpecification" : {
+-                      "FloatingRateSpecification" : {
+-                        "rateOption" : {
+-                          "address" : {
+-                            "scope" : "DOCUMENT",
+-                            "value" : "InterestRateIndex-1"
+-                          }
++                    }
++                  },
++                  "dayCountFraction" : {
++                    "value" : "ACT/365.FIXED"
++                  },
++                  "calculationPeriodDates" : {
++                    "effectiveDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2014-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "NONE"
+@@ -64,24 +50,11 @@
+-                    "dayCountFraction" : {
+-                      "value" : "ACT/365.FIXED"
+-                    },
+-                    "calculationPeriodDates" : {
+-                      "effectiveDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2014-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "NONE"
+-                          }
+-                        }
+-                      },
+-                      "terminationDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2024-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "MODFOLLOWING",
+-                            "businessCenters" : {
+-                              "businessCenter" : [ {
+-                                "value" : "USNY"
+-                              } ],
+-                              "meta" : {
+-                                "externalKey" : "primaryBusinessCenters1"
+-                              }
++                    "terminationDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2024-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "MODFOLLOWING",
++                          "businessCenters" : {
++                            "businessCenter" : [ {
++                              "value" : "USNY"
++                            } ],
++                            "meta" : {
++                              "externalKey" : "primaryBusinessCenters1"
+@@ -91,16 +64,0 @@
+-                      },
+-                      "calculationPeriodDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      },
+-                      "calculationPeriodFrequency" : {
+-                        "periodMultiplier" : 3,
+-                        "period" : "M",
+-                        "rollConvention" : "17"
+-                      },
+-                      "meta" : {
+-                        "externalKey" : "floatingCalcPeriodDates1"
+@@ -109,12 +66,5 @@
+-                    "paymentDates" : {
+-                      "paymentFrequency" : {
+-                        "periodMultiplier" : 3,
+-                        "period" : "M"
+-                      },
+-                      "payRelativeTo" : "CalculationPeriodEndDate",
+-                      "paymentDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
++                    "calculationPeriodDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -124,36 +74,7 @@
+-                    "resetDates" : {
+-                      "calculationPeriodDatesReference" : {
+-                        "externalReference" : "floatingCalcPeriodDates1"
+-                      },
+-                      "resetRelativeTo" : "CalculationPeriodStartDate",
+-                      "fixingDates" : {
+-                        "periodMultiplier" : -2,
+-                        "period" : "D",
+-                        "dayType" : "Business",
+-                        "businessDayConvention" : "NONE",
+-                        "businessCenters" : {
+-                          "businessCenter" : [ {
+-                            "value" : "GBLO"
+-                          }, {
+-                            "value" : "USNY"
+-                          } ]
+-                        },
+-                        "dateRelativeTo" : {
+-                          "externalReference" : "resetDates1"
+-                        }
+-                      },
+-                      "resetFrequency" : {
+-                        "periodMultiplier" : 3,
+-                        "period" : "M"
+-                      },
+-                      "resetDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      },
+-                      "meta" : {
+-                        "externalKey" : "resetDates1"
+-                      }
++                    "calculationPeriodFrequency" : {
++                      "periodMultiplier" : 3,
++                      "period" : "M",
++                      "rollConvention" : "17"
++                    },
++                    "meta" : {
++                      "externalKey" : "floatingCalcPeriodDates1"
+@@ -161,6 +82,5 @@
+-                  }
+-                }, {
+-                  "InterestRatePayout" : {
+-                    "payerReceiver" : {
+-                      "payer" : "Party2",
+-                      "receiver" : "Party1"
++                  },
++                  "paymentDates" : {
++                    "paymentFrequency" : {
++                      "periodMultiplier" : 3,
++                      "period" : "M"
+@@ -168,5 +88,6 @@
+-                    "priceQuantity" : {
+-                      "quantitySchedule" : {
+-                        "address" : {
+-                          "scope" : "DOCUMENT",
+-                          "value" : "quantity-2"
++                    "payRelativeTo" : "CalculationPeriodEndDate",
++                    "paymentDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -175,0 +96,5 @@
++                    }
++                  },
++                  "resetDates" : {
++                    "calculationPeriodDatesReference" : {
++                      "externalReference" : "floatingCalcPeriodDates1"
+@@ -176,10 +102,15 @@
+-                    "rateSpecification" : {
+-                      "FixedRateSpecification" : {
+-                        "rateSchedule" : {
+-                          "price" : {
+-                            "address" : {
+-                              "scope" : "DOCUMENT",
+-                              "value" : "price-1"
+-                            }
+-                          }
+-                        }
++                    "resetRelativeTo" : "CalculationPeriodStartDate",
++                    "fixingDates" : {
++                      "periodMultiplier" : -2,
++                      "period" : "D",
++                      "dayType" : "Business",
++                      "businessDayConvention" : "NONE",
++                      "businessCenters" : {
++                        "businessCenter" : [ {
++                          "value" : "GBLO"
++                        }, {
++                          "value" : "USNY"
++                        } ]
++                      },
++                      "dateRelativeTo" : {
++                        "externalReference" : "resetDates1"
+@@ -188,2 +119,3 @@
+-                    "dayCountFraction" : {
+-                      "value" : "30E/360"
++                    "resetFrequency" : {
++                      "periodMultiplier" : 3,
++                      "period" : "M"
+@@ -191,7 +123,5 @@
+-                    "calculationPeriodDates" : {
+-                      "effectiveDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2014-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "NONE"
+-                          }
++                    "resetDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -199,29 +129,0 @@
+-                      },
+-                      "terminationDate" : {
+-                        "adjustableDate" : {
+-                          "unadjustedDate" : "2019-01-17",
+-                          "dateAdjustments" : {
+-                            "businessDayConvention" : "MODFOLLOWING",
+-                            "businessCenters" : {
+-                              "businessCentersReference" : {
+-                                "externalReference" : "primaryBusinessCenters1"
+-                              }
+-                            }
+-                          }
+-                        }
+-                      },
+-                      "calculationPeriodDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      },
+-                      "calculationPeriodFrequency" : {
+-                        "periodMultiplier" : 6,
+-                        "period" : "M",
+-                        "rollConvention" : "17"
+-                      },
+-                      "meta" : {
+-                        "externalKey" : "fixedCalcPeriodDates1"
+@@ -230,14 +131,2 @@
+-                    "paymentDates" : {
+-                      "paymentFrequency" : {
+-                        "periodMultiplier" : 6,
+-                        "period" : "M"
+-                      },
+-                      "payRelativeTo" : "CalculationPeriodEndDate",
+-                      "paymentDatesAdjustments" : {
+-                        "businessDayConvention" : "MODFOLLOWING",
+-                        "businessCenters" : {
+-                          "businessCentersReference" : {
+-                            "externalReference" : "primaryBusinessCenters1"
+-                          }
+-                        }
+-                      }
++                    "meta" : {
++                      "externalKey" : "resetDates1"
+@@ -246,15 +135,12 @@
+-                } ],
+-                "nonStandardisedTerms" : false
+-              }
+-            },
+-            "tradeLot" : [ {
+-              "priceQuantity" : [ {
+-                "quantity" : [ {
+-                  "value" : {
+-                    "value" : 25000000.00,
+-                    "unit" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
+-                        }
++                }
++              }, {
++                "InterestRatePayout" : {
++                  "payerReceiver" : {
++                    "payer" : "Party2",
++                    "receiver" : "Party1"
++                  },
++                  "priceQuantity" : {
++                    "quantitySchedule" : {
++                      "address" : {
++                        "scope" : "DOCUMENT",
++                        "value" : "quantity-2"
+@@ -264,30 +150,5 @@
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "quantity-1"
+-                    } ]
+-                  }
+-                } ],
+-                "observable" : {
+-                  "value" : {
+-                    "Index" : {
+-                      "InterestRateIndex" : {
+-                        "value" : {
+-                          "FloatingRateIndex" : {
+-                            "identifier" : [ {
+-                              "identifier" : {
+-                                "value" : "USD-LIBOR-ISDA"
+-                              },
+-                              "identifierType" : "Other"
+-                            } ],
+-                            "floatingRateIndex" : {
+-                              "value" : "USD-LIBOR-ISDA"
+-                            },
+-                            "indexTenor" : {
+-                              "periodMultiplier" : 3,
+-                              "period" : "M"
+-                            }
+-                          }
+-                        },
+-                        "meta" : {
+-                          "location" : [ {
++                  "rateSpecification" : {
++                    "FixedRateSpecification" : {
++                      "rateSchedule" : {
++                        "price" : {
++                          "address" : {
+@@ -295,2 +156,2 @@
+-                            "value" : "InterestRateIndex-1"
+-                          } ]
++                            "value" : "price-1"
++                          }
+@@ -301,16 +162,9 @@
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "observable-1"
+-                    } ]
+-                  }
+-                }
+-              }, {
+-                "price" : [ {
+-                  "value" : {
+-                    "value" : 0.02232,
+-                    "unit" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                  "dayCountFraction" : {
++                    "value" : "30E/360"
++                  },
++                  "calculationPeriodDates" : {
++                    "effectiveDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2014-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "NONE"
+@@ -320,5 +174,10 @@
+-                    "perUnitOf" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    "terminationDate" : {
++                      "adjustableDate" : {
++                        "unadjustedDate" : "2019-01-17",
++                        "dateAdjustments" : {
++                          "businessDayConvention" : "MODFOLLOWING",
++                          "businessCenters" : {
++                            "businessCentersReference" : {
++                              "externalReference" : "primaryBusinessCenters1"
++                            }
++                          }
+@@ -328,17 +187,5 @@
+-                    "priceType" : "InterestRate"
+-                  },
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "price-1"
+-                    } ]
+-                  }
+-                } ],
+-                "quantity" : [ {
+-                  "value" : {
+-                    "value" : 25000000.00,
+-                    "unit" : {
+-                      "currency" : {
+-                        "value" : "USD",
+-                        "meta" : {
+-                          "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    "calculationPeriodDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
+@@ -347,0 +194,8 @@
++                    },
++                    "calculationPeriodFrequency" : {
++                      "periodMultiplier" : 6,
++                      "period" : "M",
++                      "rollConvention" : "17"
++                    },
++                    "meta" : {
++                      "externalKey" : "fixedCalcPeriodDates1"
+@@ -349,5 +204,14 @@
+-                  "meta" : {
+-                    "location" : [ {
+-                      "scope" : "DOCUMENT",
+-                      "value" : "quantity-2"
+-                    } ]
++                  "paymentDates" : {
++                    "paymentFrequency" : {
++                      "periodMultiplier" : 6,
++                      "period" : "M"
++                    },
++                    "payRelativeTo" : "CalculationPeriodEndDate",
++                    "paymentDatesAdjustments" : {
++                      "businessDayConvention" : "MODFOLLOWING",
++                      "businessCenters" : {
++                        "businessCentersReference" : {
++                          "externalReference" : "primaryBusinessCenters1"
++                        }
++                      }
++                    }
+@@ -355,0 +219,22 @@
++                }
++              } ],
++              "nonStandardisedTerms" : false
++            }
++          },
++          "priceQuantity" : [ {
++            "quantity" : [ {
++              "value" : {
++                "value" : 25000000.00,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
++                  }
++                }
++              },
++              "meta" : {
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "quantity-1"
+@@ -356,6 +242,0 @@
+-              } ]
+-            } ],
+-            "counterparty" : [ {
+-              "role" : "Party1",
+-              "partyReference" : {
+-                "externalReference" : "dco"
+@@ -363,5 +243,0 @@
+-            }, {
+-              "role" : "Party2",
+-              "partyReference" : {
+-                "externalReference" : "fcm1"
+-              }
+@@ -369,9 +244,28 @@
+-            "tradeIdentifier" : [ {
+-              "issuerReference" : {
+-                "externalReference" : "sef"
+-              },
+-              "assignedIdentifier" : [ {
+-                "identifier" : {
+-                  "value" : "1",
+-                  "meta" : {
+-                    "scheme" : "http://www.sefco.com/swaps/trade-id"
++            "observable" : {
++              "value" : {
++                "Index" : {
++                  "InterestRateIndex" : {
++                    "value" : {
++                      "FloatingRateIndex" : {
++                        "identifier" : [ {
++                          "identifier" : {
++                            "value" : "USD-LIBOR-ISDA"
++                          },
++                          "identifierType" : "Other"
++                        } ],
++                        "assetClass" : "InterestRate",
++                        "floatingRateIndex" : {
++                          "value" : "USD-LIBOR-ISDA"
++                        },
++                        "indexTenor" : {
++                          "periodMultiplier" : 3,
++                          "period" : "M"
++                        }
++                      }
++                    },
++                    "meta" : {
++                      "location" : [ {
++                        "scope" : "DOCUMENT",
++                        "value" : "InterestRateIndex-1"
++                      } ]
++                    }
+@@ -380,17 +274,0 @@
+-              } ]
+-            } ],
+-            "tradeDate" : {
+-              "value" : "2014-01-15"
+-            },
+-            "party" : [ {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "549300RE0FSXJE8G1L65",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
+-                  }
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "SEF Corp"
+@@ -399,1 +276,4 @@
+-                "externalKey" : "sef"
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "observable-1"
++                } ]
+@@ -401,6 +281,11 @@
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "CCP123",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso9362"
++            }
++          }, {
++            "price" : [ {
++              "value" : {
++                "value" : 0.02232,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
+@@ -409,14 +294,6 @@
+-                "identifierType" : "BIC"
+-              } ],
+-              "name" : {
+-                "value" : "Clearco."
+-              },
+-              "meta" : {
+-                "externalKey" : "dco"
+-              }
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "HWUPKR0MPOU8FGXBT394",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                "perUnitOf" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
+@@ -425,4 +302,1 @@
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "Megaclient"
++                "priceType" : "InterestRate"
+@@ -431,1 +305,4 @@
+-                "externalKey" : "party1"
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "price-1"
++                } ]
+@@ -433,6 +310,10 @@
+-            }, {
+-              "partyId" : [ {
+-                "identifier" : {
+-                  "value" : "969500A1DO2476C1ZL52",
+-                  "meta" : {
+-                    "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++            } ],
++            "quantity" : [ {
++              "value" : {
++                "value" : 25000000.00,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
+@@ -440,5 +321,1 @@
+-                },
+-                "identifierType" : "LEI"
+-              } ],
+-              "name" : {
+-                "value" : "FCM A"
++                }
+@@ -447,1 +324,4 @@
+-                "externalKey" : "fcm1"
++                "location" : [ {
++                  "scope" : "DOCUMENT",
++                  "value" : "quantity-2"
++                } ]
+@@ -449,0 +329,22 @@
++            } ]
++          } ],
++          "counterparty" : [ {
++            "role" : "Party1",
++            "partyReference" : {
++              "externalReference" : "dco"
++            }
++          }, {
++            "role" : "Party2",
++            "partyReference" : {
++              "externalReference" : "fcm1"
++            }
++          } ],
++          "parties" : [ {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "549300RE0FSXJE8G1L65",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
++              },
++              "identifierType" : "LEI"
+@@ -450,3 +352,13 @@
+-            "partyRole" : [ {
+-              "partyReference" : {
+-                "externalReference" : "dco"
++            "name" : {
++              "value" : "SEF Corp"
++            },
++            "meta" : {
++              "externalKey" : "sef"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "CCP123",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso9362"
++                }
+@@ -454,4 +366,1 @@
+-              "role" : "ClearingOrganization",
+-              "ownershipPartyReference" : {
+-                "externalReference" : "fcm1"
+-              }
++              "identifierType" : "BIC"
+@@ -459,14 +368,53 @@
+-            "executionDetails" : {
+-              "packageReference" : {
+-                "listId" : {
+-                  "issuer" : {
+-                    "value" : "SEF123"
+-                  },
+-                  "assignedIdentifier" : [ {
+-                    "identifier" : {
+-                      "value" : "123",
+-                      "meta" : {
+-                        "scheme" : "http://sefco.com/package_id"
+-                      }
+-                    }
+-                  } ]
++            "name" : {
++              "value" : "Clearco."
++            },
++            "meta" : {
++              "externalKey" : "dco"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "HWUPKR0MPOU8FGXBT394",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
++              },
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "Megaclient"
++            },
++            "meta" : {
++              "externalKey" : "party1"
++            }
++          }, {
++            "partyId" : [ {
++              "identifier" : {
++                "value" : "969500A1DO2476C1ZL52",
++                "meta" : {
++                  "scheme" : "http://www.fpml.org/coding-scheme/external/iso17442"
++                }
++              },
++              "identifierType" : "LEI"
++            } ],
++            "name" : {
++              "value" : "FCM A"
++            },
++            "meta" : {
++              "externalKey" : "fcm1"
++            }
++          } ],
++          "partyRoles" : [ {
++            "partyReference" : {
++              "externalReference" : "dco"
++            },
++            "role" : "ClearingOrganization",
++            "ownershipPartyReference" : {
++              "externalReference" : "fcm1"
++            }
++          } ],
++          "executionDetails" : {
++            "packageReference" : {
++              "listId" : {
++                "issuer" : {
++                  "value" : "SEF123"
+@@ -474,8 +422,5 @@
+-                "price" : {
+-                  "value" : 0.05,
+-                  "unit" : {
+-                    "currency" : {
+-                      "value" : "USD",
+-                      "meta" : {
+-                        "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
+-                      }
++                "assignedIdentifier" : [ {
++                  "identifier" : {
++                    "value" : "123",
++                    "meta" : {
++                      "scheme" : "http://sefco.com/package_id"
+@@ -483,7 +428,10 @@
+-                  },
+-                  "perUnitOf" : {
+-                    "currency" : {
+-                      "value" : "USD",
+-                      "meta" : {
+-                        "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
+-                      }
++                  }
++                } ]
++              },
++              "price" : {
++                "value" : 0.05,
++                "unit" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
+@@ -491,4 +439,12 @@
+-                  },
+-                  "priceType" : "InterestRate",
+-                  "arithmeticOperator" : "Add"
+-                }
++                  }
++                },
++                "perUnitOf" : {
++                  "currency" : {
++                    "value" : "USD",
++                    "meta" : {
++                      "scheme" : "http://www.fpml.org/coding-scheme/external/iso4217"
++                    }
++                  }
++                },
++                "priceType" : "InterestRate",
++                "arithmeticOperator" : "Add"
+@@ -496,0 +452,8 @@
++            }
++          },
++          "tradeDate" : {
++            "value" : "2014-01-15"
++          },
++          "tradeIdentifier" : [ {
++            "issuerReference" : {
++              "externalReference" : "sef"
+@@ -497,15 +461,6 @@
+-            "account" : [ {
+-              "partyReference" : {
+-                "externalReference" : "fcm1"
+-              },
+-              "accountNumber" : {
+-                "value" : "1111"
+-              },
+-              "accountBeneficiary" : {
+-                "externalReference" : "party1"
+-              },
+-              "servicingParty" : {
+-                "externalReference" : "fcm1"
+-              },
+-              "meta" : {
+-                "externalKey" : "party1acct"
++            "assignedIdentifier" : [ {
++              "identifier" : {
++                "value" : "1",
++                "meta" : {
++                  "scheme" : "http://www.sefco.com/swaps/trade-id"
++                }
+@@ -514,1 +469,1 @@
+-          }
++          } ]


### PR DESCRIPTION
PR https://github.com/finos/common-domain-model/pull/4928 was missing Ingest diagnostics that compares the synonym expectations with the function ingest expectations.  

The ingest summary diagnostics (e.g. [ingest/diagnostics/product_diagnostics.md](https://github.com/finos/common-domain-model/blob/6.x.x/tests/src/test/resources/ingest/diagnostics/product_diagnostics.md) etc) were included in the PR, but the file-by-file diffs (in [ingest/expected-output](https://github.com/finos/common-domain-model/tree/6.x.x/tests/src/test/resources/ingest/expected-output)) were omitted.  This PR generates the file-by-file diagnostics.  It does not change the model or mapping functions or test expectations, it only generates diagnostic information.

See [here](https://github.com/finos/common-domain-model/issues/4260) for more information about Ingest diagnostics.
See [here](https://github.com/finos/common-domain-model/issues/3364?issue=finos%7Ccommon-domain-model%7C4031) about synonym vs function ingestion on the 6.x.x CDM version .

This PR link should be included in the release note of https://github.com/finos/common-domain-model/pull/4928