### PR TITLE
Fix Node Audit analyzer / CVE failures

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -95,7 +95,7 @@ jobs:
             -DossIndexAnalyzerEnabled=true \
             -DossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }} \
             -DossIndexPassword=${{ secrets.OSS_INDEX_TOKEN }} \
-            -DnodeAuditAnalyzerEnabled=false
+            -DnodeAuditAnalyzerEnabled=true
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v7

--- a/allow-list.xml
+++ b/allow-list.xml
@@ -43,4 +43,17 @@
 	   ]]></notes>
         <cve>CVE-2023-35116</cve>
     </suppress>
+    <suppress>
+        <notes><![CDATA[
+	   image-size <=2.0.2 (bundled transitively inside @docusaurus/mdx-loader,
+	   via @docusaurus/core and everything that depends on it) allows a denial
+	   of service through an infinite loop when parsing a malicious ICNS/JXL/HEIF
+	   image. No fixed release exists yet - 2.0.2 is the latest on the npm
+	   registry and is still affected. Re-evaluate once a release containing
+	   the fix is published.
+	   ]]></notes>
+        <packageUrl regex="true">^pkg:npm/image\-size@.*$</packageUrl>
+        <cve>CVE-2025-71329</cve>
+        <cve>CVE-2025-71330</cve>
+    </suppress>
 </suppressions>

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -13282,9 +13282,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/website/package.json
+++ b/website/package.json
@@ -28,7 +28,8 @@
   },
   "overrides": {
     "serialize-javascript": "^7.0.7",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "nanoid": "^3.3.18"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
## Summary
- Enables the Node Audit analyzer, which scans `website/package-lock.json` against the npm audit API for known vulnerabilities in the website's npm dependencies (previously only Maven dependencies were covered).