### PR TITLE
[7.x.x] Update  DSL to 10.10.0 and bundle to 12.17.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
         <rune-fpml.version>3.4.0</rune-fpml.version>
         <rosetta.dsl.version>10.10.0</rosetta.dsl.version>
-        <rosetta.bundle.version>12.15.0</rosetta.bundle.version>
+        <rosetta.bundle.version>12.17.2</rosetta.bundle.version>
         <rosetta.code-gen.version>${rosetta.bundle.version}</rosetta.code-gen.version>
 
         <xtext.version>2.38.0</xtext.version>


### PR DESCRIPTION
Bumps `rosetta.dsl.version` to `10.10.0` and `rosetta.bundle.version` to `12.17.2` in `pom.xml`.