### PR TITLE
Fix broken external links across the CDM microsite

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,8 +1,8 @@
 # Community Specification Governance Policy 1.0
 
-The Common Domain Model is an open standard project hosted under FINOS, the [Fintech Open Source Foundation](https://community.finos.org/docs/governance/Standards-Projects), starting in February 2023.
+The Common Domain Model is an open standard project hosted under FINOS, the [Fintech Open Source Foundation](https://community.finos.org/docs/governance/#open-standard-projects), starting in February 2023.
 
-The standard is developed through the [Community Specification](https://community.finos.org/docs/governance/#open-standard-projects) open governance process, and underlying code assets are released under the [Community Specification License 1.0](https://github.com/finos/standards-project-blueprint/blob/master/governance-documents/4._License.md). For versions before 4.0.0 and other license details, check [Notice.md](https://github.com/finos/common-domain-model/blob/master/NOTICE.md).
+The standard is developed through the [Community Specification](https://community.finos.org/docs/governance/#open-standard-projects) open governance process, and underlying code assets are released under the [Community Specification License 1.0](https://github.com/finos/standards-project-blueprint/blob/master/LICENSE). For versions before 4.0.0 and other license details, check [Notice.md](https://github.com/finos/common-domain-model/blob/master/NOTICE.md).
 
 For more information on discussions and announcements subscribe to our mailing list using the following [link](mailto:cdm+subscribe@lists.finos.org).
 

--- a/docs/cdm-java-distribution.md
+++ b/docs/cdm-java-distribution.md
@@ -44,8 +44,8 @@ needs to be added to the project pom.xml:
     distribution ships with the json to java object serialisers.
 
 > _NOTE:_ All current CDM dependencies are available in Maven Central.
-> CDM releases prior to version 4.0.0 can be found in the [ISDA repository](https://europe-west1-maven.pkg.dev/production-208613/isda-maven).
-> The dependencies of CDM releases prior to version 4.0.0 can be found in the [REGnosys repository](https://europe-west1-maven.pkg.dev/production-208613/public-maven).
+> CDM releases prior to version 4.0.0 can be found in the ISDA repository at `https://europe-west1-maven.pkg.dev/production-208613/isda-maven`.
+> The dependencies of CDM releases prior to version 4.0.0 can be found in the REGnosys repository at `https://europe-west1-maven.pkg.dev/production-208613/public-maven`.
 > Add the following snippet to the `<repositories>` section of your project `pom.xml`:
 >
 > ``` xml

--- a/docs/cdm-overview.md
+++ b/docs/cdm-overview.md
@@ -127,7 +127,7 @@ The FINOS CDM distribution comprises three main sets of components:
     -   Reference Data
 -   **Executable code distribution**, automatically generated from the
     model definitions expressed in the Rune DSL using [available code
-    generators](https://docs.rosetta-technology.io/rosetta/rune-dsl/rosetta-code-generators/#what-code-generators-are-available). Once a code generator is implemented for a particular
+    generators](https://rune.finos.org/docs/developers/code-generator/#3-available-code-generators). Once a code generator is implemented for a particular
     language, the corresponding code generation is included as part of
     the CDM build and release process, allowing the CDM to be
     automatically distributed in that language going forward.
@@ -167,7 +167,7 @@ share code generators into any other languages.
 ---
 **Note:**
 All the language components, their syntax and purpose are detailed in
-the [Rune DSL Documentation](https://docs.rosetta-technology.io/rosetta/rune-dsl/rune-modelling-component/). The documentation also describes the
+the [Rune DSL Documentation](https://rune.finos.org/docs/modelling-components/). The documentation also describes the
 mechanism to write and use code generators.
 
 ---

--- a/docs/cdm-resources.md
+++ b/docs/cdm-resources.md
@@ -40,7 +40,7 @@ The Japanese Securities Clearing Corporation (JSCC) announced today that JSCC is
 
 JPMorganChase’s derivatives business leverages the Fintech Open Source Foundation (FINOS) Common Domain Model (CDM) and ISDA Digital Regulatory Reporting (DRR).
 
-### [CDM Update: Focus on Reporting, Collateral & Sec Lending Next](https://derivsource.com/2024/08/28/common-domain-model-providing-a-standardised-data-representation-of-trade-events-isda-cdm/?utm_campaign=DerivSource%20SOCIALS&utm_content=305908647&utm_medium=social&utm_source=linkedin&hss_channel=lcp-1903852)
+### [CDM Update: Focus on Reporting, Collateral & Sec Lending Next](https://regnosys.com/press/cdm-update-focus-on-reporting-collateral-sec-lending-next/)
 
 The article examines the CDMs expanded role in enhancing post-trade efficiency through standardized data models for reporting, collateral management, and securities lending, fostering transparency, regulatory alignment, and automation across financial markets.
 

--- a/docs/common-domain-model.md
+++ b/docs/common-domain-model.md
@@ -24,4 +24,4 @@ documented here:
 
 The CDM is expressed in a language called the Rune DSL. All the
 language components used by the CDM including types, functions and
-annotations are described in the [Rune DSL Documentation](https://docs.rosetta-technology.io/rosetta/rune-dsl/rune-modelling-component/).
+annotations are described in the [Rune DSL Documentation](https://rune.finos.org/docs/modelling-components/).

--- a/docs/dev-guidelines.md
+++ b/docs/dev-guidelines.md
@@ -13,7 +13,7 @@ The CSL specifies three different contribution roles for each specific [working 
 
 * [Maintainers](maintainers.md) - those who drive consensus within the working group
 * Editors - those who codify ideas into a formal specification
-* Participants - anyone who provides contributions to the project under a signed CSL CLA. A great way to sign the CLA is to open a Pull Request to add your name to the [participants](https://github.com/finos/standards-project-blueprint/blob/master/governance-documents/participants.md) file. 
+* Participants - anyone who provides contributions to the project under a signed CSL CLA. A great way to sign the CLA is to open a Pull Request to add your name to the [participants](https://github.com/finos/standards-project-blueprint/blob/master/PARTICIPANTS.md) file. 
 
 
 ## CDM Design Principles
@@ -412,7 +412,7 @@ one-off branch in the source-control repository. Please refer to the
 
 1. Fork it (https://github.com/finos/common-domain-model)
 2. Create your feature branch (`git checkout -b feature/my-new-feature`)
-3. Make a change - _hint_ you can make changes to Rosetta files directly on your desktop using the [Rosetta VS Code plugin](https://github.com/REGnosys/rosetta-dsl/tree/master/rosetta-ide/vscode)
+3. Make a change - _hint_ you can make changes to Rosetta files directly on your desktop using the [Rune VS Code plugin](https://github.com/finos/rune-dsl/tree/main/rune-ide/vscode)
 4. Read our contribution guidelines and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
 5. Commit your changes (`git commit -am 'My New Feature'`)
 6. Push to the branch (`git push origin feature/my-new-feature`)

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -460,7 +460,7 @@ prior to any release.
     languages, law, science, lists, and tables. An earlier version
     coined the phrase Oxford Comma in July 1905.
 2.  [Eats, Shoots & Leaves: The Zero Tolerance Approach to
-    Punctuation](https://www.lynnetruss.com/books/eats-shoots-leaves/):
+    Punctuation](https://www.penguinrandomhouse.com/books/294386/eats-shoots-and-leaves-by-lynne-truss/):
     A light-hearted book with a serious purpose regarding common
     problems and correctness for using punctuation in the English
     language.

--- a/docs/download.md
+++ b/docs/download.md
@@ -34,8 +34,8 @@ the following dependency needs to be added to the project pom.xml:
     <version>LATEST</version>
 
 > _NOTE:_ All current CDM dependencies are available in Maven Central.
-> CDM releases prior to version 4.0.0 can be found in the [ISDA repository](https://europe-west1-maven.pkg.dev/production-208613/isda-maven).
-> The dependencies of CDM releases prior to version 4.0.0 can be found in the [REGnosys repository](https://europe-west1-maven.pkg.dev/production-208613/public-maven).
+> CDM releases prior to version 4.0.0 can be found in the ISDA repository at `https://europe-west1-maven.pkg.dev/production-208613/isda-maven`.
+> The dependencies of CDM releases prior to version 4.0.0 can be found in the REGnosys repository at `https://europe-west1-maven.pkg.dev/production-208613/public-maven`.
 > Add the following snippet to the `<repositories>` section of your project `pom.xml`:
 >
 > ``` xml

--- a/docs/editing.md
+++ b/docs/editing.md
@@ -36,7 +36,7 @@ information.
 The model is represented in the Rosetta DSL syntax. All syntax warnings
 and errors must be resolved to have a valid model before contributing
 any changes. For further guidance about features of the syntax, please
-refer to the [Rosetta DSL Documentation](https://docs.rosetta-technology.io/rosetta/rune-dsl/rune-modelling-component/).
+refer to the [Rune DSL Documentation](https://rune.finos.org/docs/modelling-components/).
 
 In Rosetta Design, that syntax is automatically checked live as the user
 edits the model, as described in the [Rosetta Design Content Assist

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -4,7 +4,7 @@ title: Maintainers
 
 ## Maintainers
 
-This page provides detailed information about the CDM maintainers. A CDM maintainer is one of the different [roles](https://github.com/finos/common-domain-model/blob/master/GOVERNANCE#1-roles) within the CDM community.
+This page provides detailed information about the CDM maintainers. A CDM maintainer is one of the different [roles](https://github.com/finos/common-domain-model/blob/master/GOVERNANCE.md#1-roles) within the CDM community.
 
 **Appointment of CDM Maintainers:**
 

--- a/docs/process-model.md
+++ b/docs/process-model.md
@@ -41,7 +41,7 @@ widely adopted and freely available programming languages and is
 systematically distributed as part of the CDM release.
 
 The code generation process is based on the Rune DSL and is further
-described in the [Code Generation Section](https://docs.rosetta-technology.io/rosetta/rune-dsl/rosetta-code-generators/), including an up-to-date
+described in the [Code Generation Section](https://rune.finos.org/docs/developers/code-generator/), including an up-to-date
 list of available languages. Support for further languages can be
 added as required by market participants.
 

--- a/website/src/components/featuresTwoHeader-config.js
+++ b/website/src/components/featuresTwoHeader-config.js
@@ -8,7 +8,7 @@ export const featuresTwoHeader = [
             <br />
             <span style={{ fontSize: '1.25em' }}> The Common Domain Model (CDM) is a standardized, machine-readable, and machine-executable model that represents financial products, trades in those products, and the lifecycle events of those trades.</span>
 
-            <span style={{ fontSize: '1.25em' }}> The standard is developed through the <a href="https://community.finos.org/docs/governance/#open-standard-projects">Community Specification</a> open governance process, and underlying code assets are released under the <a href="https://github.com/finos/standards-project-blueprint/blob/master/governance-documents/4._License.md">Community Specification License 1.0</a>.</span>
+            <span style={{ fontSize: '1.25em' }}> The standard is developed through the <a href="https://community.finos.org/docs/governance/#open-standard-projects">Community Specification</a> open governance process, and underlying code assets are released under the <a href="https://github.com/finos/standards-project-blueprint/blob/master/LICENSE">Community Specification License 1.0</a>.</span>
             <hr />
             </>
         ),

--- a/website/versioned_docs/version-7.0.0/cdm-java-distribution.md
+++ b/website/versioned_docs/version-7.0.0/cdm-java-distribution.md
@@ -44,8 +44,8 @@ needs to be added to the project pom.xml:
     distribution ships with the json to java object serialisers.
 
 > _NOTE:_ All current CDM dependencies are available in Maven Central.
-> CDM releases prior to version 4.0.0 can be found in the [ISDA repository](https://europe-west1-maven.pkg.dev/production-208613/isda-maven).
-> The dependencies of CDM releases prior to version 4.0.0 can be found in the [REGnosys repository](https://europe-west1-maven.pkg.dev/production-208613/public-maven).
+> CDM releases prior to version 4.0.0 can be found in the ISDA repository at `https://europe-west1-maven.pkg.dev/production-208613/isda-maven`.
+> The dependencies of CDM releases prior to version 4.0.0 can be found in the REGnosys repository at `https://europe-west1-maven.pkg.dev/production-208613/public-maven`.
 > Add the following snippet to the `<repositories>` section of your project `pom.xml`:
 >
 > ``` xml

--- a/website/versioned_docs/version-7.0.0/cdm-overview.md
+++ b/website/versioned_docs/version-7.0.0/cdm-overview.md
@@ -127,7 +127,7 @@ The FINOS CDM distribution comprises three main sets of components:
     -   Reference Data
 -   **Executable code distribution**, automatically generated from the
     model definitions expressed in the Rune DSL using [available code
-    generators](https://docs.rosetta-technology.io/rosetta/rune-dsl/rosetta-code-generators/#what-code-generators-are-available). Once a code generator is implemented for a particular
+    generators](https://rune.finos.org/docs/developers/code-generator/#3-available-code-generators). Once a code generator is implemented for a particular
     language, the corresponding code generation is included as part of
     the CDM build and release process, allowing the CDM to be
     automatically distributed in that language going forward.
@@ -167,7 +167,7 @@ share code generators into any other languages.
 ---
 **Note:**
 All the language components, their syntax and purpose are detailed in
-the [Rune DSL Documentation](https://docs.rosetta-technology.io/rosetta/rune-dsl/rune-modelling-component/). The documentation also describes the
+the [Rune DSL Documentation](https://rune.finos.org/docs/modelling-components/). The documentation also describes the
 mechanism to write and use code generators.
 
 ---

--- a/website/versioned_docs/version-7.0.0/cdm-resources.md
+++ b/website/versioned_docs/version-7.0.0/cdm-resources.md
@@ -40,7 +40,7 @@ The Japanese Securities Clearing Corporation (JSCC) announced today that JSCC is
 
 JPMorganChase’s derivatives business leverages the Fintech Open Source Foundation (FINOS) Common Domain Model (CDM) and ISDA Digital Regulatory Reporting (DRR).
 
-### [CDM Update: Focus on Reporting, Collateral & Sec Lending Next](https://derivsource.com/2024/08/28/common-domain-model-providing-a-standardised-data-representation-of-trade-events-isda-cdm/?utm_campaign=DerivSource%20SOCIALS&utm_content=305908647&utm_medium=social&utm_source=linkedin&hss_channel=lcp-1903852)
+### [CDM Update: Focus on Reporting, Collateral & Sec Lending Next](https://regnosys.com/press/cdm-update-focus-on-reporting-collateral-sec-lending-next/)
 
 The article examines the CDMs expanded role in enhancing post-trade efficiency through standardized data models for reporting, collateral management, and securities lending, fostering transparency, regulatory alignment, and automation across financial markets.
 

--- a/website/versioned_docs/version-7.0.0/common-domain-model.md
+++ b/website/versioned_docs/version-7.0.0/common-domain-model.md
@@ -24,4 +24,4 @@ documented here:
 
 The CDM is expressed in a language called the Rune DSL. All the
 language components used by the CDM including types, functions and
-annotations are described in the [Rune DSL Documentation](https://docs.rosetta-technology.io/rosetta/rune-dsl/rune-modelling-component/).
+annotations are described in the [Rune DSL Documentation](https://rune.finos.org/docs/modelling-components/).

--- a/website/versioned_docs/version-7.0.0/dev-guidelines.md
+++ b/website/versioned_docs/version-7.0.0/dev-guidelines.md
@@ -13,7 +13,7 @@ The CSL specifies three different contribution roles for each specific [working 
 
 * [Maintainers](maintainers.md) - those who drive consensus within the working group
 * Editors - those who codify ideas into a formal specification
-* Participants - anyone who provides contributions to the project under a signed CSL CLA. A great way to sign the CLA is to open a Pull Request to add your name to the [participants](https://github.com/finos/standards-project-blueprint/blob/master/governance-documents/participants.md) file. 
+* Participants - anyone who provides contributions to the project under a signed CSL CLA. A great way to sign the CLA is to open a Pull Request to add your name to the [participants](https://github.com/finos/standards-project-blueprint/blob/master/PARTICIPANTS.md) file. 
 
 
 ## CDM Design Principles
@@ -412,7 +412,7 @@ one-off branch in the source-control repository. Please refer to the
 
 1. Fork it (https://github.com/finos/common-domain-model)
 2. Create your feature branch (`git checkout -b feature/my-new-feature`)
-3. Make a change - _hint_ you can make changes to Rosetta files directly on your desktop using the [Rosetta VS Code plugin](https://github.com/REGnosys/rosetta-dsl/tree/master/rosetta-ide/vscode)
+3. Make a change - _hint_ you can make changes to Rosetta files directly on your desktop using the [Rune VS Code plugin](https://github.com/finos/rune-dsl/tree/main/rune-ide/vscode)
 4. Read our contribution guidelines and [Community Code of Conduct](https://www.finos.org/code-of-conduct)
 5. Commit your changes (`git commit -am 'My New Feature'`)
 6. Push to the branch (`git push origin feature/my-new-feature`)

--- a/website/versioned_docs/version-7.0.0/documentation-style-guide.md
+++ b/website/versioned_docs/version-7.0.0/documentation-style-guide.md
@@ -460,7 +460,7 @@ prior to any release.
     languages, law, science, lists, and tables. An earlier version
     coined the phrase Oxford Comma in July 1905.
 2.  [Eats, Shoots & Leaves: The Zero Tolerance Approach to
-    Punctuation](https://www.lynnetruss.com/books/eats-shoots-leaves/):
+    Punctuation](https://www.penguinrandomhouse.com/books/294386/eats-shoots-and-leaves-by-lynne-truss/):
     A light-hearted book with a serious purpose regarding common
     problems and correctness for using punctuation in the English
     language.

--- a/website/versioned_docs/version-7.0.0/download.md
+++ b/website/versioned_docs/version-7.0.0/download.md
@@ -34,8 +34,8 @@ the following dependency needs to be added to the project pom.xml:
     <version>LATEST</version>
 
 > _NOTE:_ All current CDM dependencies are available in Maven Central.
-> CDM releases prior to version 4.0.0 can be found in the [ISDA repository](https://europe-west1-maven.pkg.dev/production-208613/isda-maven).
-> The dependencies of CDM releases prior to version 4.0.0 can be found in the [REGnosys repository](https://europe-west1-maven.pkg.dev/production-208613/public-maven).
+> CDM releases prior to version 4.0.0 can be found in the ISDA repository at `https://europe-west1-maven.pkg.dev/production-208613/isda-maven`.
+> The dependencies of CDM releases prior to version 4.0.0 can be found in the REGnosys repository at `https://europe-west1-maven.pkg.dev/production-208613/public-maven`.
 > Add the following snippet to the `<repositories>` section of your project `pom.xml`:
 >
 > ``` xml

--- a/website/versioned_docs/version-7.0.0/editing.md
+++ b/website/versioned_docs/version-7.0.0/editing.md
@@ -36,7 +36,7 @@ information.
 The model is represented in the Rosetta DSL syntax. All syntax warnings
 and errors must be resolved to have a valid model before contributing
 any changes. For further guidance about features of the syntax, please
-refer to the [Rosetta DSL Documentation](https://docs.rosetta-technology.io/rosetta/rune-dsl/rune-modelling-component/).
+refer to the [Rune DSL Documentation](https://rune.finos.org/docs/modelling-components/).
 
 In Rosetta Design, that syntax is automatically checked live as the user
 edits the model, as described in the [Rosetta Design Content Assist

--- a/website/versioned_docs/version-7.0.0/maintainers.md
+++ b/website/versioned_docs/version-7.0.0/maintainers.md
@@ -4,7 +4,7 @@ title: Maintainers
 
 ## Maintainers
 
-This page provides detailed information about the CDM maintainers. A CDM maintainer is one of the different [roles](https://github.com/finos/common-domain-model/blob/master/GOVERNANCE#1-roles) within the CDM community.
+This page provides detailed information about the CDM maintainers. A CDM maintainer is one of the different [roles](https://github.com/finos/common-domain-model/blob/master/GOVERNANCE.md#1-roles) within the CDM community.
 
 **Appointment of CDM Maintainers:**
 

--- a/website/versioned_docs/version-7.0.0/process-model.md
+++ b/website/versioned_docs/version-7.0.0/process-model.md
@@ -41,7 +41,7 @@ widely adopted and freely available programming languages and is
 systematically distributed as part of the CDM release.
 
 The code generation process is based on the Rune DSL and is further
-described in the [Code Generation Section](https://docs.rosetta-technology.io/rosetta/rune-dsl/rosetta-code-generators/), including an up-to-date
+described in the [Code Generation Section](https://rune.finos.org/docs/developers/code-generator/), including an up-to-date
 list of available languages. Support for further languages can be
 added as required by market participants.
 


### PR DESCRIPTION
## Summary

Fixes the 16 broken external links identified in #5113, in `docs/` (Next) and in the `version-7.0.0` snapshot. All replacement URLs were verified to resolve, and named anchors were verified to exist on the destination page.

## Changes

- **Rune DSL documentation moved to rune.finos.org** — `cdm-overview.md` (×2), `common-domain-model.md`, `editing.md`, `process-model.md`
  - `docs.rosetta-technology.io/rosetta/rune-dsl/rune-modelling-component/` → `rune.finos.org/docs/modelling-components/`
  - `docs.rosetta-technology.io/rosetta/rune-dsl/rosetta-code-generators/` → `rune.finos.org/docs/developers/code-generator/`
  - The `#what-code-generators-are-available` anchor is now `#3-available-code-generators`

- **Rune VS Code plugin repository moved** — `dev-guidelines.md`
  - `REGnosys/rosetta-dsl/tree/master/rosetta-ide/vscode` → `finos/rune-dsl/tree/main/rune-ide/vscode` (repository transferred and renamed, default branch now `main`, module renamed `rune-ide`)

- **Maven endpoints un-linked** — `cdm-java-distribution.md`, `download.md` (2 each)
  - The ISDA and REGnosys repository URLs are Google Artifact Registry endpoints, not web pages — they return 404 to a browser by design and have no browsable equivalent. Now rendered as inline code, matching how the same URLs already appear in the XML snippet directly below each note.

- **FINOS community site and standards-project-blueprint restructured** — `GOVERNANCE.md` (×2), `dev-guidelines.md`
  - `community.finos.org/docs/governance/Standards-Projects` → `community.finos.org/docs/governance/#open-standard-projects`
  - `.../governance-documents/4._License.md` → `.../blob/master/LICENSE`
  - `.../governance-documents/participants.md` → `.../blob/master/PARTICIPANTS.md` (this one blocked new contributors following our own CLA instructions)
  - The first two were originally in `docs/governance.md`, which #4761 consolidated into the root `GOVERNANCE.md` — both broken links came across with it, so they are fixed there instead. See the second commit.

- **Missing file extension** — `maintainers.md`
  - `blob/master/GOVERNANCE#1-roles` → `blob/master/GOVERNANCE.md#1-roles`

- **Third-party pages relocated** — `cdm-resources.md`, `documentation-style-guide.md`
  - DerivSource was absorbed into Traders Magazine and the CDM article did not survive the migration; repointed to the same article hosted by REGnosys
  - Lynne Truss's site restructured; repointed to the publisher's page for the book, keeping the parallel structure with the OUP-linked entry above it

- **Site homepage** — `website/src/components/featuresTwoHeader-config.js`
  - Carried the same dead `governance-documents/4._License.md` link → `.../blob/master/LICENSE`

Stale "Rosetta DSL" link text updated to "Rune DSL" where the target was renamed.

Resolves #5113
