### PR TITLE
CVE scanning: increase read timeout for Node Audit / OSS Index calls

### DIFF
--- a/.github/workflows/cve-scanning.yml
+++ b/.github/workflows/cve-scanning.yml
@@ -81,6 +81,12 @@ jobs:
           key: nvd-data-${{ steps.date.outputs.date }}
       # Scans against whatever NVD data is already cached (autoUpdate=false),
       # so this step stays fast and isn't blocked by a flaky/slow sync.
+      #
+      # readTimeout doubles dependency-check's 60s default for the Node
+      # Audit Analyzer's call to registry.npmjs.org - a 2026-09-04 scheduled
+      # run hit that default and failed outright (dependency-check's
+      # failOnError default turns one analyzer's network error into a hard
+      # failure of the whole aggregate goal, with no report produced).
       - name: CVE scanning
         id: cve-scanning
         run: |
@@ -96,7 +102,8 @@ jobs:
             -DossIndexUsername=${{ secrets.OSS_INDEX_USERNAME }} \
             -DossIndexPassword=${{ secrets.OSS_INDEX_TOKEN }} \
             -DnodeAuditAnalyzerEnabled=true \
-            -DscanDirectory=website
+            -DscanDirectory=website \
+            -DreadTimeout=120000
       - name: Upload results
         if: always()
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

- The scheduled CVE Scanning run on 2026-09-04 failed outright: `NodeAuditAnalyzer` hit dependency-check's default 60s read timeout talking to `registry.npmjs.org`'s audit API, and dependency-check's `failOnError` default (`true`) turned that single analyzer's network error into a hard failure of the whole `aggregate` goal - no report was produced, and the job looked like a real vulnerability failure when it wasn't.
- Doubles the read timeout to 120s (`-DreadTimeout=120000`). Confirmed against dependency-check's `URLConnectionFactory` source: the property maps straight to `connection.read.timeout`, in milliseconds, default `60_000` - matching the log's exact "60 seconds" before the timeout.

## Test plan

- [ ] YAML validated locally (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cve-scanning.yml'))"`)
- [ ] Confirm the workflow runs clean via `workflow_dispatch` on this branch
