### PR TITLE
Bump logback to 1.5.38 and jsoup to 1.23.2

### DIFF
--- a/allow-list.xml
+++ b/allow-list.xml
@@ -43,4 +43,14 @@
 	   ]]></notes>
         <cve>CVE-2023-35116</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+	   Resource exhaustion in jsoup's XmlTreeBuilder when parsing deeply nested
+	   XML with many uniquely-namespaced elements. Fixed upstream in commit
+	   862ba2f, but that fix has not shipped in a jsoup release yet - 1.23.2 is
+	   the latest available on Maven Central and is still affected. Re-evaluate
+	   once a release containing the fix is published.
+	   ]]></notes>
+        <cve>CVE-2026-75140</cve>
+    </suppress>
 </suppressions>

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <guice.version>6.0.0</guice.version>
         <opengamma.strata.version>1.7.0</opengamma.strata.version>
         <apache.commons.cli.version>1.4</apache.commons.cli.version>
-        <jsoup.version>1.15.3</jsoup.version>
+        <jsoup.version>1.23.2</jsoup.version>
         <jaxb.version>2.3.1</jaxb.version>
         <slf4j-api.version>2.0.7</slf4j-api.version>
         <guava.version>33.3.1-jre</guava.version>
@@ -103,7 +103,7 @@
         <junit-platform-commons.version>1.9.1</junit-platform-commons.version>
         <mockito.version>5.1.1</mockito.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <logback.version>1.5.25</logback.version>
+        <logback.version>1.5.38</logback.version>
         <java-diff-utils.version>4.12</java-diff-utils.version>
 
         <!-- plugins -->

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
         <rune-fpml.version>2.6.0</rune-fpml.version>
         <rosetta.dsl.version>9.92.1</rosetta.dsl.version>
-        <rosetta.bundle.version>11.132.0</rosetta.bundle.version>
+        <rosetta.bundle.version>11.132.1</rosetta.bundle.version>
         <rosetta.code-gen.version>${rosetta.bundle.version}</rosetta.code-gen.version>
 
         <xtext.version>2.38.0</xtext.version>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
         <rune-fpml.version>2.6.0</rune-fpml.version>
         <rosetta.dsl.version>9.92.1</rosetta.dsl.version>
-        <rosetta.bundle.version>11.132.1</rosetta.bundle.version>
+        <rosetta.bundle.version>11.132.0</rosetta.bundle.version>
         <rosetta.code-gen.version>${rosetta.bundle.version}</rosetta.code-gen.version>
 
         <xtext.version>2.38.0</xtext.version>


### PR DESCRIPTION
## Summary
- Same fix as 7.x.x (#5103) and master (#5104): `logback-core` bumped 1.5.25 → 1.5.38 (CVE-2026-13006, CVSS 7.0) and `jsoup` bumped 1.15.3 → 1.23.2 (CVE-2026-75140, CVSS 8.7 — latest available; actual fix not yet released, so also suppressed in `allow-list.xml`).

## Test plan
- [x] `mvn clean test` passes with both bumps