### PR TITLE
[7.x.x] CDM-Ingest-fpml-confirmation-party - Mapping identifierType to fpml schemes

### DIFF
--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-fx-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-fx-derivatives.json
@@ -189,5 +189,29 @@
       "modelValidationFailures" : 14,
       "runtimeError" : false
     }
+  }, {
+    "id" : "fx-fwd-npid",
+    "name" : "fx fwd NPID",
+    "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-fwd-npid.xml",
+    "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-npid.json",
+    "assertions" : {
+      "inputPathCount" : 0,
+      "outputPathCount" : 0,
+      "modelValidationFailures" : 0,
+      "schemaValidationFailure" : false,
+      "runtimeError" : false
+    }
+  }, {
+    "id" : "fx-fwd-plid",
+    "name" : "Fx fwd PLID",
+    "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-fwd-plid.xml",
+    "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-plid.json",
+    "assertions" : {
+      "inputPathCount" : 0,
+      "outputPathCount" : 0,
+      "modelValidationFailures" : 0,
+      "schemaValidationFailure" : false,
+      "runtimeError" : false
+    }
   } ]
 }

--- a/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-fx-derivatives.json
+++ b/rosetta-source/src/main/resources/ingest/config/test-pack-translate-fpml-confirmation-to-trade-state-fpml-5-13-products-fx-derivatives.json
@@ -191,26 +191,24 @@
     }
   }, {
     "id" : "fx-fwd-npid",
-    "name" : "fx fwd NPID",
+    "name" : "fx fwd npid",
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-fwd-npid.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-npid.json",
     "assertions" : {
-      "inputPathCount" : 0,
-      "outputPathCount" : 0,
-      "modelValidationFailures" : 0,
-      "schemaValidationFailure" : false,
+      "inputPathCount" : 40,
+      "outputPathCount" : 46,
+      "modelValidationFailures" : 5,
       "runtimeError" : false
     }
   }, {
     "id" : "fx-fwd-plid",
-    "name" : "Fx fwd PLID",
+    "name" : "fx fwd plid",
     "inputPath" : "ingest/input/fpml-5-13-products-fx-derivatives/fx-fwd-plid.xml",
     "outputPath" : "ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-plid.json",
     "assertions" : {
-      "inputPathCount" : 0,
-      "outputPathCount" : 0,
-      "modelValidationFailures" : 0,
-      "schemaValidationFailure" : false,
+      "inputPathCount" : 40,
+      "outputPathCount" : 46,
+      "modelValidationFailures" : 5,
       "runtimeError" : false
     }
   } ]

--- a/rosetta-source/src/main/resources/ingest/input/fpml-5-13-products-fx-derivatives/fx-fwd-npid.xml
+++ b/rosetta-source/src/main/resources/ingest/input/fpml-5-13-products-fx-derivatives/fx-fwd-npid.xml
@@ -1,0 +1,61 @@
+<requestConfirmation fpmlVersion="5-13" xmlns="http://www.fpml.org/FpML-5/confirmation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <header>
+    <messageId messageIdScheme="http://www.matchingservice.com/coding-scheme/messageId">FX456a789b</messageId>
+    <sentBy messageAddressScheme="http://www.matchingservice.com/partyId">ABN</sentBy>
+    <sendTo messageAddressScheme="http://www.matchingservice.com/partyId">MATCHSRV</sendTo>
+    <creationTimestamp>2001-11-19T08:57:00Z</creationTimestamp>
+  </header>
+  <isCorrection>false</isCorrection>
+  <correlationId correlationIdScheme="http://www.matchingservice.com/coding-scheme/correlationId">FX987</correlationId>
+  <sequenceNumber>1</sequenceNumber>
+  <trade>
+    <tradeHeader>
+      <partyTradeIdentifier>
+        <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
+      </partyTradeIdentifier>
+      <partyTradeIdentifier>
+        <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
+      </partyTradeIdentifier>
+      <tradeDate>2001-11-19T00:00:00</tradeDate>
+    </tradeHeader>
+    <fxSingleLeg>
+      <exchangedCurrency1>
+        <payerPartyReference href="party2"/>
+        <receiverPartyReference href="party1"/>
+        <paymentAmount>
+          <currency>EUR</currency>
+          <amount>10000000</amount>
+        </paymentAmount>
+      </exchangedCurrency1>
+      <exchangedCurrency2>
+        <payerPartyReference href="party1"/>
+        <receiverPartyReference href="party2"/>
+        <paymentAmount>
+          <currency>USD</currency>
+          <amount>9175000</amount>
+        </paymentAmount>
+      </exchangedCurrency2>
+      <valueDate>2001-12-21T00:00:00</valueDate>
+      <exchangeRate>
+        <quotedCurrencyPair>
+          <currency1>EUR</currency1>
+          <currency2>USD</currency2>
+          <quoteBasis>Currency2PerCurrency1</quoteBasis>
+        </quotedCurrencyPair>
+        <rate>0.9175</rate>
+        <spotRate>0.9130</spotRate>
+        <forwardPoints>0.0045</forwardPoints>
+      </exchangeRate>
+    </fxSingleLeg>
+  </trade>
+  <party id="party1">
+    <partyId partyIdScheme="http://www.fpml.org/coding-scheme/external/iso17442">BFXS5XCH7N0Y05NIXW11</partyId>
+  </party>
+<party id="party2">
+   <person>
+     <personId personIdScheme="http://www.fpml.org/coding-scheme/external/person-id">213800QILIUD4ROSUO03NATURALID</personId>
+    </person>
+</party>
+</requestConfirmation>

--- a/rosetta-source/src/main/resources/ingest/input/fpml-5-13-products-fx-derivatives/fx-fwd-plid.xml
+++ b/rosetta-source/src/main/resources/ingest/input/fpml-5-13-products-fx-derivatives/fx-fwd-plid.xml
@@ -1,0 +1,61 @@
+<requestConfirmation fpmlVersion="5-13" xmlns="http://www.fpml.org/FpML-5/confirmation" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <header>
+    <messageId messageIdScheme="http://www.matchingservice.com/coding-scheme/messageId">FX456a789b</messageId>
+    <sentBy messageAddressScheme="http://www.matchingservice.com/partyId">ABN</sentBy>
+    <sendTo messageAddressScheme="http://www.matchingservice.com/partyId">MATCHSRV</sendTo>
+    <creationTimestamp>2001-11-19T08:57:00Z</creationTimestamp>
+  </header>
+  <isCorrection>false</isCorrection>
+  <correlationId correlationIdScheme="http://www.matchingservice.com/coding-scheme/correlationId">FX987</correlationId>
+  <sequenceNumber>1</sequenceNumber>
+  <trade>
+    <tradeHeader>
+      <partyTradeIdentifier>
+        <partyReference href="party1"/>
+        <tradeId tradeIdScheme="http://www.abn-amro.com/fx/trade-id">ABN1234</tradeId>
+      </partyTradeIdentifier>
+      <partyTradeIdentifier>
+        <partyReference href="party2"/>
+        <tradeId tradeIdScheme="http://www.db.com/fx/trade-id">DB5678</tradeId>
+      </partyTradeIdentifier>
+      <tradeDate>2001-11-19T00:00:00</tradeDate>
+    </tradeHeader>
+    <fxSingleLeg>
+      <exchangedCurrency1>
+        <payerPartyReference href="party2"/>
+        <receiverPartyReference href="party1"/>
+        <paymentAmount>
+          <currency>EUR</currency>
+          <amount>10000000</amount>
+        </paymentAmount>
+      </exchangedCurrency1>
+      <exchangedCurrency2>
+        <payerPartyReference href="party1"/>
+        <receiverPartyReference href="party2"/>
+        <paymentAmount>
+          <currency>USD</currency>
+          <amount>9175000</amount>
+        </paymentAmount>
+      </exchangedCurrency2>
+      <valueDate>2001-12-21T00:00:00</valueDate>
+      <exchangeRate>
+        <quotedCurrencyPair>
+          <currency1>EUR</currency1>
+          <currency2>USD</currency2>
+          <quoteBasis>Currency2PerCurrency1</quoteBasis>
+        </quotedCurrencyPair>
+        <rate>0.9175</rate>
+        <spotRate>0.9130</spotRate>
+        <forwardPoints>0.0045</forwardPoints>
+      </exchangeRate>
+    </fxSingleLeg>
+  </trade>
+  <party id="party1">
+    <partyId partyIdScheme="http://www.fpml.org/coding-scheme/external/iso17442">BFXS5XCH7N0Y05NIXW11</partyId>
+  </party>
+  <party id="party2">
+    <person>
+      <personId personIdScheme="http://www.fpml.org/coding-scheme/external/person-id/privacy-law-id">213800QILIUD4ROSUO03NATURALID</personId>
+    </person>
+  </party>
+</requestConfirmation>

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-npid.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-npid.json
@@ -1,7 +1,7 @@
 {
   "@model" : "cdm",
   "@type" : "cdm.event.common.TradeState",
-  "@version" : "8.0.0-dev.4",
+  "@version" : "0.0.0.master-SNAPSHOT",
   "@key" : "72a40fa8",
   "trade" : {
     "product" : {

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-npid.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-npid.json
@@ -1,0 +1,156 @@
+{
+  "@model" : "cdm",
+  "@type" : "cdm.event.common.TradeState",
+  "@version" : "8.0.0-dev.4",
+  "@key" : "72a40fa8",
+  "trade" : {
+    "product" : {
+      "taxonomy" : [ {
+        "source" : "ISDA",
+        "value" : {
+          "name" : {
+            "@data" : "ForeignExchange_Spot_Forward"
+          }
+        },
+        "calculated" : true
+      } ],
+      "economicTerms" : {
+        "payout" : [ {
+          "@type" : "cdm.product.template.SettlementPayout",
+          "payerReceiver" : {
+            "payer" : "Party1",
+            "receiver" : "Party2"
+          },
+          "priceQuantity" : {
+            "quantitySchedule" : {
+              "@ref:scoped" : "quantity-1"
+            },
+            "priceSchedule" : [ {
+              "@ref:scoped" : "price-1"
+            } ]
+          },
+          "settlementTerms" : {
+            "settlementDate" : {
+              "valueDate" : "2001-12-21"
+            }
+          },
+          "underlier" : {
+            "@type" : "cdm.observable.asset.Observable",
+            "@ref:scoped" : "observable-1"
+          }
+        } ]
+      }
+    },
+    "tradeLot" : [ {
+      "priceQuantity" : [ {
+        "price" : [ {
+          "@key:scoped" : "price-1",
+          "value" : 0.9175,
+          "unit" : {
+            "currency" : {
+              "@data" : "USD"
+            }
+          },
+          "perUnitOf" : {
+            "currency" : {
+              "@data" : "EUR"
+            }
+          },
+          "priceType" : "ExchangeRate",
+          "composite" : {
+            "baseValue" : 0.9130,
+            "operand" : 0.0045,
+            "arithmeticOperator" : "Add",
+            "operandType" : "ForwardPoint"
+          },
+          "derivedQuantity" : {
+            "value" : 9175000,
+            "unit" : {
+              "currency" : {
+                "@data" : "USD"
+              }
+            }
+          }
+        } ],
+        "quantity" : {
+          "@key:scoped" : "quantity-1",
+          "value" : 10000000,
+          "unit" : {
+            "currency" : {
+              "@data" : "EUR"
+            }
+          }
+        },
+        "observable" : {
+          "@key:scoped" : "observable-1",
+          "@data" : {
+            "@type" : "cdm.base.staticdata.asset.common.Cash",
+            "identifier" : [ {
+              "identifier" : {
+                "@data" : "EUR"
+              },
+              "identifierType" : "CurrencyCode"
+            } ],
+            "assetType" : "Cash"
+          }
+        }
+      } ]
+    } ],
+    "counterparty" : [ {
+      "role" : "Party1",
+      "partyReference" : {
+        "@ref:external" : "party2"
+      }
+    }, {
+      "role" : "Party2",
+      "partyReference" : {
+        "@ref:external" : "party1"
+      }
+    } ],
+    "tradeIdentifier" : [ {
+      "issuerReference" : {
+        "@ref:external" : "party1"
+      },
+      "assignedIdentifier" : [ {
+        "identifier" : {
+          "@scheme" : "http://www.abn-amro.com/fx/trade-id",
+          "@data" : "ABN1234"
+        }
+      } ]
+    }, {
+      "issuerReference" : {
+        "@ref:external" : "party2"
+      },
+      "assignedIdentifier" : [ {
+        "identifier" : {
+          "@scheme" : "http://www.db.com/fx/trade-id",
+          "@data" : "DB5678"
+        }
+      } ]
+    } ],
+    "tradeDate" : {
+      "@data" : "2001-11-19"
+    },
+    "party" : [ {
+      "@key:external" : "party1",
+      "partyId" : [ {
+        "identifier" : {
+          "@scheme" : "http://www.fpml.org/coding-scheme/external/iso17442",
+          "@data" : "BFXS5XCH7N0Y05NIXW11"
+        },
+        "identifierType" : "LEI"
+      } ]
+    }, {
+      "@key:external" : "party2",
+      "person" : [ {
+        "personId" : [ {
+          "identifier" : {
+            "@scheme" : "http://www.fpml.org/coding-scheme/external/person-id",
+            "@data" : "213800QILIUD4ROSUO03NATURALID"
+          },
+          "identifierType" : "NPID"
+        } ]
+      } ]
+    } ]
+  }
+}

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-plid.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-plid.json
@@ -1,0 +1,156 @@
+{
+  "@model" : "cdm",
+  "@type" : "cdm.event.common.TradeState",
+  "@version" : "8.0.0-dev.4",
+  "@key" : "72a4e962",
+  "trade" : {
+    "product" : {
+      "taxonomy" : [ {
+        "source" : "ISDA",
+        "value" : {
+          "name" : {
+            "@data" : "ForeignExchange_Spot_Forward"
+          }
+        },
+        "calculated" : true
+      } ],
+      "economicTerms" : {
+        "payout" : [ {
+          "@type" : "cdm.product.template.SettlementPayout",
+          "payerReceiver" : {
+            "payer" : "Party1",
+            "receiver" : "Party2"
+          },
+          "priceQuantity" : {
+            "quantitySchedule" : {
+              "@ref:scoped" : "quantity-1"
+            },
+            "priceSchedule" : [ {
+              "@ref:scoped" : "price-1"
+            } ]
+          },
+          "settlementTerms" : {
+            "settlementDate" : {
+              "valueDate" : "2001-12-21"
+            }
+          },
+          "underlier" : {
+            "@type" : "cdm.observable.asset.Observable",
+            "@ref:scoped" : "observable-1"
+          }
+        } ]
+      }
+    },
+    "tradeLot" : [ {
+      "priceQuantity" : [ {
+        "price" : [ {
+          "@key:scoped" : "price-1",
+          "value" : 0.9175,
+          "unit" : {
+            "currency" : {
+              "@data" : "USD"
+            }
+          },
+          "perUnitOf" : {
+            "currency" : {
+              "@data" : "EUR"
+            }
+          },
+          "priceType" : "ExchangeRate",
+          "composite" : {
+            "baseValue" : 0.9130,
+            "operand" : 0.0045,
+            "arithmeticOperator" : "Add",
+            "operandType" : "ForwardPoint"
+          },
+          "derivedQuantity" : {
+            "value" : 9175000,
+            "unit" : {
+              "currency" : {
+                "@data" : "USD"
+              }
+            }
+          }
+        } ],
+        "quantity" : {
+          "@key:scoped" : "quantity-1",
+          "value" : 10000000,
+          "unit" : {
+            "currency" : {
+              "@data" : "EUR"
+            }
+          }
+        },
+        "observable" : {
+          "@key:scoped" : "observable-1",
+          "@data" : {
+            "@type" : "cdm.base.staticdata.asset.common.Cash",
+            "identifier" : [ {
+              "identifier" : {
+                "@data" : "EUR"
+              },
+              "identifierType" : "CurrencyCode"
+            } ],
+            "assetType" : "Cash"
+          }
+        }
+      } ]
+    } ],
+    "counterparty" : [ {
+      "role" : "Party1",
+      "partyReference" : {
+        "@ref:external" : "party2"
+      }
+    }, {
+      "role" : "Party2",
+      "partyReference" : {
+        "@ref:external" : "party1"
+      }
+    } ],
+    "tradeIdentifier" : [ {
+      "issuerReference" : {
+        "@ref:external" : "party1"
+      },
+      "assignedIdentifier" : [ {
+        "identifier" : {
+          "@scheme" : "http://www.abn-amro.com/fx/trade-id",
+          "@data" : "ABN1234"
+        }
+      } ]
+    }, {
+      "issuerReference" : {
+        "@ref:external" : "party2"
+      },
+      "assignedIdentifier" : [ {
+        "identifier" : {
+          "@scheme" : "http://www.db.com/fx/trade-id",
+          "@data" : "DB5678"
+        }
+      } ]
+    } ],
+    "tradeDate" : {
+      "@data" : "2001-11-19"
+    },
+    "party" : [ {
+      "@key:external" : "party1",
+      "partyId" : [ {
+        "identifier" : {
+          "@scheme" : "http://www.fpml.org/coding-scheme/external/iso17442",
+          "@data" : "BFXS5XCH7N0Y05NIXW11"
+        },
+        "identifierType" : "LEI"
+      } ]
+    }, {
+      "@key:external" : "party2",
+      "person" : [ {
+        "personId" : [ {
+          "identifier" : {
+            "@scheme" : "http://www.fpml.org/coding-scheme/external/person-id/privacy-law-id",
+            "@data" : "213800QILIUD4ROSUO03NATURALID"
+          },
+          "identifierType" : "PLID"
+        } ]
+      } ]
+    } ]
+  }
+}

--- a/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-plid.json
+++ b/rosetta-source/src/main/resources/ingest/output/fpml-confirmation-to-trade-state/fpml-5-13-products-fx-derivatives/fx-fwd-plid.json
@@ -1,7 +1,7 @@
 {
   "@model" : "cdm",
   "@type" : "cdm.event.common.TradeState",
-  "@version" : "8.0.0-dev.4",
+  "@version" : "0.0.0.master-SNAPSHOT",
   "@key" : "72a4e962",
   "trade" : {
     "product" : {

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-other-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-other-func.rosetta
@@ -7,7 +7,6 @@ import cdm.base.math.*
 import cdm.base.staticdata.asset.common.*
 import cdm.base.staticdata.asset.credit.*
 import cdm.base.staticdata.asset.rates.*
-import cdm.base.staticdata.codelist.*
 import cdm.base.staticdata.party.*
 import cdm.event.common.*
 import cdm.event.workflow.*
@@ -2125,6 +2124,19 @@ func MapPartyIdentifierTypeEnum:
             "http://www.fpml.org/coding-scheme/external/iso10383" then MIC,
             "http://www.fpml.org/coding-scheme/external/exchange-id-MIC" then MIC,
             "http://www.fpml.org/coding-scheme/external/mifir/extension-iso10383" then MIC,
+            default empty
+
+func MapPersonIdentifierTypeEnum:
+    inputs:
+        value string (0..1)
+    output:
+        result PersonIdentifierTypeEnum (0..1)
+    set result:
+        value switch
+            "http://www.fpml.org/coding-scheme/external/person-id" then NPID,
+            "http://www.fpml.org/coding-scheme/external/person-id/privacy-law-id" then PLID,
+            "http://www.fpml.org/coding-scheme/external/person-id/national-identity-number" then NIDN,
+            "http://www.fpml.org/coding-scheme/external/person-id/passport-number" then CCPT,
             default empty
 
 func MapPartyRoleEnum:

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-party-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-party-func.rosetta
@@ -545,7 +545,6 @@ func MapNaturalPerson:
                             extract fpmlPersonId [
                                 MapPersonIdentifier(
                                         fpmlPersonId,
-                                        fpmlPersonId -> personIdScheme,
                                         person -> contactInfo -> address -> country
                                     )
                             ]
@@ -568,7 +567,6 @@ func MapNaturalPerson:
 func MapPersonIdentifier:
     inputs:
         fpmlPersonId fpml.PersonId (0..1)
-        identifierScheme string (0..1)
         fpmlCountryCode fpml.CountryCode (0..1)
     output:
         cdmPersonIdentifier PersonIdentifier (0..1)
@@ -580,7 +578,7 @@ func MapPersonIdentifier:
                         fpmlPersonId -> value,
                         fpmlPersonId -> personIdScheme
                     ),
-            identifierType: MapPersonIdentifierTypeEnum(identifierScheme),
+            identifierType: MapPersonIdentifierTypeEnum(fpmlPersonId -> personIdScheme),
             country: MapStringWithScheme(
                         fpmlCountryCode -> value,
                         fpmlCountryCode -> countryScheme

--- a/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-party-func.rosetta
+++ b/rosetta-source/src/main/rosetta/ingest-fpml-confirmation-party-func.rosetta
@@ -539,12 +539,17 @@ func MapNaturalPerson:
 
     set cdmNaturalPerson:
         NaturalPerson {
-            personId: fpmlPerson -> personId
-                    extract
-                        MapPersonIdentifier(
-                                item,
-                                fpmlPerson -> contactInfo -> address -> country
-                            ),
+            personId: fpmlPerson
+                    extract person [
+                        person -> personId
+                            extract fpmlPersonId [
+                                MapPersonIdentifier(
+                                        fpmlPersonId,
+                                        fpmlPersonId -> personIdScheme,
+                                        person -> contactInfo -> address -> country
+                                    )
+                            ]
+                    ],
             honorific: fpmlPerson -> honorific,
             firstName: fpmlPerson -> firstName,
             middleName: fpmlPerson -> middleName,
@@ -563,6 +568,7 @@ func MapNaturalPerson:
 func MapPersonIdentifier:
     inputs:
         fpmlPersonId fpml.PersonId (0..1)
+        identifierScheme string (0..1)
         fpmlCountryCode fpml.CountryCode (0..1)
     output:
         cdmPersonIdentifier PersonIdentifier (0..1)
@@ -574,11 +580,11 @@ func MapPersonIdentifier:
                         fpmlPersonId -> value,
                         fpmlPersonId -> personIdScheme
                     ),
+            identifierType: MapPersonIdentifierTypeEnum(identifierScheme),
             country: MapStringWithScheme(
                         fpmlCountryCode -> value,
                         fpmlCountryCode -> countryScheme
                     ),
-            ...
         }
 
 func MapNaturalPersonRoleList:


### PR DESCRIPTION
Backport of #5122 to `7.x.x`.

## What

- Adds `MapPersonIdentifierTypeEnum` to map the FpML `personIdScheme` URI onto `PersonIdentifierTypeEnum` (`NPID`, `PLID`, `NIDN`, `CCPT`).
- Reworks `MapNaturalPerson` to iterate the `personId` list, so a person with more than one identifier maps correctly (previously only a single-cardinality path was handled).
- Threads the scheme through `MapPersonIdentifier` and sets `identifierType`.
- Adds `fx-fwd-npid` / `fx-fwd-plid` ingest samples and expectations to the FpML 5.13 FX derivatives test pack.

## Notes

- Cherry-picked from 105e2333b5a4c1ed61423808359f027c8d5a120b with no conflicts; `MapNaturalPerson` and `MapPersonIdentifier` were identical to `master` on this branch.
- Test-pack expectations were verified to be identical between `master` and `7.x.x` for this test pack, so the generated output files carry over unchanged.
- Minor formatting corrected relative to #5122 (indentation of the `personId` assignment and of the new `func` declaration).