### PR TITLE
Reset Step 5: Determine unadjusted observation dates

### DIFF
--- a/rosetta-source/src/main/rosetta/base-datetime-func.rosetta
+++ b/rosetta-source/src/main/rosetta/base-datetime-func.rosetta
@@ -460,3 +460,31 @@ func AdjustDateToModfollowingBusinessDay: <"Applies the 'Following' convention, 
         if IsDifferentMonth
         then AdjustDateToPrecedingBusinessDay(unadjustedDate, nonBusinessDates)
         else followingDate
+
+func GenerateCalendarDateList: <"Recursively generates a list of all calendar dates between startDate and endDate (inclusive). Does not filter weekends or holidays.">
+    inputs:
+        startDate date (1..1) <"Start of the date range to be generated.">
+        endDate date (1..1) <"End of the date range to be generated">
+        isEndDateExclusive boolean (0..1) <"If True, the endDate is excluded from the list [startDate, endDate). Defaults to False.">
+    output:
+        dateList date (0..*) <"Resulting list of calendar dates between startDate and endDate (inclusive).">
+
+    alias effectiveEndDate: <"Adjusts the end date ONLY if the exclusive flag is explicitly True.">
+        if isEndDateExclusive exists and isEndDateExclusive = True
+        then AddDays(endDate, -1)
+        else endDate
+
+    alias active: <"Condition to determine if generation should continue (startDate must be before or equal to endDate).">
+        startDate <= effectiveEndDate
+
+    alias priorDate: <"Date immediately preceding the current endDate, used for recursion.">
+        AddDays(effectiveEndDate, -1)
+
+    alias priorList: <"Recursive call to generate all dates from startDate up to the priorDate. Pass False so we don't subtract a day on every single recursive step.">
+        GenerateCalendarDateList(startDate, priorDate, False)
+
+    alias newList: <"Append the current endDate to the recursively generated list.">
+        AppendDateToList(priorList, effectiveEndDate)
+
+    add dateList: <"Return the new list if still within range, stops recursion when startDate passes endDate.">
+        if active then newList

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-func.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-func.rosetta
@@ -2,8 +2,12 @@ namespace cdm.event.instructioncomposition.reset
 version "${project.version}"
 
 import cdm.base.datetime.*
+import cdm.base.staticdata.asset.rates.*
 import cdm.base.staticdata.codelist.*
 import cdm.event.instructioncomposition.*
+import cdm.observable.asset.*
+import cdm.observable.asset.calculatedrate.*
+import cdm.observable.asset.fro.*
 import cdm.product.asset.*
 import cdm.product.common.schedule.*
 
@@ -95,7 +99,6 @@ func Create_AdjustPeriodInstruction: <"This function generates the Instruction C
                     adjustedEndDate: adjustedCalculationPeriodEnd
         }}
 
-// COMPOSITION STATE CHANGES FOR RESET
 // Instruction Composition STEP 4 - Adjust the Reset Date
 func Create_AdjustDateInstruction: <"This function generates the Instruction Composition step instruction necessary to adjust the unadjusted reset date, and adding it to the AdjustResetDateInstruction. Supported business day conventions in this version are: {Following, Preceding, ModFollowing}. Other conventions (e.g., ModPreceding, Nearest) are currently out-of-scope.">
     inputs:
@@ -115,6 +118,58 @@ func Create_AdjustDateInstruction: <"This function generates the Instruction Com
     set adjustDateInstruction:
         AdjustDateInstruction {
             adjustedDate: adjustedResetDate
+        }
+
+// External call to fetch FRO metadata from the ISDA FRO Matrix
+func ExtractFloatingRateOptionData: <"This function, given a floating rate option, extracts the floating rate option's metadata from the ISDA FRO Matrix and returns that data in a CDM structured format. Additionally, it uses the reference date specified to select the relevant version of the FRO Matrix.">
+    [codeImplementation]
+    inputs:
+        tradeDate date (1..1) <"The Trade Date, used to reference the ISDA FRO Matrix version.">
+        floatingRateIndex FloatingRateIndexEnum (1..1) <"The Floating Rate Index for which to extract its metadata from the ISDA FRO Matrix.">
+    output:
+        floatingRateIndexData FloatingRateIndexDefinition (1..1) <"The Floating Rate Index data extracted from the ISDA FRO Matrix.">
+
+// Instruction Composition STEP 5 - Determine Unadjusted Observation Dates
+func Create_DetermineUnadjustedObservationDatesInstruction: <"This function generates the Instruction Composition step instruction necessary to generate the unadjusted observation dates, and adding them to the DetermineUnadjustedObservationDatesInstruction.">
+    inputs:
+        adjustedCalculationPeriod CalculationPeriodBase (1..1) <"The adjusted calculation period.">
+        adjustedResetDate date (1..1) <"The adjusted reset date.">
+        floatingRateIndexData FloatingRateIndexDefinition (1..1) <"The Floating Rate Index data extracted from the ISDA FRO Matrix.">
+        calculationMethodologyFromConfirmation CalculationMethodEnum (0..1) <"The calculation methodology applicable to the Floating Rate Index found in the Confirmation.">
+    output:
+        determineUnadjustedObservationDatesInstruction DetermineUnadjustedObservationDatesInstruction (1..1) <"The list of one or more Unadjusted Observation Dates.">
+
+    alias category: floatingRateIndexData -> calculationDefaults -> category
+
+    alias style: floatingRateIndexData -> calculationDefaults -> indexStyle
+
+    alias calculationMethodologyFromFloatingRateOption:
+        floatingRateIndexData -> calculationDefaults -> method
+
+    alias observationType:
+        DetermineObservationType(
+                category,
+                style,
+                calculationMethodologyFromFloatingRateOption,
+                calculationMethodologyFromConfirmation
+            )
+
+    condition MethodFromConfirmationExistsWhenOvernightRate: <"If the Floating Rate Index has a Style of Overnight, then the calculation methodology originating from the Workflow Step must be present.">
+        if style = Overnight
+        then calculationMethodologyFromConfirmation exists
+    set determineUnadjustedObservationDatesInstruction:
+        DetermineUnadjustedObservationDatesInstruction {
+            unadjustedObservationDates: if observationType = Single
+                    then adjustedResetDate
+                else if observationType = Multiple
+                then GenerateCalendarDateList(
+                            adjustedCalculationPeriod -> adjustedStartDate,
+                            adjustedCalculationPeriod -> adjustedEndDate,
+                            False
+                        )
+                else if observationType = CompoundedIndex
+                then [adjustedCalculationPeriod -> adjustedStartDate, adjustedCalculationPeriod -> adjustedEndDate],
+            floatingRateIndexData: floatingRateIndexData
         }
 
 // COMPOSITION STATE CHANGES FOR RESET
@@ -156,6 +211,12 @@ func UpdateResetCompositionState: <"Handles the field-by-field overlay for the R
         if nextStepToAdd -> adjustDate exists
         then nextStepToAdd -> adjustDate -> adjustedDate
         else currentResetCompositionState -> adjustedResetDate
+
+    // Step 5: Unadjusted Observation Dates & Index Definition
+    set updatedResetCompositionState -> unadjustedObservationDates:
+        if nextStepToAdd -> determineUnadjustedObservationDates exists
+        then nextStepToAdd -> determineUnadjustedObservationDates -> unadjustedObservationDates
+        else currentResetCompositionState -> unadjustedObservationDates
 
 // NEXT STEP FOR RESET
 func ResetInstructionNextStep: <"A state-machine evaluator for the Reset process that identifies the next required instruction by checking for the presence of mandatory data fields across the seven-step lifecycle.">

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-reset-type.rosetta
@@ -2,6 +2,8 @@ namespace cdm.event.instructioncomposition.reset
 version "${project.version}"
 
 import cdm.base.staticdata.asset.rates.*
+import cdm.observable.asset.*
+import cdm.observable.asset.fro.*
 import cdm.product.common.schedule.*
 
 type CollectFloatingRateOptionInstruction: <"Instruction that identifies the floating rate index and the trade date required for downstream Floating Rate Option Data retrieval.">
@@ -18,6 +20,10 @@ type AdjustPeriodInstruction: <"Instruction that holds the adjusted period.">
 type AdjustDateInstruction: <"Instruction that holds the adjusted date.">
     adjustedDate date (1..1)
 
+type DetermineUnadjustedObservationDatesInstruction: <"Instruction that holds the unadjusted observation dates.">
+    unadjustedObservationDates date (1..*)
+    floatingRateIndexData FloatingRateIndexDefinition (1..1)
+
 type ResetInstructionState: <"The definitive state object for the Reset process. It acts as a cumulative 'Golden Record,' storing every data point captured from Step 1 (Index Collection) through Step 7 (Final Calculation) to ensure deterministic processing.">
 
     // Step 1 - CollectFloatingRateOptionInstruction
@@ -30,6 +36,9 @@ type ResetInstructionState: <"The definitive state object for the Reset process.
     adjustedCalculationPeriod CalculationPeriodBase (0..1) <"The calculation period after adjusting for non-business days and relevant financial calendars.">
     // Step 4 - AdjustDateInstruction
     adjustedResetDate date (0..1) <"The final, legally binding reset date after applying business day conventions.">
+    // Step 5 - DetermineUnadjustedObservationDatesInstruction
+    unadjustedObservationDates date (0..*) <"The raw dates on which the market rate should be observed according to the index definition.">
+    floatingRateOptionData FloatingRateIndexDefinition (0..1) <"The specific day count fraction, fixings, and lookback parameters associated with the chosen index.">
 
 type ResetInstructionSteps: <"A wrapper that encapsulates the specific ResetInstructionCompositionStepsEnum, allowing the engine to identify the exact phase of the Reset lifecycle currently being processed.">
     resetInstructionCompositionSteps ResetInstructionCompositionStepsEnum (1..1)

--- a/rosetta-source/src/main/rosetta/event-instructioncomposition-type.rosetta
+++ b/rosetta-source/src/main/rosetta/event-instructioncomposition-type.rosetta
@@ -44,6 +44,7 @@ type CompositionStepInstructions: <"Container for all instruction steps that can
     determineUnadjustedCalculationPeriod DetermineUnadjustedCalculationPeriodInstruction (0..1) <"Data needed to determine the Unadjusted Calculation Period.">
     adjustPeriod AdjustPeriodInstruction (0..1) <"Data needed to adjust the Calculation Period.">
     adjustDate AdjustDateInstruction (0..1) <"Data needed to adjust the Reset Date.">
+    determineUnadjustedObservationDates DetermineUnadjustedObservationDatesInstruction (0..1) <"Data needed to determine the Unadjusted Observation Dates.">
 
     condition NonEmptyInstruction:
         one-of

--- a/rosetta-source/src/main/rosetta/observable-asset-fro-enum.rosetta
+++ b/rosetta-source/src/main/rosetta/observable-asset-fro-enum.rosetta
@@ -23,3 +23,8 @@ enum FloatingRateIndexCalculationMethodEnum: <"3rd level ISDA FRO category.">
     Average  displayName "Overnight Averaging" <"A calculation methodology using the arithmetic mean.">
     Compounded displayName "Compounded Index"
     AllInCompounded displayName "All-In Compounded Index"
+
+enum FloatingRateIndexPeriodObservationTypeEnum: <"Defines the observation pattern for a floating rate index period.">
+    Single <"Single observation date pattern (e.g., term rate / screen rate).">
+    Multiple <"Multiple observation dates pattern requiring a date range generation.">
+    CompoundedIndex <"Compounded Index pattern requiring start and end dates.">

--- a/rosetta-source/src/main/rosetta/observable-asset-fro-func.rosetta
+++ b/rosetta-source/src/main/rosetta/observable-asset-fro-func.rosetta
@@ -4,6 +4,7 @@ version "${project.version}"
 import cdm.base.staticdata.asset.rates.*
 import cdm.event.common.*
 import cdm.legaldocumentation.common.*
+import cdm.observable.asset.calculatedrate.*
 import cdm.observable.asset.fro.*
 
 // =====================================================================
@@ -49,3 +50,54 @@ func FilterInvalidFloatingRateIndexTradeDate: <"Returns the invalid floating rat
             then filter
                 history -> startDate > tradeState -> trade -> tradeDate or history -> endDate < tradeState -> trade -> tradeDate
             then extract item -> fro -> floatingRateIndex
+
+func DetermineObservationType: <"Evaluates the Floating Rate Index properties and methodologies to determine the Observation Type.">
+    inputs:
+        category FloatingRateIndexCategoryEnum (1..1) <"The ISDA category of the floating rate index.">
+        style FloatingRateIndexStyleEnum (0..1) <"The ISDA style of the index.">
+        calculationMethodologyFromFloatingRateOption FloatingRateIndexCalculationMethodEnum (0..1) <"Method from FRO matrix.">
+        calculationMethodologyFromConfirmation CalculationMethodEnum (0..1) <"Method from Confirmation.">
+    output:
+        observationType FloatingRateIndexPeriodObservationTypeEnum (1..1) <"The resulting observation type classification.">
+
+    alias isSingle:
+        category = FloatingRateIndexCategoryEnum -> ScreenRate
+            and style <> FloatingRateIndexStyleEnum -> Overnight
+            and calculationMethodologyFromFloatingRateOption is absent
+            and calculationMethodologyFromConfirmation is absent
+
+    alias isCompoundedIndex:
+        category = FloatingRateIndexCategoryEnum -> Calculated
+            and style = FloatingRateIndexStyleEnum -> CompoundedIndex
+            and (if calculationMethodologyFromConfirmation exists
+                then calculationMethodologyFromConfirmation = CalculationMethodEnum -> CompoundedIndex
+                else if calculationMethodologyFromFloatingRateOption exists
+                then calculationMethodologyFromFloatingRateOption = FloatingRateIndexCalculationMethodEnum -> Compounded)
+
+    alias isMultiple:
+        ( // Calculated Rate Scenarios
+            category = FloatingRateIndexCategoryEnum -> Calculated
+                and (style = FloatingRateIndexStyleEnum -> AverageFRO or style = FloatingRateIndexStyleEnum -> CompoundedFRO)
+                and (if calculationMethodologyFromConfirmation exists
+                    then calculationMethodologyFromConfirmation = CalculationMethodEnum -> Compounding
+                            or calculationMethodologyFromConfirmation = CalculationMethodEnum -> Averaging
+                    else if calculationMethodologyFromFloatingRateOption exists
+                    then calculationMethodologyFromFloatingRateOption = FloatingRateIndexCalculationMethodEnum -> OISCompound
+                            or calculationMethodologyFromFloatingRateOption = FloatingRateIndexCalculationMethodEnum -> Average))
+            or ( // Screen Rate + Overnight Rate Scenario
+            category = FloatingRateIndexCategoryEnum -> ScreenRate
+                and style = FloatingRateIndexStyleEnum -> Overnight
+                and (if calculationMethodologyFromConfirmation exists
+                    then calculationMethodologyFromConfirmation = CalculationMethodEnum -> Compounding
+                            or calculationMethodologyFromConfirmation = CalculationMethodEnum -> Averaging
+                    else if calculationMethodologyFromFloatingRateOption exists
+                    then calculationMethodologyFromFloatingRateOption = FloatingRateIndexCalculationMethodEnum -> OISCompound
+                            or calculationMethodologyFromFloatingRateOption = FloatingRateIndexCalculationMethodEnum -> Average))
+
+    set observationType:
+        if isSingle
+        then FloatingRateIndexPeriodObservationTypeEnum -> Single
+        else if isMultiple
+        then FloatingRateIndexPeriodObservationTypeEnum -> Multiple
+        else if isCompoundedIndex
+        then FloatingRateIndexPeriodObservationTypeEnum -> CompoundedIndex

--- a/rosetta-source/src/main/rosetta/observable-asset-fro-type.rosetta
+++ b/rosetta-source/src/main/rosetta/observable-asset-fro-type.rosetta
@@ -3,6 +3,7 @@ version "${project.version}"
 
 import cdm.base.datetime.*
 import cdm.base.datetime.daycount.*
+import cdm.base.math.*
 import cdm.base.staticdata.asset.common.*
 import cdm.base.staticdata.asset.rates.*
 import cdm.base.staticdata.codelist.*
@@ -29,6 +30,7 @@ type FloatingRateIndexDefinition:
     history FroHistory (0..1) <"FRO History">
     deprecationReason string (0..1) <"Deprecation and Code Descriptions">
     fpmlDescription string (0..1) <"FpML Description">
+    rounding Rounding (0..1) <"The rounding rules applicable to the floating rate index in case of a calculation.">
 
 type FloatingRateIndexIdentification:
     floatingRateIndex FloatingRateIndexEnum (0..1) <"The reference index that is used to specify the floating interest rate. The FpML standard maintains the list of such indices, which are positioned as enumeration values as part of the CDM.">

--- a/rosetta-source/src/test/java/cdm/base/datetime/functions/GenerateCalendarDateListTest.java
+++ b/rosetta-source/src/test/java/cdm/base/datetime/functions/GenerateCalendarDateListTest.java
@@ -1,0 +1,122 @@
+package cdm.base.datetime.functions;
+
+import com.rosetta.model.lib.records.Date;
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class GenerateCalendarDateListTest extends AbstractFunctionTest {
+
+    @Inject
+    private GenerateCalendarDateList func;
+
+    @Test
+    void shouldGenerateInclusiveRangeWithNullFlag() {
+        // isEndDateExclusive null => defaults to inclusive
+        List<Date> result = func.evaluate(Date.of(2024, 3, 1), Date.of(2024, 3, 5), null);
+        List<Date> expected = Arrays.asList(
+                Date.of(2024, 3, 1),
+                Date.of(2024, 3, 2),
+                Date.of(2024, 3, 3),
+                Date.of(2024, 3, 4),
+                Date.of(2024, 3, 5));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldGenerateInclusiveRangeWithFalseFlag() {
+        List<Date> result = func.evaluate(Date.of(2024, 3, 1), Date.of(2024, 3, 5), false);
+        List<Date> expected = Arrays.asList(
+                Date.of(2024, 3, 1),
+                Date.of(2024, 3, 2),
+                Date.of(2024, 3, 3),
+                Date.of(2024, 3, 4),
+                Date.of(2024, 3, 5));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldGenerateExclusiveRange() {
+        List<Date> result = func.evaluate(Date.of(2024, 3, 1), Date.of(2024, 3, 5), true);
+        List<Date> expected = Arrays.asList(
+                Date.of(2024, 3, 1),
+                Date.of(2024, 3, 2),
+                Date.of(2024, 3, 3),
+                Date.of(2024, 3, 4));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldReturnSingleDateWhenStartEqualsEnd() {
+        List<Date> result = func.evaluate(Date.of(2024, 6, 15), Date.of(2024, 6, 15), false);
+        assertEquals(Collections.singletonList(Date.of(2024, 6, 15)), result);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenStartEqualsEndAndExclusive() {
+        List<Date> result = func.evaluate(Date.of(2024, 6, 15), Date.of(2024, 6, 15), true);
+        assertEquals(Collections.emptyList(), result);
+    }
+
+    @Test
+    void shouldReturnEmptyWhenStartAfterEnd() {
+        List<Date> result = func.evaluate(Date.of(2024, 3, 10), Date.of(2024, 3, 5), false);
+        assertEquals(Collections.emptyList(), result);
+    }
+
+    @Test
+    void shouldCrossMonthBoundary() {
+        List<Date> result = func.evaluate(Date.of(2024, 1, 30), Date.of(2024, 2, 2), false);
+        List<Date> expected = Arrays.asList(
+                Date.of(2024, 1, 30),
+                Date.of(2024, 1, 31),
+                Date.of(2024, 2, 1),
+                Date.of(2024, 2, 2));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldCrossYearBoundary() {
+        List<Date> result = func.evaluate(Date.of(2023, 12, 30), Date.of(2024, 1, 2), false);
+        List<Date> expected = Arrays.asList(
+                Date.of(2023, 12, 30),
+                Date.of(2023, 12, 31),
+                Date.of(2024, 1, 1),
+                Date.of(2024, 1, 2));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldIncludeWeekendsAndNotFilterHolidays() {
+        // 2024-03-01 is a Friday, 2024-03-04 is a Monday — includes Sat/Sun
+        List<Date> result = func.evaluate(Date.of(2024, 3, 1), Date.of(2024, 3, 4), false);
+        List<Date> expected = Arrays.asList(
+                Date.of(2024, 3, 1),
+                Date.of(2024, 3, 2),
+                Date.of(2024, 3, 3),
+                Date.of(2024, 3, 4));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldHandleLeapDayInclusive() {
+        List<Date> result = func.evaluate(Date.of(2024, 2, 28), Date.of(2024, 3, 1), false);
+        List<Date> expected = Arrays.asList(
+                Date.of(2024, 2, 28),
+                Date.of(2024, 2, 29),
+                Date.of(2024, 3, 1));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void shouldHandleExclusiveEndOneDayRange() {
+        List<Date> result = func.evaluate(Date.of(2024, 3, 5), Date.of(2024, 3, 6), true);
+        assertEquals(Collections.singletonList(Date.of(2024, 3, 5)), result);
+    }
+}

--- a/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/Create_DetermineUnadjustedObservationDatesInstructionTest.java
+++ b/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/Create_DetermineUnadjustedObservationDatesInstructionTest.java
@@ -1,0 +1,109 @@
+package cdm.event.instructioncomposition.reset.functions;
+
+import cdm.event.instructioncomposition.reset.DetermineUnadjustedObservationDatesInstruction;
+import cdm.observable.asset.fro.FloatingRateIndexCalculationDefaults;
+import cdm.observable.asset.fro.FloatingRateIndexCalculationMethodEnum;
+import cdm.observable.asset.fro.FloatingRateIndexCategoryEnum;
+import cdm.observable.asset.fro.FloatingRateIndexDefinition;
+import cdm.observable.asset.fro.FloatingRateIndexStyleEnum;
+import cdm.product.common.schedule.CalculationPeriodBase;
+import com.rosetta.model.lib.records.Date;
+import com.rosetta.model.lib.functions.ConditionValidator;
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Create_DetermineUnadjustedObservationDatesInstructionTest extends AbstractFunctionTest {
+
+    @Inject
+    private Create_DetermineUnadjustedObservationDatesInstruction createDetermineUnadjustedObservationDatesInstruction;
+
+    @Test
+    void shouldSetUnadjustedObservationDateToAdjustedResetDateForSingleObservation() {
+        Date startDate = Date.of(2024, 1, 15);
+        Date endDate = Date.of(2024, 1, 17);
+        Date resetDate = Date.of(2024, 1, 14);
+
+        DetermineUnadjustedObservationDatesInstruction result =
+                createDetermineUnadjustedObservationDatesInstruction.evaluate(
+                        buildCalculationPeriod(startDate, endDate),
+                        resetDate,
+                        buildFroData(FloatingRateIndexCategoryEnum.SCREEN_RATE, FloatingRateIndexStyleEnum.AVERAGE_FRO, null),
+                        null);
+
+        assertEquals(Collections.singletonList(resetDate), result.getUnadjustedObservationDates());
+        assertEquals(buildFroData(FloatingRateIndexCategoryEnum.SCREEN_RATE, FloatingRateIndexStyleEnum.AVERAGE_FRO, null), result.getFloatingRateIndexData());
+    }
+
+    @Test
+    void shouldGenerateCalendarDateListForMultipleObservation() {
+        Date startDate = Date.of(2024, 1, 15);
+        Date endDate = Date.of(2024, 1, 17);
+
+        DetermineUnadjustedObservationDatesInstruction result =
+                createDetermineUnadjustedObservationDatesInstruction.evaluate(
+                        buildCalculationPeriod(startDate, endDate),
+                        Date.of(2024, 1, 14),
+                        buildFroData(FloatingRateIndexCategoryEnum.CALCULATED, FloatingRateIndexStyleEnum.AVERAGE_FRO, FloatingRateIndexCalculationMethodEnum.OIS_COMPOUND),
+                        null);
+
+        List<Date> expectedDates = Arrays.asList(Date.of(2024, 1, 15), Date.of(2024, 1, 16), Date.of(2024, 1, 17));
+        assertEquals(expectedDates, result.getUnadjustedObservationDates());
+    }
+
+    @Test
+    void shouldThrowWhenScreenRateOvernightHasNoConfirmationMethod() {
+        ConditionValidator.ConditionException exception = assertThrows(ConditionValidator.ConditionException.class, () ->
+                createDetermineUnadjustedObservationDatesInstruction.evaluate(
+                        buildCalculationPeriod(Date.of(2024, 1, 15), Date.of(2024, 1, 17)),
+                        Date.of(2024, 1, 14),
+                        buildFroData(FloatingRateIndexCategoryEnum.SCREEN_RATE, FloatingRateIndexStyleEnum.OVERNIGHT, null),
+                        null));
+        assertEquals("If the Floating Rate Index has a Style of Overnight, then the calculation methodology originating from the Workflow Step must be present.",
+                exception.getMessage());
+    }
+
+    @Test
+    void shouldSetStartAndEndDatesForCompoundedIndexObservation() {
+        Date startDate = Date.of(2024, 1, 15);
+        Date endDate = Date.of(2024, 1, 17);
+
+        DetermineUnadjustedObservationDatesInstruction result =
+                createDetermineUnadjustedObservationDatesInstruction.evaluate(
+                        buildCalculationPeriod(startDate, endDate),
+                        Date.of(2024, 1, 14),
+                        buildFroData(FloatingRateIndexCategoryEnum.CALCULATED, FloatingRateIndexStyleEnum.COMPOUNDED_INDEX, FloatingRateIndexCalculationMethodEnum.COMPOUNDED),
+                        null);
+
+        assertEquals(Arrays.asList(startDate, endDate), result.getUnadjustedObservationDates());
+    }
+
+    // -------- Helper methods -----------
+
+    private static CalculationPeriodBase buildCalculationPeriod(Date startDate, Date endDate) {
+        return CalculationPeriodBase.builder()
+                .setAdjustedStartDate(startDate)
+                .setAdjustedEndDate(endDate)
+                .build();
+    }
+
+    private static FloatingRateIndexDefinition buildFroData(
+            FloatingRateIndexCategoryEnum category,
+            FloatingRateIndexStyleEnum style,
+            FloatingRateIndexCalculationMethodEnum method) {
+        return FloatingRateIndexDefinition.builder()
+                .setCalculationDefaults(FloatingRateIndexCalculationDefaults.builder()
+                        .setCategory(category)
+                        .setIndexStyle(style)
+                        .setMethod(method)
+                        .build())
+                .build();
+    }
+}

--- a/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/UpdateResetCompositionStateTest.java
+++ b/rosetta-source/src/test/java/cdm/event/instructioncomposition/reset/functions/UpdateResetCompositionStateTest.java
@@ -6,8 +6,11 @@ import cdm.event.instructioncomposition.reset.AdjustPeriodInstruction;
 import cdm.event.instructioncomposition.reset.AdjustDateInstruction;
 import cdm.event.instructioncomposition.reset.CollectFloatingRateOptionInstruction;
 import cdm.event.instructioncomposition.reset.DetermineUnadjustedCalculationPeriodInstruction;
+import cdm.event.instructioncomposition.reset.DetermineUnadjustedObservationDatesInstruction;
 import cdm.event.instructioncomposition.reset.ResetInstructionState;
 import cdm.product.common.schedule.CalculationPeriodBase;
+import cdm.observable.asset.fro.FloatingRateIndexDefinition;
+import cdm.observable.asset.fro.FloatingRateIndexIdentification;
 import com.rosetta.model.lib.records.Date;
 import org.finos.cdm.functions.AbstractFunctionTest;
 import org.junit.jupiter.api.DisplayName;
@@ -15,6 +18,8 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 import javax.inject.Inject;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -235,5 +240,62 @@ class UpdateResetCompositionStateTest extends AbstractFunctionTest {
             assertNull(result.getAdjustedResetDate(),
                     "adjustedResetDate must be null when both current state and step instruction are absent");
         }
+    }
+
+    @Nested
+    @DisplayName("Step 5 - Determine Unadjusted Observation Dates")
+    class DetermineUnadjustedObservationDatesTest {
+
+        @Test
+        @DisplayName("Sets unadjustedObservationDates from the step instruction when determineUnadjustedObservationDates is present")
+        void shouldSetUnadjustedObservationDatesFromStepWhenDetermineUnadjustedObservationDatesIsPresent() {
+            List<Date> observationDates = Arrays.asList(Date.of(2024, 1, 15), Date.of(2024, 1, 16));
+
+            CompositionStepInstructions nextStep = CompositionStepInstructions.builder()
+                    .setDetermineUnadjustedObservationDates(DetermineUnadjustedObservationDatesInstruction.builder()
+                            .setUnadjustedObservationDates(observationDates)
+                            .setFloatingRateIndexData(buildFloatingRateIndexDefinition())
+                            .build())
+                    .build();
+
+            ResetInstructionState result = updateResetCompositionState.evaluate(null, nextStep);
+
+            assertEquals(observationDates, result.getUnadjustedObservationDates(),
+                    "unadjustedObservationDates must be taken from the step instruction");
+        }
+
+        @Test
+        @DisplayName("Carries forward unadjustedObservationDates from the current state when determineUnadjustedObservationDates is absent")
+        void shouldCarryForwardUnadjustedObservationDatesFromCurrentStateWhenDetermineUnadjustedObservationDatesIsAbsent() {
+            List<Date> observationDates = Arrays.asList(Date.of(2024, 1, 15), Date.of(2024, 1, 16));
+            ResetInstructionState currentState = ResetInstructionState.builder()
+                    .setUnadjustedObservationDates(observationDates)
+                    .build();
+            CompositionStepInstructions nextStepWithoutDetermineUnadjustedObservationDates = CompositionStepInstructions.builder().build();
+
+            ResetInstructionState result = updateResetCompositionState.evaluate(currentState, nextStepWithoutDetermineUnadjustedObservationDates);
+
+            assertEquals(observationDates, result.getUnadjustedObservationDates(),
+                    "unadjustedObservationDates must be carried forward from the current state");
+        }
+
+        @Test
+        @DisplayName("Produces null unadjustedObservationDates when determineUnadjustedObservationDates is absent and current state is absent")
+        void shouldProduceEmptyUnadjustedObservationDatesWhenDetermineUnadjustedObservationDatesAndCurrentStateAreBothAbsent() {
+            CompositionStepInstructions nextStepWithoutDetermineUnadjustedObservationDates = CompositionStepInstructions.builder().build();
+
+            ResetInstructionState result = updateResetCompositionState.evaluate(null, nextStepWithoutDetermineUnadjustedObservationDates);
+
+            assertNull(result.getUnadjustedObservationDates(),
+                    "unadjustedObservationDates must be null when both current state and step instruction are absent");
+        }
+    }
+
+    // -------- Helper methods -----------
+
+    private static FloatingRateIndexDefinition buildFloatingRateIndexDefinition() {
+        return FloatingRateIndexDefinition.builder()
+                .setFro(FloatingRateIndexIdentification.builder().build())
+                .build();
     }
 }

--- a/rosetta-source/src/test/java/cdm/observable/asset/fro/functions/DetermineObservationTypeTest.java
+++ b/rosetta-source/src/test/java/cdm/observable/asset/fro/functions/DetermineObservationTypeTest.java
@@ -1,0 +1,101 @@
+package cdm.observable.asset.fro.functions;
+
+import cdm.observable.asset.calculatedrate.CalculationMethodEnum;
+import cdm.observable.asset.fro.FloatingRateIndexCalculationMethodEnum;
+import cdm.observable.asset.fro.FloatingRateIndexCategoryEnum;
+import cdm.observable.asset.fro.FloatingRateIndexStyleEnum;
+import cdm.observable.asset.fro.FloatingRateIndexPeriodObservationTypeEnum;
+import javax.inject.Inject;
+import org.finos.cdm.functions.AbstractFunctionTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class DetermineObservationTypeTest extends AbstractFunctionTest {
+
+    @Inject
+    private DetermineObservationType func;
+
+    // ---- Single observation type ----
+
+    @Test
+    void shouldReturnSingleForScreenRateWithNoStyle() {
+        assertEquals(FloatingRateIndexPeriodObservationTypeEnum.SINGLE,
+                func.evaluate(FloatingRateIndexCategoryEnum.SCREEN_RATE, null, null, null));
+    }
+
+    @ParameterizedTest(name = "SCREEN_RATE with style {0} returns SINGLE")
+    @EnumSource(value = FloatingRateIndexStyleEnum.class, mode = EnumSource.Mode.EXCLUDE, names = {"OVERNIGHT"})
+    void shouldReturnSingleForScreenRateWithNonOvernightStyle(FloatingRateIndexStyleEnum style) {
+        assertEquals(FloatingRateIndexPeriodObservationTypeEnum.SINGLE,
+                func.evaluate(FloatingRateIndexCategoryEnum.SCREEN_RATE, style, null, null));
+    }
+
+    // ---- Multiple observation type: Calculated Rate scenarios ----
+
+    static Stream<Arguments> calculatedRateMultipleObservationCombinations() {
+        return Stream.of(
+                Arguments.of(FloatingRateIndexStyleEnum.AVERAGE_FRO, CalculationMethodEnum.COMPOUNDING, null),
+                Arguments.of(FloatingRateIndexStyleEnum.AVERAGE_FRO, CalculationMethodEnum.AVERAGING, null),
+                Arguments.of(FloatingRateIndexStyleEnum.AVERAGE_FRO, null, FloatingRateIndexCalculationMethodEnum.OIS_COMPOUND),
+                Arguments.of(FloatingRateIndexStyleEnum.AVERAGE_FRO, null, FloatingRateIndexCalculationMethodEnum.AVERAGE),
+                Arguments.of(FloatingRateIndexStyleEnum.COMPOUNDED_FRO, CalculationMethodEnum.COMPOUNDING, null),
+                Arguments.of(FloatingRateIndexStyleEnum.COMPOUNDED_FRO, CalculationMethodEnum.AVERAGING, null),
+                Arguments.of(FloatingRateIndexStyleEnum.COMPOUNDED_FRO, null, FloatingRateIndexCalculationMethodEnum.OIS_COMPOUND),
+                Arguments.of(FloatingRateIndexStyleEnum.COMPOUNDED_FRO, null, FloatingRateIndexCalculationMethodEnum.AVERAGE)
+        );
+    }
+
+    @ParameterizedTest(name = "CALCULATED + {0} + confirmation={1} + FRO={2} returns MULTIPLE")
+    @MethodSource("calculatedRateMultipleObservationCombinations")
+    void shouldReturnMultipleForCalculatedRate(FloatingRateIndexStyleEnum style,
+                                               CalculationMethodEnum confirmationMethod,
+                                               FloatingRateIndexCalculationMethodEnum froMethod) {
+        assertEquals(FloatingRateIndexPeriodObservationTypeEnum.MULTIPLE,
+                func.evaluate(FloatingRateIndexCategoryEnum.CALCULATED, style, froMethod, confirmationMethod));
+    }
+
+    // ---- Multiple observation type: Screen Rate + Overnight scenarios ----
+
+    static Stream<Arguments> overnightMultipleObservationCombinations() {
+        return Stream.of(
+                Arguments.of(CalculationMethodEnum.COMPOUNDING, null),
+                Arguments.of(CalculationMethodEnum.AVERAGING, null),
+                Arguments.of(null, FloatingRateIndexCalculationMethodEnum.OIS_COMPOUND),
+                Arguments.of(null, FloatingRateIndexCalculationMethodEnum.AVERAGE)
+        );
+    }
+
+    @ParameterizedTest(name = "SCREEN_RATE + OVERNIGHT + confirmation={0} + FRO={1} returns MULTIPLE")
+    @MethodSource("overnightMultipleObservationCombinations")
+    void shouldReturnMultipleForScreenRateOvernight(CalculationMethodEnum confirmationMethod,
+                                                    FloatingRateIndexCalculationMethodEnum froMethod) {
+        assertEquals(FloatingRateIndexPeriodObservationTypeEnum.MULTIPLE,
+                func.evaluate(FloatingRateIndexCategoryEnum.SCREEN_RATE,
+                        FloatingRateIndexStyleEnum.OVERNIGHT, froMethod, confirmationMethod));
+    }
+
+    // ---- CompoundedIndex observation type ----
+
+    @Test
+    void shouldReturnCompoundedIndexWithConfirmationMethod() {
+        assertEquals(FloatingRateIndexPeriodObservationTypeEnum.COMPOUNDED_INDEX,
+                func.evaluate(FloatingRateIndexCategoryEnum.CALCULATED,
+                        FloatingRateIndexStyleEnum.COMPOUNDED_INDEX,
+                        null, CalculationMethodEnum.COMPOUNDED_INDEX));
+    }
+
+    @Test
+    void shouldReturnCompoundedIndexWithFROMethod() {
+        assertEquals(FloatingRateIndexPeriodObservationTypeEnum.COMPOUNDED_INDEX,
+                func.evaluate(FloatingRateIndexCategoryEnum.CALCULATED,
+                        FloatingRateIndexStyleEnum.COMPOUNDED_INDEX,
+                        FloatingRateIndexCalculationMethodEnum.COMPOUNDED, null));
+    }
+}


### PR DESCRIPTION
# _Instruction Composition Reset Step 5: Determine Unadjusted Observation Dates_


_Background_

This release implements Step 5 (Determine Unadjusted Observation Dates & Index Metadata Integration) of the 8-step lifecycle execution engine. A critical requirement for calculating interest rate resets—particularly across compound, average, overnight, and term rates—is the deterministic generation of observation date lists and the integration of Floating Rate Option metadata. This release establishes key date-generation utility logic, incorporates ISDA FRO Matrix lookup capabilities, and introduces observation date schedule compilation. For further information, see issue #4413.

_What is being released?_

This release introduces recursive date generation functions, ISDA FRO Matrix metadata extraction endpoints, and observation date calculation logic catering to Single Observation, Multiple Observation (Overnight/Compounded/Averaged), and Compounded Index methodologies. Additionally, it updates state accumulators and asset floating rate definitions to capture observation schedules and index rounding parameters.

_Functions_

Changes in the cdm.base.datetime namespace:
- `GenerateCalendarDateList`: A recursive utility function that generates a complete list of contiguous calendar dates between a start date and an end date (inclusive).

Changes in the cdm.event.instructioncomposition.reset namespace:
- `ExtractFloatingRateOptionData`: An operational interface function that extracts comprehensive benchmark index metadata (FloatingRateIndexDefinition) from the ISDA FRO Matrix for a specified trade date and floating rate index.
- `Create_DetermineUnadjustedObservationDatesInstruction`: Evaluates calculation period boundaries, index styles, categories, and confirmation methodologies to determine whether single, compounded index, or multiple observation schedules apply, returning the unadjusted observation dates alongside the index metadata.

Changes in the cdm.event.instructioncomposition namespace:
- `UpdateResetCompositionState`: Updated. Modified to implement "Step 5" state overlay logic. Conditionally checks for the presence of the determineUnadjustedObservationDates, incrementally appending unadjustedObservationDates to the cumulative state or preserving existing state values if absent.

_Types and Choices_

Changes in the cdm.event.instructioncomposition namespace:
- `CompositionStepInstructions` (Updated): Expanded to include determineUnadjustedObservationDates for Step 5 processing.

Changes in the cdm.event.instructioncomposition.reset namespace:
- `DetermineUnadjustedObservationDatesInstruction`: Introduced as the official type for Step 5.
- `ResetInstructionState` (Updated): Expanded to hold its fourth phase state variable (adjustedResetDate), allowing the cumulative workflow to track adjusted parameters over its lifecycle.

Changes in the cdm.observable.asset.fro namespace:
- `FloatingRateIndexDefinition`: (Updated). Enhanced with an optional rounding property (Rounding) to capture index-specific precision and rounding conventions required during downstream calculations.