### PR TITLE
Bump logback to 1.5.38 and jsoup to 1.23.2

### DIFF
--- a/allow-list.xml
+++ b/allow-list.xml
@@ -43,4 +43,14 @@
 	   ]]></notes>
         <cve>CVE-2023-35116</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+	   Resource exhaustion in jsoup's XmlTreeBuilder when parsing deeply nested
+	   XML with many uniquely-namespaced elements. Fixed upstream in commit
+	   862ba2f, but that fix has not shipped in a jsoup release yet - 1.23.2 is
+	   the latest available on Maven Central and is still affected. Re-evaluate
+	   once a release containing the fix is published.
+	   ]]></notes>
+        <cve>CVE-2026-75140</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <guice.version>6.0.0</guice.version>
         <opengamma.strata.version>1.7.0</opengamma.strata.version>
         <apache.commons.cli.version>1.4</apache.commons.cli.version>
-        <jsoup.version>1.23.1</jsoup.version>
+        <jsoup.version>1.23.2</jsoup.version>
         <jaxb.version>2.3.1</jaxb.version>
         <slf4j-api.version>2.0.7</slf4j-api.version>
         <guava.version>33.3.1-jre</guava.version>
@@ -106,7 +106,7 @@
         <junit-platform-commons.version>1.9.1</junit-platform-commons.version>
         <mockito.version>5.1.1</mockito.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <logback.version>1.5.34</logback.version>
+        <logback.version>1.5.38</logback.version>
 
         <!-- plugins -->
         <maven-dependency-plugin.version>3.6.1</maven-dependency-plugin.version>


### PR DESCRIPTION
## Summary
- `logback-core` 1.5.34 is vulnerable to arbitrary code execution via Janino-evaluated conditional expressions in configuration files (CVSS 7.0, CVE-2026-13006). Bumped to 1.5.38 (1.5.37 is the definitive fix).
- `jsoup` 1.23.1 is vulnerable to resource exhaustion in `XmlTreeBuilder` via deeply-nested XML namespaces (CVSS 8.7, CVE-2026-75140). Bumped to 1.23.2 (latest on Maven Central) — the actual fix (jsoup commit 862ba2f) hasn't shipped in a release yet, so also suppressed that CVE in `allow-list.xml` with a note to re-check once it does.

## Test plan
- [x] `mvn clean test` passes with both bumps