### PR TITLE
CVE scanning: enable OSS Index with OSS_INDEX_* secrets

### DIFF
--- a/.github/workflows/cve-scanning-schedule.yml
+++ b/.github/workflows/cve-scanning-schedule.yml
@@ -8,8 +8,8 @@ name: CVE Scanning Schedule
 on:
   workflow_dispatch:
   schedule:
-    # Run daily to catch newly published CVEs even without repo changes.
-    - cron: '0 5 * * *'
+    # Run Mon/Wed/Fri to catch newly published CVEs even without repo changes.
+    - cron: '0 5 * * 1,3,5'
 
 # Neither step below uses the default GITHUB_TOKEN, so it's granted no
 # permissions at all.

--- a/.github/workflows/cve-scanning-schedule.yml
+++ b/.github/workflows/cve-scanning-schedule.yml
@@ -8,8 +8,8 @@ name: CVE Scanning Schedule
 on:
   workflow_dispatch:
   schedule:
-    # Run Mon/Wed/Fri to catch newly published CVEs even without repo changes.
-    - cron: '0 5 * * 1,3,5'
+    # Run daily to catch newly published CVEs even without repo changes.
+    - cron: '0 5 * * *'
 
 # Neither step below uses the default GITHUB_TOKEN, so it's granted no
 # permissions at all.

--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       scheduled:
-        description: 'Set by cve-scanning-schedule.yml when dispatching this run from the daily cron'
+        description: 'Set by cve-scanning-schedule.yml when dispatching this run from the scheduled cron'
         type: boolean
         default: false
   push:
@@ -91,7 +91,11 @@ jobs:
             -DsuppressionFiles=allow-list.xml \
             -Dformats=HTML \
             -DoutputDirectory=reports \
-            -DfailBuildOnCVSS=7
+            -DfailBuildOnCVSS=7 \
+            -DossIndexAnalyzerEnabled=true \
+            -DossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }} \
+            -DossIndexPassword=${{ secrets.OSS_INDEX_TOKEN }} \
+            -DnodeAuditAnalyzerEnabled=false
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v7
@@ -109,7 +113,7 @@ jobs:
           fi
       # Notify Slack if the scan itself failed (e.g. a real CVSS>=7 finding),
       # so the team doesn't have to check the Actions tab. Restricted to runs
-      # dispatched by cve-scanning-schedule.yml's daily cron so manual/PR/push
+      # dispatched by cve-scanning-schedule.yml's scheduled cron so manual/PR/push
       # triggers don't spam the channel.
       - name: Notify Slack on scan failure
         if: failure() && steps.cve-scanning.outcome == 'failure' && inputs.scheduled == true
@@ -122,7 +126,7 @@ jobs:
             }" \
             "$SLACK_WEBHOOK_URL"
       # Also notify Slack on success for the scheduled run, so the team has
-      # positive confirmation that the daily scan is running and clean.
+      # positive confirmation that the scheduled scan is running and clean.
       - name: Notify Slack on scan success
         if: success() && inputs.scheduled == true
         env:


### PR DESCRIPTION
## Summary
- Enabled the Sonatype OSS Index analyzer in `cve-scanning.yml`, using `OSS_INDEX_USERNAME`/`OSS_INDEX_TOKEN` secrets (the naming now standard across rune-dsl/rune-common/rune-testing/rosetta-code-generators/rune-fpml/ISO-20022) — OSS Index wasn't referenced here at all previously.

## Test plan
- [ ] Repo secrets `OSS_INDEX_USERNAME` and `OSS_INDEX_TOKEN` exist before/at merge