### PR TITLE
Bump jackson to 2.18.10 to fix CVE-2026-68497

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,8 @@
         <jaxb.version>2.3.1</jaxb.version>
         <slf4j-api.version>2.0.7</slf4j-api.version>
         <guava.version>33.3.1-jre</guava.version>
-        <jackson.version>2.18.8</jackson.version>
+        <!-- Pinned past 2.18.8 to fix CVE-2026-68497 -->
+        <jackson.version>2.18.10</jackson.version>
         <plexus-utils.version>3.6.1</plexus-utils.version>
 
         <!-- org.finos.cdm.CodeListTransformer -->


### PR DESCRIPTION
## Summary
- Same fix as master (#5100) and 6.x.x (#5101): `jackson.version` pins the whole jackson family via `jackson-bom`; bumped 2.18.8 → 2.18.10 to fix CVE-2026-68497 (CVSS 8.7).

## Test plan
- [x] `mvn clean test` passes with the bumped version