### PR TITLE
[6xx] Update runefpml.version to 2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <!-- release version is overridden in rosetta-source -->
         <maven.compiler.release>11</maven.compiler.release>
 
-        <rune-fpml.version>2.6.0</rune-fpml.version>
+        <rune-fpml.version>2.8.0</rune-fpml.version>
         <rosetta.dsl.version>9.92.1</rosetta.dsl.version>
         <rosetta.bundle.version>11.132.4</rosetta.bundle.version>
         <rosetta.code-gen.version>${rosetta.bundle.version}</rosetta.code-gen.version>


### PR DESCRIPTION
# _Infrastructure - Dependency Update_

Version updates include:

- `Rune-FpML` `2.7.0` - Update Dependencies. See release notes: [2.7.0](https://github.com/rosetta-models/rune-fpml/releases/tag/2.7.0)
- `Rune-FpML` `2.8.0` - CVE fixes and update dependencies. See release notes: [2.8.0](https://github.com/rosetta-models/rune-fpml/releases/tag/2.8..0)

_Review Directions_
Changes can be reviewed in PR: https://github.com/finos/common-domain-model/pull/5119