### PR TITLE
Enable OSS Index analyzer with OSS_INDEX_* secrets in CVE scanning

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       scheduled:
-        description: 'Set by cve-scanning-schedule.yml when dispatching this run from the daily cron'
+        description: 'Set by cve-scanning-schedule.yml when dispatching this run from the scheduled cron'
         type: boolean
         default: false
   push:
@@ -92,7 +92,9 @@ jobs:
             -Dformats=HTML \
             -DoutputDirectory=reports \
             -DfailBuildOnCVSS=7 \
-            -DossIndexAnalyzerEnabled=false \
+            -DossIndexAnalyzerEnabled=true \
+            -DossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }} \
+            -DossIndexPassword=${{ secrets.OSS_INDEX_TOKEN }} \
             -DnodeAuditAnalyzerEnabled=false
       - name: Upload results
         if: always()
@@ -111,7 +113,7 @@ jobs:
           fi
       # Notify Slack if the scan itself failed (e.g. a real CVSS>=7 finding),
       # so the team doesn't have to check the Actions tab. Restricted to runs
-      # dispatched by cve-scanning-schedule.yml's daily cron so manual/PR/push
+      # dispatched by cve-scanning-schedule.yml's scheduled cron so manual/PR/push
       # triggers don't spam the channel.
       - name: Notify Slack on scan failure
         if: failure() && steps.cve-scanning.outcome == 'failure' && inputs.scheduled == true
@@ -124,7 +126,7 @@ jobs:
             }" \
             "$SLACK_WEBHOOK_URL"
       # Also notify Slack on success for the scheduled run, so the team has
-      # positive confirmation that the daily scan is running and clean.
+      # positive confirmation that the scheduled scan is running and clean.
       - name: Notify Slack on scan success
         if: success() && inputs.scheduled == true
         env:


### PR DESCRIPTION
## Summary
- Enabled the Sonatype OSS Index analyzer in `cve-scanning.yml` on 6.x.x, matching master (#5096), using `OSS_INDEX_USERNAME`/`OSS_INDEX_TOKEN` secrets.

## Test plan
- [ ] Repo secrets `OSS_INDEX_USERNAME` and `OSS_INDEX_TOKEN` exist before/at merge