### PR TITLE
CVE scanning schedule: run on weekdays only, stagger start time

### DIFF
--- a/.github/workflows/cve-scanning-schedule.yml
+++ b/.github/workflows/cve-scanning-schedule.yml
@@ -8,8 +8,10 @@ name: CVE Scanning Schedule
 on:
   workflow_dispatch:
   schedule:
-    # Run daily to catch newly published CVEs even without repo changes.
-    - cron: '0 5 * * 1,2,3,4,5'
+    # Run on weekdays only (CVEs published over the weekend are still caught by
+    # Monday's run). Staggered in 30-minute steps from 05:00 UTC across the
+    # rosetta-models repos so the scans don't all queue at once.
+    - cron: '30 6 * * 1-5'
 
 # Neither step below uses the default GITHUB_TOKEN, so it's granted no
 # permissions at all.


### PR DESCRIPTION
## Summary
- Restrict the CVE scanning schedule to weekdays (CVEs published over the weekend are still caught by Monday's run)
- Move the start time to 06:30 UTC, this repo's slot in the rosetta-models-wide 30-minute stagger starting at 05:00 UTC, so scans across repos don't all queue at once

## Test plan
- [x] `cron: '30 6 * * 1-5'` validated against crontab syntax
- No functional test needed — schedule-only change to a workflow that already runs correctly on `workflow_dispatch`