### PR TITLE
Fix codefresh.yml PyPI dev-release skip condition (invalid !~ regex operator)

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -118,7 +118,7 @@ steps:
       condition:
         all:
           isRelease: "${{IS_RELEASE}} == true"
-          isNotDevVersion: "'${{RELEASE_NAME}}' !~ /dev/"
+          isNotDevVersion: 'match("${{RELEASE_NAME}}", "dev", true) == false'
           pythonBuildSuccess: steps.BuildPython.result == 'success'
     environment:
       - TWINE_PASSWORD=${{PYPI_TOKEN}}


### PR DESCRIPTION
## Summary

The change in the July commit (`c97ab5dc`, "feat: skip deployment for development versions") intended to stop `-dev` pre-releases from being published to PyPI, but the guard never took effect — [release history](https://pypi.org/project/finos-cdm/#history) shows `8.0.0.dev1`/`dev2` (Jul 21), `dev3` (Aug 7), and `dev4` (Aug 21) all published *after* that change merged.

## Root cause

The `DeployPython` step's condition used Perl/Ruby-style regex syntax:

```yaml
isNotDevVersion: "'${{RELEASE_NAME}}' !~ /dev/"
```

Codefresh's step-condition language doesn't support `=~` / `!~`. Its documented operators are `==`, `!=`, `>`, `>=`, `<`, `<=`, `&&`, `||`, `!`, and regex matching is done via a `match(string, pattern, caseSensitive)` function instead. Since `!~ /dev/` isn't valid in that grammar, the condition never evaluated correctly, so the guard silently fell through and PyPI publishing proceeded for dev tags (e.g. `8.0.0-dev.4`) exactly as before the fix.

## Fix

Replace the invalid regex literal with Codefresh's `match()` function:

```yaml
isNotDevVersion: 'match("${{RELEASE_NAME}}", "dev", true) == false'
```

## Testing

- [ ] Trigger a dev-tagged release build (e.g. `x.y.z-dev.N`) and confirm the `DeployPython` step is skipped.
- [ ] Trigger a stable release build and confirm `DeployPython` still runs and publishes to PyPI as expected.