### PR TITLE
Updating CDM maintainers lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | -------------------- | -------------- | ------------------------------------------- | -------------------- |           
 | Gabriel Callsen      | ICMA           | OrgRep                                      | gabriel-ICMA         | 
 | Tom Healey           | ICMA           | OrgRep                                      | tomhealey-icma       | 
+| Tabish Ahmed         | ISDA           | OrgRep                                      | tabi5h               | 
 | Eleonora Acuna       | ISDA           | OrgRep                                      | eacunaISDA           | 
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 
 | Chris Rayner         | ISLA           | OrgRep                                      | chrisisla            | 
-| Minesh Patel         | Individual     | OrgRep                                      | minesh-s-patel       | 
+| Minesh Patel         | Individual     | Individual                                  | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
 | Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 
 | Chris Rayner         | ISLA           | OrgRep                                      | chrisisla            | 
-| Minesh Patel         |                | OrgRep                                      | minesh-s-patel       | 
+| Minesh Patel         | Individual     | OrgRep                                      | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
 | Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 
 | Chris Rayner         | ISLA           | OrgRep                                      | chrisisla            | 
-| Minesh Patel         | Regnosys       | OrgRep                                      | minesh-s-patel       | 
+| Minesh Patel         |                | OrgRep                                      | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
 | Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 

--- a/README.md
+++ b/README.md
@@ -173,15 +173,14 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | -------------------- | -------------- | ------------------------------------------- | -------------------- |           
 | Gabriel Callsen      | ICMA           | OrgRep                                      | gabriel-ICMA         | 
 | Tom Healey           | ICMA           | OrgRep                                      | tomhealey-icma       | 
-| Vernon Alden-Smith   | ISDA           | OrgRep                                      | valdensmith          | 
 | Eleonora Acuna       | ISDA           | OrgRep                                      | eacunaISDA           | 
-| David Shone          | ISDA           | OrgRep                                      | dshoneisda           | 
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 
 | Chris Rayner         | ISLA           | OrgRep                                      | chrisisla            | 
 | Minesh Patel         | Regnosys       | OrgRep                                      | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
+| Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 
 | Manuel Martos        | TradeHeader    | OrgRep                                      | manel-martos         | 
 | Marc Gratacos        | TradeHeader    | OrgRep                                      | mgratacos            | 
 | Nicholas Moger       | JPMorgan Chase & Co.|  OrgRep                                | nicholas-moger         | 

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -43,7 +43,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 
 | Chris Rayner         | ISLA           | OrgRep                                      | chrisisla            | 
-| Minesh Patel         |                | OrgRep                                      | minesh-s-patel       | 
+| Minesh Patel         | Individual     | OrgRep                                      | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
 | Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -43,7 +43,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 
 | Chris Rayner         | ISLA           | OrgRep                                      | chrisisla            | 
-| Minesh Patel         | Individual     | OrgRep                                      | minesh-s-patel       | 
+| Minesh Patel         | Individual     | Individual                                  | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
 | Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -46,6 +46,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Minesh Patel         | Regnosys       | OrgRep                                      | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
+| Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 
 | Manuel Martos        | TradeHeader    | OrgRep                                      | manel-martos         | 
 | Marc Gratacos        | TradeHeader    | OrgRep                                      | mgratacos            | 
 | Nicholas Moger       | JPMorgan Chase & Co.|  OrgRep                                | nicholas-moger       | 

--- a/docs/maintainers.md
+++ b/docs/maintainers.md
@@ -43,7 +43,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 
 | Chris Rayner         | ISLA           | OrgRep                                      | chrisisla            | 
-| Minesh Patel         | Regnosys       | OrgRep                                      | minesh-s-patel       | 
+| Minesh Patel         |                | OrgRep                                      | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
 | Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 

--- a/website/versioned_docs/version-7.0.0/maintainers.md
+++ b/website/versioned_docs/version-7.0.0/maintainers.md
@@ -43,7 +43,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 
 | Chris Rayner         | ISLA           | OrgRep                                      | chrisisla            | 
-| Minesh Patel         |                | OrgRep                                      | minesh-s-patel       | 
+| Minesh Patel         | Individual     | OrgRep                                      | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
 | Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 

--- a/website/versioned_docs/version-7.0.0/maintainers.md
+++ b/website/versioned_docs/version-7.0.0/maintainers.md
@@ -43,7 +43,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 
 | Chris Rayner         | ISLA           | OrgRep                                      | chrisisla            | 
-| Minesh Patel         | Individual     | OrgRep                                      | minesh-s-patel       | 
+| Minesh Patel         | Individual     | Individual                                  | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
 | Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 

--- a/website/versioned_docs/version-7.0.0/maintainers.md
+++ b/website/versioned_docs/version-7.0.0/maintainers.md
@@ -46,6 +46,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Minesh Patel         | Regnosys       | OrgRep                                      | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
+| Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 
 | Manuel Martos        | TradeHeader    | OrgRep                                      | manel-martos         | 
 | Marc Gratacos        | TradeHeader    | OrgRep                                      | mgratacos            | 
 | Nicholas Moger       | JPMorgan Chase & Co.|  OrgRep                                | nicholas-moger       | 

--- a/website/versioned_docs/version-7.0.0/maintainers.md
+++ b/website/versioned_docs/version-7.0.0/maintainers.md
@@ -43,7 +43,7 @@ The following are the FINOS CDM maintainers and the firms they represent.
 | Lyteck Lynhiavu      | ISDA           | OrgRep                                      | llynhiavu            | 
 | Adrian Dale          | ISLA           | OrgRep                                      | ADaleISLA            | 
 | Chris Rayner         | ISLA           | OrgRep                                      | chrisisla            | 
-| Minesh Patel         | Regnosys       | OrgRep                                      | minesh-s-patel       | 
+| Minesh Patel         |                | OrgRep                                      | minesh-s-patel       | 
 | Leo Labeis           | Regnosys       | OrgRep                                      | lolabeis             | 
 | Hugo Hills           | Regnosys       | OrgRep                                      | hugohills-regnosys   | 
 | Jayasri Radhakrishnan| Regnosys       | OrgRep                                      | JayasriR             | 


### PR DESCRIPTION
## Summary

Brings the three published maintainer lists into line with the `finos/cdm-maintainers` GitHub team, which `.github/CODEOWNERS` delegates to.

## Changes

**Added Jayasri Radhakrishnan** — already a member of the GitHub team, missing from every published list:

| FINOS CDM Maintainer | Representing | Capacity | GithubID |
| --- | --- | --- | --- |
| Jayasri Radhakrishnan | Regnosys | OrgRep | JayasriR |

Applied to all three places a roster is published:

- `docs/maintainers.md` — served at `/docs/next/maintainers`
- `website/versioned_docs/version-7.0.0/maintainers.md` — served at [cdm.finos.org/docs/maintainers](https://cdm.finos.org/docs/maintainers), the current default version
- `README.md` — the table under "FINOS CDM Project Maintainers"

**Added Tabish Ahmed** (`tabi5h`) to `README.md` — he is in the GitHub team and on the documentation pages, but had never been listed in the README.

**Removed from `README.md`:** Vernon Alden-Smith (`valdensmith`) and David Shone (`dshoneisda`). They appeared only in the README, not on the documentation pages.

After this the three published lists are identical. 


**Cleared the organisation for Minesh Patel** — he is no longer at REGnosys. Both `Representing` and `Capacity` now read "Individual" pending a Steering Working Group decision on whether he stays on as a maintainer, and if so whether that stands, he is marked as a private individual, or his current organisation is added. He remains listed and remains in the GitHub team.

## Notes

- Older snapshots (6.0.0, 5.20.0, 5.13.0) are not touched, consistent with leaving released versions as shipped.
- Nicholas Moger appears on all three lists but not yet in the GitHub team; his invitation is sent and pending acceptance, so no change is needed.

Resolves #5140
Relates to #5076



