### PR TITLE
Reset Step 4 Adjust the Reset Date

### DIFF
--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-func.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-func.rosetta
@@ -96,6 +96,28 @@ func Create_AdjustPeriodInstruction: <"This function generates the Instruction C
         }}
 
 // COMPOSITION STATE CHANGES FOR RESET
+// Instruction Composition STEP 4 - Adjust the Reset Date
+func Create_AdjustDateInstruction: <"This function generates the Instruction Composition step instruction necessary to adjust the unadjusted reset date, and adding it to the AdjustResetDateInstruction. Supported business day conventions in this version are: {Following, Preceding, ModFollowing}. Other conventions (e.g., ModPreceding, Nearest) are currently out-of-scope.">
+    inputs:
+        unadjustedDate date (1..1) <"The Unadjusted Date.">
+        nonBusinessDates date (0..*) <"The list of non business dates applicable to the Reset Date, obtained from the GetNonBusinessDates function.">
+        businessConvention BusinessDayConventionEnum (1..1) <"The business day convention to apply to adjust the Unadjusted Reset Date (e.g., FOLLOWING, PRECEDING).">
+    output:
+        adjustDateInstruction AdjustDateInstruction (1..1) <"The Adjusted Reset Date.">
+
+    alias adjustedResetDate: <"The adjusted reset date.">
+        AdjustDateToBusinessDayConvention(
+                unadjustedDate,
+                nonBusinessDates,
+                businessConvention
+            )
+
+    set adjustDateInstruction:
+        AdjustDateInstruction {
+            adjustedDate: adjustedResetDate
+        }
+
+// COMPOSITION STATE CHANGES FOR RESET
 func UpdateResetCompositionState: <"Handles the field-by-field overlay for the Reset process state.">
     inputs:
         currentResetCompositionState ResetInstructionState (0..1)
@@ -128,6 +150,12 @@ func UpdateResetCompositionState: <"Handles the field-by-field overlay for the R
         if nextStepToAdd -> adjustPeriod exists
         then nextStepToAdd -> adjustPeriod -> adjustedPeriod
         else currentResetCompositionState -> adjustedCalculationPeriod
+
+    // Step 4: Adjusted Date
+    set updatedResetCompositionState -> adjustedResetDate:
+        if nextStepToAdd -> adjustDate exists
+        then nextStepToAdd -> adjustDate -> adjustedDate
+        else currentResetCompositionState -> adjustedResetDate
 
 // NEXT STEP FOR RESET
 func ResetInstructionNextStep: <"A state-machine evaluator for the Reset process that identifies the next required instruction by checking for the presence of mandatory data fields across the seven-step lifecycle.">

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-type.rosetta
@@ -15,6 +15,9 @@ type DetermineUnadjustedCalculationPeriodInstruction: <"Instruction that contain
 type AdjustPeriodInstruction: <"Instruction that holds the adjusted period.">
     adjustedPeriod CalculationPeriodBase (1..1)
 
+type AdjustDateInstruction: <"Instruction that holds the adjusted date.">
+    adjustedDate date (1..1)
+
 type ResetInstructionState: <"The definitive state object for the Reset process. It acts as a cumulative 'Golden Record,' storing every data point captured from Step 1 (Index Collection) through Step 7 (Final Calculation) to ensure deterministic processing.">
 
     // Step 1 - CollectFloatingRateOptionInstruction
@@ -25,6 +28,8 @@ type ResetInstructionState: <"The definitive state object for the Reset process.
     unadjustedResetDate date (0..1) <"The theoretical reset date before applying business day conventions.">
     // Step 3 - AdjustPeriodInstruction
     adjustedCalculationPeriod CalculationPeriodBase (0..1) <"The calculation period after adjusting for non-business days and relevant financial calendars.">
+    // Step 4 - AdjustDateInstruction
+    adjustedResetDate date (0..1) <"The final, legally binding reset date after applying business day conventions.">
 
 type ResetInstructionSteps: <"A wrapper that encapsulates the specific ResetInstructionCompositionStepsEnum, allowing the engine to identify the exact phase of the Reset lifecycle currently being processed.">
     resetInstructionCompositionSteps ResetInstructionCompositionStepsEnum (1..1)

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-type.rosetta
@@ -43,6 +43,7 @@ type CompositionStepInstructions: <"Container for all instruction steps that can
     collectFloatingRateOption CollectFloatingRateOptionInstruction (0..1) <"Data needed to execute the extraction of the Floating Rate Option index name.">
     determineUnadjustedCalculationPeriod DetermineUnadjustedCalculationPeriodInstruction (0..1) <"Data needed to determine the Unadjusted Calculation Period.">
     adjustPeriod AdjustPeriodInstruction (0..1) <"Data needed to adjust the Calculation Period.">
+    adjustDate AdjustDateInstruction (0..1) <"Data needed to adjust the Reset Date.">
 
     condition NonEmptyInstruction:
         one-of

--- a/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/Create_AdjustDateInstructionTest.java
+++ b/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/Create_AdjustDateInstructionTest.java
@@ -1,0 +1,80 @@
+package cdm.event.instructioncomposition.reset.functions;
+
+import cdm.base.datetime.BusinessDayConventionEnum;
+import cdm.event.instructioncomposition.reset.AdjustDateInstruction;
+import com.rosetta.model.lib.records.Date;
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.Collections;
+
+import static cdm.base.datetime.BusinessDayConventionEnum.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class Create_AdjustDateInstructionTest extends AbstractFunctionTest {
+
+    @Inject
+    private Create_AdjustDateInstruction createAdjustDateInstruction;
+
+    @Test
+    @DisplayName("Returns the unadjusted date unchanged when it is not a non-business date")
+    void shouldReturnUnadjustedDateWhenNotANonBusinessDate() {
+        AdjustDateInstruction result = createAdjustDateInstruction.evaluate(
+                Date.of(2024, 3, 20), Collections.emptyList(), FOLLOWING);
+
+        assertEquals(Date.of(2024, 3, 20), result.getAdjustedDate(),
+                "adjustedDate must equal the unadjusted date when it is not a non-business date");
+    }
+
+    @Test
+    @DisplayName("NONE: returns the unadjusted date unchanged even when it is a non-business date")
+    void shouldReturnUnadjustedDateUnchangedUnderNoneConvention() {
+        AdjustDateInstruction result = createAdjustDateInstruction.evaluate(
+                Date.of(2024, 3, 20), Collections.singletonList(Date.of(2024, 3, 20)), NONE);
+
+        assertEquals(Date.of(2024, 3, 20), result.getAdjustedDate(),
+                "adjustedDate must equal the unadjusted date under NONE convention regardless of non-business dates");
+    }
+
+    @Test
+    @DisplayName("FOLLOWING: moves forward to the next business day when the unadjusted date is a non-business date")
+    void shouldMoveForwardToNextBusinessDayUnderFollowingConvention() {
+        AdjustDateInstruction result = createAdjustDateInstruction.evaluate(
+                Date.of(2024, 3, 20), Collections.singletonList(Date.of(2024, 3, 20)), FOLLOWING);
+
+        assertEquals(Date.of(2024, 3, 21), result.getAdjustedDate(),
+                "adjustedDate must be the next business day under FOLLOWING convention");
+    }
+
+    @Test
+    @DisplayName("PRECEDING: moves backward to the previous business day when the unadjusted date is a non-business date")
+    void shouldMoveBackwardToPreviousBusinessDayUnderPrecedingConvention() {
+        AdjustDateInstruction result = createAdjustDateInstruction.evaluate(
+                Date.of(2024, 3, 20), Collections.singletonList(Date.of(2024, 3, 20)), PRECEDING);
+
+        assertEquals(Date.of(2024, 3, 19), result.getAdjustedDate(),
+                "adjustedDate must be the previous business day under PRECEDING convention");
+    }
+
+    @Test
+    @DisplayName("MODFOLLOWING: moves forward when the next business day is in the same month")
+    void shouldMoveForwardUnderModFollowingWhenNextBusinessDayIsInSameMonth() {
+        AdjustDateInstruction result = createAdjustDateInstruction.evaluate(
+                Date.of(2024, 3, 20), Collections.singletonList(Date.of(2024, 3, 20)), MODFOLLOWING);
+
+        assertEquals(Date.of(2024, 3, 21), result.getAdjustedDate(),
+                "adjustedDate must move forward when the next business day is in the same month");
+    }
+
+    @Test
+    @DisplayName("MODFOLLOWING: falls back to preceding when the next business day crosses a month boundary")
+    void shouldFallBackToPrecedingUnderModFollowingWhenNextBusinessDayCrossesMonthBoundary() {
+        AdjustDateInstruction result = createAdjustDateInstruction.evaluate(
+                Date.of(2024, 3, 31), Collections.singletonList(Date.of(2024, 3, 31)), MODFOLLOWING);
+
+        assertEquals(Date.of(2024, 3, 30), result.getAdjustedDate(),
+                "adjustedDate must fall back to preceding when following crosses a month boundary");
+    }
+}

--- a/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/UpdateResetCompositionStateTest.java
+++ b/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/UpdateResetCompositionStateTest.java
@@ -3,6 +3,7 @@ package cdm.event.instructioncomposition.reset.functions;
 import cdm.base.staticdata.asset.rates.FloatingRateIndexEnum;
 import cdm.event.instructioncomposition.CompositionStepInstructions;
 import cdm.event.instructioncomposition.reset.AdjustPeriodInstruction;
+import cdm.event.instructioncomposition.reset.AdjustDateInstruction;
 import cdm.event.instructioncomposition.reset.CollectFloatingRateOptionInstruction;
 import cdm.event.instructioncomposition.reset.DetermineUnadjustedCalculationPeriodInstruction;
 import cdm.event.instructioncomposition.reset.ResetInstructionState;
@@ -188,6 +189,51 @@ class UpdateResetCompositionStateTest extends AbstractFunctionTest {
 
             assertNull(result.getAdjustedCalculationPeriod(),
                     "adjustedCalculationPeriod must be null when both current state and step instruction are absent");
+        }
+    }
+
+    @Nested
+    @DisplayName("Step 4 - Adjusted Date")
+    class AdjustDateTest {
+
+        @Test
+        @DisplayName("Sets adjustedResetDate from the step instruction when adjustDate is present")
+        void shouldSetAdjustedResetDateFromStepWhenAdjustDateIsPresent() {
+            CompositionStepInstructions nextStep = CompositionStepInstructions.builder()
+                    .setAdjustDate(AdjustDateInstruction.builder()
+                            .setAdjustedDate(Date.of(2024, 3, 20))
+                            .build())
+                    .build();
+
+            ResetInstructionState result = updateResetCompositionState.evaluate(null, nextStep);
+
+            assertEquals(Date.of(2024, 3, 20), result.getAdjustedResetDate(),
+                    "adjustedResetDate must be taken from the step instruction");
+        }
+
+        @Test
+        @DisplayName("Carries forward adjustedResetDate from the current state when adjustDate is absent")
+        void shouldCarryForwardAdjustedResetDateFromCurrentStateWhenAdjustDateIsAbsent() {
+            ResetInstructionState currentState = ResetInstructionState.builder()
+                    .setAdjustedResetDate(Date.of(2024, 3, 20))
+                    .build();
+            CompositionStepInstructions nextStepWithoutAdjustDate = CompositionStepInstructions.builder().build();
+
+            ResetInstructionState result = updateResetCompositionState.evaluate(currentState, nextStepWithoutAdjustDate);
+
+            assertEquals(Date.of(2024, 3, 20), result.getAdjustedResetDate(),
+                    "adjustedResetDate must be carried forward from the current state");
+        }
+
+        @Test
+        @DisplayName("Produces null adjustedResetDate when adjustDate is absent and current state is absent")
+        void shouldProduceNullAdjustedResetDateWhenAdjustDateAndCurrentStateAreBothAbsent() {
+            CompositionStepInstructions nextStepWithoutAdjustDate = CompositionStepInstructions.builder().build();
+
+            ResetInstructionState result = updateResetCompositionState.evaluate(null, nextStepWithoutAdjustDate);
+
+            assertNull(result.getAdjustedResetDate(),
+                    "adjustedResetDate must be null when both current state and step instruction are absent");
         }
     }
 }


### PR DESCRIPTION
# _Instruction Composition Reset Step 4:  Adjust the Reset Date_


_Background_

This release delivers the complete set of components required to execute Step 4 (Adjust Reset Date) of the 8-step Interest Rate Reset processing workflow. This addition advances the framework's stateful timeline logic, ensuring the deterministic calculation of adjusted, legally binding reset dates based on transactional variables and regional business day rules. For further information, see issue #4388.

_What is being released?_

This release provides the state mutation structures and operational logic required to calculate, pass, and log adjusted date boundaries. It integrates Step 4 payload structural bindings into the reusable instruction wrapper definitions and introduces the overlay processing mechanics needed to track intermediate date metrics across the active execution lifecycle.

_Functions_

Changes in the cdm.base.datetime namespace:
- `AdjustDateToBusinessDayConvention`: Core mapping function that routes an unadjusted date through a selected business day convention matrix when a calendar clash is detected.
- `ApplyFollowing`: Recursive utility evaluating calendar forward-shifts to find the next valid business day.
- `ApplyPreceding`: Recursive utility evaluating calendar backward-shifts to find the previous valid business day.
- `ApplyModFollowing`: Evaluation function ensuring forward-shifted dates do not cross month boundaries, defaulting to preceding lookbacks where necessary.

Changes in the cdm.event.instructioncomposition.reset namespace:
- `Create_AdjustDateInstruction`: An operational mapping function that processes a single unadjusted date entry alongside custom non-business calendars to resolve and output a convention-aligned adjusted reset date.

Changes in the cdm.event.instructioncomposition namespace:
- `UpdateResetCompositionState`: (Updated) Modified to include "Step 4" state overlay logic. It checks for the presence of the adjustDate payload, incrementally updating the active state with the new adjustedResetDate or preserving existing attributes if absent.

_Types and Choices_

Changes in the cdm.event.instructioncomposition namespace:
- `CompositionStepInstructions` (Updated): Expanded to include adjustDate as an active data payload property, allowing the global step orchestrator to wrap single date adjustment data structures.

Changes in the cdm.event.instructioncomposition.reset namespace:
- `AdjustDateInstruction`: Introduced as the official type for Step 4.
- `ResetInstructionState` (Updated): Expanded to hold its fourth phase state variable (adjustedResetDate), allowing the cumulative workflow to track adjusted parameters over its lifecycle.

_Review Directions_

Navigate to the following paths to inspect the new models:
- rosetta-source/src/main/rosetta/instructionComposition-type.rosetta: Review the updated CompositionStepInstructions container to verify the inclusion of the Step 4 instruction payload mapping.
- rosetta-source/src/main/rosetta/instructionComposition-func.rosetta: Examine the updated field overlay logic inside UpdateResetCompositionState handling adjusted date state tracking.
- rosetta-source/src/main/rosetta/instructionComposition-reset-type.rosetta: Inspect the new AdjustDateInstruction type structure and the updated tracking properties embedded within ResetInstructionState.
- rosetta-source/src/main/rosetta/instructionComposition-reset-func.rosetta: Inspect the date computation and convention mapping calls wrapped inside Create_AdjustDateInstruction.